### PR TITLE
Start card rotation

### DIFF
--- a/Cauldron/Assets/Plugins/FMOD/Cache/Editor/FMODStudioCache.asset
+++ b/Cauldron/Assets/Plugins/FMOD/Cache/Editor/FMODStudioCache.asset
@@ -1,5 +1,113 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-9056130099399744577
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ceb653cd98e289a4e8697a1af55201f2, type: 3}
+  m_Name: event:/Chars/Blackman/in
+  m_EditorClassIdentifier: 
+  Path: event:/Chars/Blackman/in
+  Guid:
+    Data1: 1629924409
+    Data2: 1301691552
+    Data3: -779281257
+    Data4: -242245512
+  Banks:
+  - {fileID: 1538880662454187021}
+  IsStream: 0
+  Is3D: 0
+  IsOneShot: 1
+  Parameters: []
+  MinDistance: 1
+  MaxDistance: 20
+  Length: 2142
+--- !u!114 &-8977585902030710500
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ceb653cd98e289a4e8697a1af55201f2, type: 3}
+  m_Name: event:/Chars/Blackman/out
+  m_EditorClassIdentifier: 
+  Path: event:/Chars/Blackman/out
+  Guid:
+    Data1: 1503094848
+    Data2: 1291710695
+    Data3: 444249785
+    Data4: 1787299024
+  Banks:
+  - {fileID: 1538880662454187021}
+  IsStream: 0
+  Is3D: 0
+  IsOneShot: 1
+  Parameters: []
+  MinDistance: 1
+  MaxDistance: 20
+  Length: 1799
+--- !u!114 &-8528070367390426488
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ceb653cd98e289a4e8697a1af55201f2, type: 3}
+  m_Name: event:/UX/potion_focus
+  m_EditorClassIdentifier: 
+  Path: event:/UX/potion_focus
+  Guid:
+    Data1: 536702542
+    Data2: 1118139685
+    Data3: 1072109711
+    Data4: -1178693083
+  Banks:
+  - {fileID: 1538880662454187021}
+  IsStream: 0
+  Is3D: 0
+  IsOneShot: 1
+  Parameters: []
+  MinDistance: 1
+  MaxDistance: 20
+  Length: 1249
+--- !u!114 &-8248834691234853599
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ceb653cd98e289a4e8697a1af55201f2, type: 3}
+  m_Name: event:/Chars/Cat/annoy
+  m_EditorClassIdentifier: 
+  Path: event:/Chars/Cat/annoy
+  Guid:
+    Data1: -106282121
+    Data2: 1330686625
+    Data3: 397700530
+    Data4: 1611905687
+  Banks:
+  - {fileID: 1538880662454187021}
+  IsStream: 0
+  Is3D: 0
+  IsOneShot: 1
+  Parameters: []
+  MinDistance: 1
+  MaxDistance: 20
+  Length: 1240
 --- !u!114 &-8024967669597156249
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -20,6 +128,33 @@ MonoBehaviour:
     Data4: 1074406678
   Banks:
   - {fileID: -1434276780203061547}
+  IsStream: 0
+  Is3D: 0
+  IsOneShot: 1
+  Parameters: []
+  MinDistance: 1
+  MaxDistance: 20
+  Length: 0
+--- !u!114 &-7475318917968912554
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ceb653cd98e289a4e8697a1af55201f2, type: 3}
+  m_Name: event:/UX/potion_choose
+  m_EditorClassIdentifier: 
+  Path: event:/UX/potion_choose
+  Guid:
+    Data1: 97758724
+    Data2: 1221232502
+    Data3: -1245783640
+    Data4: 790895502
+  Banks:
+  - {fileID: 1538880662454187021}
   IsStream: 0
   Is3D: 0
   IsOneShot: 1
@@ -54,6 +189,33 @@ MonoBehaviour:
   MinDistance: 1
   MaxDistance: 20
   Length: 1160
+--- !u!114 &-6898284717567636291
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ceb653cd98e289a4e8697a1af55201f2, type: 3}
+  m_Name: event:/Chars/Cat/purr_long
+  m_EditorClassIdentifier: 
+  Path: event:/Chars/Cat/purr_long
+  Guid:
+    Data1: -1902970582
+    Data2: 1129863727
+    Data3: -841304176
+    Data4: -1430759482
+  Banks:
+  - {fileID: 1538880662454187021}
+  IsStream: 0
+  Is3D: 0
+  IsOneShot: 1
+  Parameters: []
+  MinDistance: 1
+  MaxDistance: 20
+  Length: 2539
 --- !u!114 &-6795376441656961152
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -81,6 +243,33 @@ MonoBehaviour:
   MinDistance: 1
   MaxDistance: 20
   Length: 9000
+--- !u!114 &-6368047652405976862
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ceb653cd98e289a4e8697a1af55201f2, type: 3}
+  m_Name: event:/Chars/Cat/purr_short
+  m_EditorClassIdentifier: 
+  Path: event:/Chars/Cat/purr_short
+  Guid:
+    Data1: 289463931
+    Data2: 1193820746
+    Data3: 1328318648
+    Data4: 1975130322
+  Banks:
+  - {fileID: 1538880662454187021}
+  IsStream: 0
+  Is3D: 0
+  IsOneShot: 1
+  Parameters: []
+  MinDistance: 1
+  MaxDistance: 20
+  Length: 1165
 --- !u!114 &-6161441151164943836
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -108,6 +297,33 @@ MonoBehaviour:
   MinDistance: 1
   MaxDistance: 20
   Length: 3816
+--- !u!114 &-5678999817879149159
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ceb653cd98e289a4e8697a1af55201f2, type: 3}
+  m_Name: event:/Location/House/mus
+  m_EditorClassIdentifier: 
+  Path: event:/Location/House/mus
+  Guid:
+    Data1: -1194859955
+    Data2: 1215088978
+    Data3: 1710768003
+    Data4: -1834542631
+  Banks:
+  - {fileID: 1538880662454187021}
+  IsStream: 1
+  Is3D: 0
+  IsOneShot: 1
+  Parameters: []
+  MinDistance: 1
+  MaxDistance: 20
+  Length: 155585
 --- !u!114 &-5627102640347451574
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -128,6 +344,60 @@ MonoBehaviour:
     Data4: -1132985261
   Banks:
   - {fileID: -1434276780203061547}
+  IsStream: 0
+  Is3D: 0
+  IsOneShot: 1
+  Parameters: []
+  MinDistance: 1
+  MaxDistance: 20
+  Length: 1062
+--- !u!114 &-5619047329089409827
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ceb653cd98e289a4e8697a1af55201f2, type: 3}
+  m_Name: event:/UX/potion_give
+  m_EditorClassIdentifier: 
+  Path: event:/UX/potion_give
+  Guid:
+    Data1: 99115271
+    Data2: 1262855970
+    Data3: 1242101123
+    Data4: 5795274
+  Banks:
+  - {fileID: 1538880662454187021}
+  IsStream: 0
+  Is3D: 0
+  IsOneShot: 1
+  Parameters: []
+  MinDistance: 1
+  MaxDistance: 20
+  Length: 1093
+--- !u!114 &-5604472991079920758
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ceb653cd98e289a4e8697a1af55201f2, type: 3}
+  m_Name: event:/UX/menu_submit
+  m_EditorClassIdentifier: 
+  Path: event:/UX/menu_submit
+  Guid:
+    Data1: -1614273891
+    Data2: 1311000525
+    Data3: -1068740985
+    Data4: -1132985261
+  Banks:
+  - {fileID: 1538880662454187021}
   IsStream: 0
   Is3D: 0
   IsOneShot: 1
@@ -162,6 +432,33 @@ MonoBehaviour:
   MinDistance: 1
   MaxDistance: 20
   Length: 1240
+--- !u!114 &-5206787727162842642
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ceb653cd98e289a4e8697a1af55201f2, type: 3}
+  m_Name: event:/Game/game_end
+  m_EditorClassIdentifier: 
+  Path: event:/Game/game_end
+  Guid:
+    Data1: -528153210
+    Data2: 1092747596
+    Data3: -602540892
+    Data4: -1422591904
+  Banks:
+  - {fileID: 1538880662454187021}
+  IsStream: 0
+  Is3D: 0
+  IsOneShot: 1
+  Parameters: []
+  MinDistance: 1
+  MaxDistance: 20
+  Length: 3816
 --- !u!114 &-5139880003689405849
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -216,6 +513,53 @@ MonoBehaviour:
   MinDistance: 1
   MaxDistance: 20
   Length: 2166
+--- !u!114 &-4884395401892527009
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ceb653cd98e289a4e8697a1af55201f2, type: 3}
+  m_Name: event:/Game/potion_success
+  m_EditorClassIdentifier: 
+  Path: event:/Game/potion_success
+  Guid:
+    Data1: 804817785
+    Data2: 1208461890
+    Data3: -806772329
+    Data4: 2124913505
+  Banks:
+  - {fileID: 1538880662454187021}
+  IsStream: 0
+  Is3D: 0
+  IsOneShot: 1
+  Parameters: []
+  MinDistance: 1
+  MaxDistance: 20
+  Length: 3041
+--- !u!114 &-4217917264191943376
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c18180ecb35941f4682ae60107b85b7c, type: 3}
+  m_Name: bank:/Master.strings.bank
+  m_EditorClassIdentifier: 
+  Path: CompiledAudio/Master.strings.bank
+  Name: Master.strings
+  StudioPath: bank:/Master.strings
+  lastModified: 638183676343232235
+  FileSizes:
+  - Name: 
+    Value: 2552
+  Exists: 1
 --- !u!114 &-3613053970640958595
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -324,6 +668,114 @@ MonoBehaviour:
   MinDistance: 1
   MaxDistance: 20
   Length: 1249
+--- !u!114 &-2871627831067386798
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ceb653cd98e289a4e8697a1af55201f2, type: 3}
+  m_Name: event:/Chars/Cat/hungry
+  m_EditorClassIdentifier: 
+  Path: event:/Chars/Cat/hungry
+  Guid:
+    Data1: 1766581129
+    Data2: 1160347572
+    Data3: 1371512474
+    Data4: -1046058031
+  Banks:
+  - {fileID: 1538880662454187021}
+  IsStream: 0
+  Is3D: 0
+  IsOneShot: 1
+  Parameters: []
+  MinDistance: 1
+  MaxDistance: 20
+  Length: 1446
+--- !u!114 &-2822475258497210014
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ceb653cd98e289a4e8697a1af55201f2, type: 3}
+  m_Name: event:/UX/ingridients_usage
+  m_EditorClassIdentifier: 
+  Path: event:/UX/ingridients_usage
+  Guid:
+    Data1: -1469753933
+    Data2: 1236253669
+    Data3: -1259993956
+    Data4: 608576754
+  Banks:
+  - {fileID: 1538880662454187021}
+  IsStream: 0
+  Is3D: 0
+  IsOneShot: 1
+  Parameters: []
+  MinDistance: 1
+  MaxDistance: 20
+  Length: 2271
+--- !u!114 &-2630744804140410433
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ceb653cd98e289a4e8697a1af55201f2, type: 3}
+  m_Name: event:/Chars/VisitorComing/whoosh
+  m_EditorClassIdentifier: 
+  Path: event:/Chars/VisitorComing/whoosh
+  Guid:
+    Data1: -1382553725
+    Data2: 1245975558
+    Data3: 243212703
+    Data4: 367218225
+  Banks:
+  - {fileID: 1538880662454187021}
+  IsStream: 0
+  Is3D: 0
+  IsOneShot: 1
+  Parameters: []
+  MinDistance: 1
+  MaxDistance: 20
+  Length: 1416
+--- !u!114 &-2522103749156452464
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ceb653cd98e289a4e8697a1af55201f2, type: 3}
+  m_Name: event:/Chars/Visitors_coming
+  m_EditorClassIdentifier: 
+  Path: event:/Chars/Visitors_coming
+  Guid:
+    Data1: 2060909958
+    Data2: 1291069867
+    Data3: 1833198778
+    Data4: 1116246517
+  Banks:
+  - {fileID: 1538880662454187021}
+  IsStream: 0
+  Is3D: 0
+  IsOneShot: 1
+  Parameters: []
+  MinDistance: 1
+  MaxDistance: 20
+  Length: 9000
 --- !u!114 &-2451279688731240748
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -378,6 +830,60 @@ MonoBehaviour:
   MinDistance: 1
   MaxDistance: 20
   Length: 875
+--- !u!114 &-2344315120170001498
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ceb653cd98e289a4e8697a1af55201f2, type: 3}
+  m_Name: event:/Game/day_end
+  m_EditorClassIdentifier: 
+  Path: event:/Game/day_end
+  Guid:
+    Data1: -131565596
+    Data2: 1266121145
+    Data3: 2065434257
+    Data4: -1077230187
+  Banks:
+  - {fileID: 1538880662454187021}
+  IsStream: 0
+  Is3D: 0
+  IsOneShot: 1
+  Parameters: []
+  MinDistance: 1
+  MaxDistance: 20
+  Length: 0
+--- !u!114 &-2326308573902718575
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ceb653cd98e289a4e8697a1af55201f2, type: 3}
+  m_Name: event:/UX/bookleaf_right
+  m_EditorClassIdentifier: 
+  Path: event:/UX/bookleaf_right
+  Guid:
+    Data1: 906484965
+    Data2: 1084783885
+    Data3: -1451794783
+    Data4: -1515579945
+  Banks:
+  - {fileID: 1538880662454187021}
+  IsStream: 0
+  Is3D: 0
+  IsOneShot: 1
+  Parameters: []
+  MinDistance: 1
+  MaxDistance: 20
+  Length: 875
 --- !u!114 &-2277473148791874743
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -405,6 +911,33 @@ MonoBehaviour:
   MinDistance: 1
   MaxDistance: 20
   Length: 2000
+--- !u!114 &-2188003815315548020
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ceb653cd98e289a4e8697a1af55201f2, type: 3}
+  m_Name: event:/UX/book_open
+  m_EditorClassIdentifier: 
+  Path: event:/UX/book_open
+  Guid:
+    Data1: 844306991
+    Data2: 1126958569
+    Data3: 504043946
+    Data4: 1593482994
+  Banks:
+  - {fileID: 1538880662454187021}
+  IsStream: 0
+  Is3D: 0
+  IsOneShot: 1
+  Parameters: []
+  MinDistance: 1
+  MaxDistance: 20
+  Length: 2166
 --- !u!114 &-2009738118498821630
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -504,6 +1037,33 @@ MonoBehaviour:
   lastModified: 638174533579904962
   FileSizes: []
   Exists: 1
+--- !u!114 &-1398056848311759497
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ceb653cd98e289a4e8697a1af55201f2, type: 3}
+  m_Name: event:/Location/cauldron_gurgling
+  m_EditorClassIdentifier: 
+  Path: event:/Location/cauldron_gurgling
+  Guid:
+    Data1: -248018065
+    Data2: 1286203235
+    Data3: 1278168505
+    Data4: 132505251
+  Banks:
+  - {fileID: 1538880662454187021}
+  IsStream: 1
+  Is3D: 0
+  IsOneShot: 0
+  Parameters: []
+  MinDistance: 1
+  MaxDistance: 20
+  Length: 21978
 --- !u!114 &-1119888099295746918
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -558,6 +1118,33 @@ MonoBehaviour:
   MinDistance: 1
   MaxDistance: 20
   Length: 1799
+--- !u!114 &-632495026071545967
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ceb653cd98e289a4e8697a1af55201f2, type: 3}
+  m_Name: event:/Game/night_events
+  m_EditorClassIdentifier: 
+  Path: event:/Game/night_events
+  Guid:
+    Data1: 426622294
+    Data2: 1119988114
+    Data3: 313977259
+    Data4: 328655761
+  Banks:
+  - {fileID: 1538880662454187021}
+  IsStream: 0
+  Is3D: 0
+  IsOneShot: 1
+  Parameters: []
+  MinDistance: 1
+  MaxDistance: 20
+  Length: 0
 --- !u!114 &-623264713942235401
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -585,6 +1172,33 @@ MonoBehaviour:
   MinDistance: 1
   MaxDistance: 20
   Length: 2271
+--- !u!114 &-388550348233625315
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ceb653cd98e289a4e8697a1af55201f2, type: 3}
+  m_Name: event:/UX/potion_unlock
+  m_EditorClassIdentifier: 
+  Path: event:/UX/potion_unlock
+  Guid:
+    Data1: 472608145
+    Data2: 1157609419
+    Data3: -685312865
+    Data4: 1074406678
+  Banks:
+  - {fileID: 1538880662454187021}
+  IsStream: 0
+  Is3D: 0
+  IsOneShot: 1
+  Parameters: []
+  MinDistance: 1
+  MaxDistance: 20
+  Length: 0
 --- !u!114 &-235277184869874500
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -625,51 +1239,51 @@ MonoBehaviour:
   m_Name: FMODStudioCache
   m_EditorClassIdentifier: 
   EditorBanks:
-  - {fileID: 9060005250830422542}
-  - {fileID: -1434276780203061547}
+  - {fileID: -4217917264191943376}
+  - {fileID: 1538880662454187021}
   EditorEvents:
-  - {fileID: 8624780530120273035}
-  - {fileID: -3327404232257965205}
-  - {fileID: -4936611575477843158}
-  - {fileID: 6206815673667749271}
-  - {fileID: -2944947927895103288}
-  - {fileID: 3382570717731215109}
-  - {fileID: 93735921157391449}
-  - {fileID: 1983880945278355103}
-  - {fileID: -8024967669597156249}
-  - {fileID: -5627102640347451574}
-  - {fileID: 401402719662524760}
-  - {fileID: -623264713942235401}
-  - {fileID: -1829057791742325010}
-  - {fileID: -7187157224931278943}
-  - {fileID: 8464851980840269980}
-  - {fileID: -2451279688731240748}
-  - {fileID: 5228465887873214558}
-  - {fileID: -3613053970640958595}
-  - {fileID: -3203165074107959609}
-  - {fileID: 4593369216373668026}
-  - {fileID: -676265205725961270}
-  - {fileID: 4344594104934397143}
-  - {fileID: -235277184869874500}
-  - {fileID: -5510325942155711218}
-  - {fileID: 935359067667729800}
-  - {fileID: 5172203238100069970}
-  - {fileID: -5139880003689405849}
-  - {fileID: -1119888099295746918}
-  - {fileID: -6161441151164943836}
-  - {fileID: -6795376441656961152}
-  - {fileID: 3057297743775903851}
-  - {fileID: -2009738118498821630}
-  - {fileID: -1701711811705237860}
-  - {fileID: -2277473148791874743}
-  - {fileID: -2428428483168861904}
-  - {fileID: 3644251969997637177}
+  - {fileID: -7475318917968912554}
+  - {fileID: -5619047329089409827}
+  - {fileID: 4800673504918352178}
+  - {fileID: -6898284717567636291}
+  - {fileID: -2188003815315548020}
+  - {fileID: 2328290386043115678}
+  - {fileID: -9056130099399744577}
+  - {fileID: -8977585902030710500}
+  - {fileID: -5678999817879149159}
+  - {fileID: -8528070367390426488}
+  - {fileID: -632495026071545967}
+  - {fileID: -1398056848311759497}
+  - {fileID: 7450883594911522931}
+  - {fileID: -8248834691234853599}
+  - {fileID: -4884395401892527009}
+  - {fileID: -6368047652405976862}
+  - {fileID: 7414995638332648430}
+  - {fileID: 8265628087193813794}
+  - {fileID: -2630744804140410433}
+  - {fileID: -5206787727162842642}
+  - {fileID: -2522103749156452464}
+  - {fileID: -2871627831067386798}
+  - {fileID: -388550348233625315}
+  - {fileID: 5848980932317320855}
+  - {fileID: -5604472991079920758}
+  - {fileID: 4056622156513523717}
+  - {fileID: -2822475258497210014}
+  - {fileID: 9210926516677842002}
+  - {fileID: 5429516597022590861}
+  - {fileID: 4745588014100792177}
+  - {fileID: 7777133503797814050}
+  - {fileID: 306526720820298446}
+  - {fileID: -2344315120170001498}
+  - {fileID: 2574649546467153491}
+  - {fileID: -2326308573902718575}
+  - {fileID: 3335531045901929678}
   EditorParameters: []
   MasterBanks:
-  - {fileID: -1434276780203061547}
+  - {fileID: 1538880662454187021}
   StringsBanks:
-  - {fileID: 9060005250830422542}
-  cacheTime: 638174533579924962
+  - {fileID: -4217917264191943376}
+  cacheTime: 638183676343232235
   cacheVersion: 131601
 --- !u!114 &93735921157391449
 MonoBehaviour:
@@ -698,6 +1312,33 @@ MonoBehaviour:
   MinDistance: 1
   MaxDistance: 20
   Length: 21978
+--- !u!114 &306526720820298446
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ceb653cd98e289a4e8697a1af55201f2, type: 3}
+  m_Name: event:/UX/book_close
+  m_EditorClassIdentifier: 
+  Path: event:/UX/book_close
+  Guid:
+    Data1: 561215971
+    Data2: 1278941553
+    Data3: 801953468
+    Data4: -303231180
+  Banks:
+  - {fileID: 1538880662454187021}
+  IsStream: 0
+  Is3D: 0
+  IsOneShot: 1
+  Parameters: []
+  MinDistance: 1
+  MaxDistance: 20
+  Length: 1875
 --- !u!114 &401402719662524760
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -752,6 +1393,24 @@ MonoBehaviour:
   MinDistance: 1
   MaxDistance: 20
   Length: 1165
+--- !u!114 &1538880662454187021
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c18180ecb35941f4682ae60107b85b7c, type: 3}
+  m_Name: bank:/Master.bank
+  m_EditorClassIdentifier: 
+  Path: CompiledAudio/Master.bank
+  Name: Master
+  StudioPath: bank:/Master
+  lastModified: 638183676343232235
+  FileSizes: []
+  Exists: 1
 --- !u!114 &1983880945278355103
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -779,6 +1438,60 @@ MonoBehaviour:
   MinDistance: 1
   MaxDistance: 20
   Length: 3041
+--- !u!114 &2328290386043115678
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ceb653cd98e289a4e8697a1af55201f2, type: 3}
+  m_Name: event:/UX/menu_select
+  m_EditorClassIdentifier: 
+  Path: event:/UX/menu_select
+  Guid:
+    Data1: 18570545
+    Data2: 1209806179
+    Data3: 1879785140
+    Data4: 1499301106
+  Banks:
+  - {fileID: 1538880662454187021}
+  IsStream: 0
+  Is3D: 0
+  IsOneShot: 1
+  Parameters: []
+  MinDistance: 1
+  MaxDistance: 20
+  Length: 1057
+--- !u!114 &2574649546467153491
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ceb653cd98e289a4e8697a1af55201f2, type: 3}
+  m_Name: event:/Game/endings
+  m_EditorClassIdentifier: 
+  Path: event:/Game/endings
+  Guid:
+    Data1: -97341724
+    Data2: 1169016539
+    Data3: 600563638
+    Data4: 299315686
+  Banks:
+  - {fileID: 1538880662454187021}
+  IsStream: 0
+  Is3D: 0
+  IsOneShot: 1
+  Parameters: []
+  MinDistance: 1
+  MaxDistance: 20
+  Length: 0
 --- !u!114 &3057297743775903851
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -806,6 +1519,33 @@ MonoBehaviour:
   MinDistance: 1
   MaxDistance: 20
   Length: 1446
+--- !u!114 &3335531045901929678
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ceb653cd98e289a4e8697a1af55201f2, type: 3}
+  m_Name: event:/UX/bookleaf_left
+  m_EditorClassIdentifier: 
+  Path: event:/UX/bookleaf_left
+  Guid:
+    Data1: -236316174
+    Data2: 1101568571
+    Data3: 400823168
+    Data4: -2121267716
+  Banks:
+  - {fileID: 1538880662454187021}
+  IsStream: 0
+  Is3D: 0
+  IsOneShot: 1
+  Parameters: []
+  MinDistance: 1
+  MaxDistance: 20
+  Length: 875
 --- !u!114 &3382570717731215109
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -860,6 +1600,33 @@ MonoBehaviour:
   MinDistance: 1
   MaxDistance: 20
   Length: 875
+--- !u!114 &4056622156513523717
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ceb653cd98e289a4e8697a1af55201f2, type: 3}
+  m_Name: event:/Game/timer_end
+  m_EditorClassIdentifier: 
+  Path: event:/Game/timer_end
+  Guid:
+    Data1: -1405110352
+    Data2: 1266655836
+    Data3: -1658953344
+    Data4: -1198345738
+  Banks:
+  - {fileID: 1538880662454187021}
+  IsStream: 0
+  Is3D: 0
+  IsOneShot: 1
+  Parameters: []
+  MinDistance: 1
+  MaxDistance: 20
+  Length: 1888
 --- !u!114 &4344594104934397143
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -914,6 +1681,60 @@ MonoBehaviour:
   MinDistance: 1
   MaxDistance: 20
   Length: 2142
+--- !u!114 &4745588014100792177
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ceb653cd98e289a4e8697a1af55201f2, type: 3}
+  m_Name: event:/Game/potion_failed
+  m_EditorClassIdentifier: 
+  Path: event:/Game/potion_failed
+  Guid:
+    Data1: 2135570381
+    Data2: 1171060592
+    Data3: -57909620
+    Data4: 178883166
+  Banks:
+  - {fileID: 1538880662454187021}
+  IsStream: 0
+  Is3D: 0
+  IsOneShot: 1
+  Parameters: []
+  MinDistance: 1
+  MaxDistance: 20
+  Length: 1160
+--- !u!114 &4800673504918352178
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ceb653cd98e289a4e8697a1af55201f2, type: 3}
+  m_Name: event:/Chars/Cat/conversation
+  m_EditorClassIdentifier: 
+  Path: event:/Chars/Cat/conversation
+  Guid:
+    Data1: 1285987105
+    Data2: 1166348065
+    Data3: 478632844
+    Data4: -1168773200
+  Banks:
+  - {fileID: 1538880662454187021}
+  IsStream: 0
+  Is3D: 0
+  IsOneShot: 1
+  Parameters: []
+  MinDistance: 1
+  MaxDistance: 20
+  Length: 1507
 --- !u!114 &5172203238100069970
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -968,6 +1789,60 @@ MonoBehaviour:
   MinDistance: 1
   MaxDistance: 20
   Length: 0
+--- !u!114 &5429516597022590861
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ceb653cd98e289a4e8697a1af55201f2, type: 3}
+  m_Name: event:/Game/day_begin
+  m_EditorClassIdentifier: 
+  Path: event:/Game/day_begin
+  Guid:
+    Data1: 1011686080
+    Data2: 1261222706
+    Data3: -2027922499
+    Data4: -286419024
+  Banks:
+  - {fileID: 1538880662454187021}
+  IsStream: 0
+  Is3D: 0
+  IsOneShot: 1
+  Parameters: []
+  MinDistance: 1
+  MaxDistance: 20
+  Length: 0
+--- !u!114 &5848980932317320855
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ceb653cd98e289a4e8697a1af55201f2, type: 3}
+  m_Name: event:/Game/nightCards/in
+  m_EditorClassIdentifier: 
+  Path: event:/Game/nightCards/in
+  Guid:
+    Data1: -1296143467
+    Data2: 1087338784
+    Data3: -1641858925
+    Data4: 1759107464
+  Banks:
+  - {fileID: 1538880662454187021}
+  IsStream: 0
+  Is3D: 0
+  IsOneShot: 1
+  Parameters: []
+  MinDistance: 1
+  MaxDistance: 20
+  Length: 633
 --- !u!114 &6206815673667749271
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -995,6 +1870,114 @@ MonoBehaviour:
   MinDistance: 1
   MaxDistance: 20
   Length: 1057
+--- !u!114 &7414995638332648430
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ceb653cd98e289a4e8697a1af55201f2, type: 3}
+  m_Name: event:/Game/potion_brewed
+  m_EditorClassIdentifier: 
+  Path: event:/Game/potion_brewed
+  Guid:
+    Data1: -448958082
+    Data2: 1213714196
+    Data3: -1428382556
+    Data4: 30564739
+  Banks:
+  - {fileID: 1538880662454187021}
+  IsStream: 0
+  Is3D: 0
+  IsOneShot: 1
+  Parameters: []
+  MinDistance: 1
+  MaxDistance: 20
+  Length: 2450
+--- !u!114 &7450883594911522931
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ceb653cd98e289a4e8697a1af55201f2, type: 3}
+  m_Name: event:/Game/nightCards/out
+  m_EditorClassIdentifier: 
+  Path: event:/Game/nightCards/out
+  Guid:
+    Data1: -1320785291
+    Data2: 1293383631
+    Data3: 86329987
+    Data4: 2052743982
+  Banks:
+  - {fileID: 1538880662454187021}
+  IsStream: 0
+  Is3D: 0
+  IsOneShot: 1
+  Parameters: []
+  MinDistance: 1
+  MaxDistance: 20
+  Length: 671
+--- !u!114 &7777133503797814050
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ceb653cd98e289a4e8697a1af55201f2, type: 3}
+  m_Name: event:/Chars/VisitorComing/enter
+  m_EditorClassIdentifier: 
+  Path: event:/Chars/VisitorComing/enter
+  Guid:
+    Data1: 1944832213
+    Data2: 1201902676
+    Data3: -1662719085
+    Data4: -976462059
+  Banks:
+  - {fileID: 1538880662454187021}
+  IsStream: 0
+  Is3D: 0
+  IsOneShot: 1
+  Parameters: []
+  MinDistance: 1
+  MaxDistance: 20
+  Length: 2000
+--- !u!114 &8265628087193813794
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ceb653cd98e289a4e8697a1af55201f2, type: 3}
+  m_Name: event:/Chars/VisitorComing/voice
+  m_EditorClassIdentifier: 
+  Path: event:/Chars/VisitorComing/voice
+  Guid:
+    Data1: -319895935
+    Data2: 1311772517
+    Data3: -360789346
+    Data4: -1417014897
+  Banks:
+  - {fileID: 1538880662454187021}
+  IsStream: 0
+  Is3D: 0
+  IsOneShot: 1
+  Parameters: []
+  MinDistance: 1
+  MaxDistance: 20
+  Length: 0
 --- !u!114 &8464851980840269980
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1069,3 +2052,30 @@ MonoBehaviour:
   - Name: 
     Value: 2552
   Exists: 1
+--- !u!114 &9210926516677842002
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ceb653cd98e289a4e8697a1af55201f2, type: 3}
+  m_Name: event:/Game/game_start
+  m_EditorClassIdentifier: 
+  Path: event:/Game/game_start
+  Guid:
+    Data1: 1690105011
+    Data2: 1153047362
+    Data3: 1299211670
+    Data4: 853182659
+  Banks:
+  - {fileID: 1538880662454187021}
+  IsStream: 0
+  Is3D: 0
+  IsOneShot: 1
+  Parameters: []
+  MinDistance: 1
+  MaxDistance: 20
+  Length: 4603

--- a/Cauldron/Assets/Plugins/FMOD/Resources/FMODStudioSettings.asset
+++ b/Cauldron/Assets/Plugins/FMOD/Resources/FMODStudioSettings.asset
@@ -1,349 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!114 &-5046919928832263627
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 93a382382f106584e8f8f62412fee177, type: 3}
-  m_Name: FMODStudioSettingsPlatform
-  m_EditorClassIdentifier: 
-  identifier: fd7c55dab0fce234b8c25f6ffca523c1
-  parentIdentifier: default
-  active: 0
-  Properties:
-    LiveUpdate:
-      Value: 0
-      HasValue: 0
-    LiveUpdatePort:
-      Value: 0
-      HasValue: 0
-    Overlay:
-      Value: 0
-      HasValue: 0
-    Logging:
-      Value: 0
-      HasValue: 0
-    SampleRate:
-      Value: 0
-      HasValue: 0
-    BuildDirectory:
-      Value: 
-      HasValue: 0
-    SpeakerMode:
-      Value: 0
-      HasValue: 0
-    VirtualChannelCount:
-      Value: 0
-      HasValue: 0
-    RealChannelCount:
-      Value: 0
-      HasValue: 0
-    DSPBufferLength:
-      Value: 0
-      HasValue: 0
-    DSPBufferCount:
-      Value: 0
-      HasValue: 0
-    Plugins:
-      Value: []
-      HasValue: 0
-    StaticPlugins:
-      Value: []
-      HasValue: 0
-    CallbackHandler:
-      Value: {fileID: 0}
-      HasValue: 0
-  OutputTypeName: 
-  threadAffinities:
-    Value: []
-    HasValue: 0
-  displaySortOrder: 0
-  childIdentifiers: []
-  codecChannels:
-    Value: []
-    HasValue: 0
---- !u!114 &-4694168995181346541
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b87314b32fbe18943af496e4b47136c6, type: 3}
-  m_Name: FMODStudioSettingsPlatform
-  m_EditorClassIdentifier: 
-  identifier: 46fbfdf3fc43db0458918377fd40293e
-  parentIdentifier: default
-  active: 0
-  Properties:
-    LiveUpdate:
-      Value: 0
-      HasValue: 0
-    LiveUpdatePort:
-      Value: 0
-      HasValue: 0
-    Overlay:
-      Value: 0
-      HasValue: 0
-    Logging:
-      Value: 0
-      HasValue: 0
-    SampleRate:
-      Value: 0
-      HasValue: 0
-    BuildDirectory:
-      Value: 
-      HasValue: 0
-    SpeakerMode:
-      Value: 0
-      HasValue: 0
-    VirtualChannelCount:
-      Value: 0
-      HasValue: 0
-    RealChannelCount:
-      Value: 0
-      HasValue: 0
-    DSPBufferLength:
-      Value: 0
-      HasValue: 0
-    DSPBufferCount:
-      Value: 0
-      HasValue: 0
-    Plugins:
-      Value: []
-      HasValue: 0
-    StaticPlugins:
-      Value: []
-      HasValue: 0
-    CallbackHandler:
-      Value: {fileID: 0}
-      HasValue: 0
-  OutputTypeName: 
-  threadAffinities:
-    Value: []
-    HasValue: 0
-  displaySortOrder: 0
-  childIdentifiers: []
-  codecChannels:
-    Value: []
-    HasValue: 0
---- !u!114 &-3100756610407417861
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9587379c972e4a54da1949613f11e1c6, type: 3}
-  m_Name: FMODStudioSettingsPlatform
-  m_EditorClassIdentifier: 
-  identifier: default
-  parentIdentifier: 
-  active: 1
-  Properties:
-    LiveUpdate:
-      Value: 0
-      HasValue: 1
-    LiveUpdatePort:
-      Value: 9264
-      HasValue: 1
-    Overlay:
-      Value: 0
-      HasValue: 0
-    Logging:
-      Value: 0
-      HasValue: 0
-    SampleRate:
-      Value: 0
-      HasValue: 0
-    BuildDirectory:
-      Value: 
-      HasValue: 0
-    SpeakerMode:
-      Value: 3
-      HasValue: 1
-    VirtualChannelCount:
-      Value: 0
-      HasValue: 0
-    RealChannelCount:
-      Value: 0
-      HasValue: 0
-    DSPBufferLength:
-      Value: 0
-      HasValue: 0
-    DSPBufferCount:
-      Value: 0
-      HasValue: 0
-    Plugins:
-      Value: []
-      HasValue: 1
-    StaticPlugins:
-      Value: []
-      HasValue: 1
-    CallbackHandler:
-      Value: {fileID: 0}
-      HasValue: 0
-  OutputTypeName: 
-  threadAffinities:
-    Value: []
-    HasValue: 0
-  displaySortOrder: 0
-  childIdentifiers:
-  - c88d16e5272a4e241b0ef0ac2e53b73d
-  - fd7c55dab0fce234b8c25f6ffca523c1
-  - 2c5177b11d81d824dbb064f9ac8527da
-  - e7a046c753c3c3d4aacc91f6597f310d
-  - 52eb9df5db46521439908db3a29a1bbb
-  - b7716510a1f36934c87976f3a81dbf3d
-  - 0f8eb3f400726694eb47beb1a9f94ce8
-  - 46fbfdf3fc43db0458918377fd40293e
-  - 2fea114e74ecf3c4f920e1d5cc1c4c40
-  codecChannels:
-    Value: []
-    HasValue: 0
---- !u!114 &11400000
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: eef8d824ea7b63742966aaa0e94ac383, type: 3}
-  m_Name: FMODStudioSettings
-  m_EditorClassIdentifier: 
-  switchSettingsMigration: 1
-  HasSourceProject: 0
-  HasPlatforms: 0
-  sourceProjectPath: 
-  sourceBankPath: CompiledAudio
-  sourceBankPathUnformatted: 
-  BankRefreshCooldown: 5
-  ShowBankRefreshWindow: 1
-  AutomaticEventLoading: 1
-  BankLoadType: 0
-  AutomaticSampleLoading: 0
-  EncryptionKey: 
-  ImportType: 0
-  TargetAssetPath: FMODBanks
-  TargetBankFolder: 
-  EventLinkage: 0
-  LoggingLevel: 2
-  SpeakerModeSettings: []
-  SampleRateSettings: []
-  LiveUpdateSettings: []
-  OverlaySettings: []
-  BankDirectorySettings: []
-  VirtualChannelSettings: []
-  RealChannelSettings: []
-  Plugins: []
-  MasterBanks:
-  - Master
-  Banks: []
-  BanksToLoad: []
-  LiveUpdatePort: 9264
-  EnableMemoryTracking: 0
-  AndroidUseOBB: 0
-  MeterChannelOrdering: 0
-  StopEventsOutsideMaxDistance: 0
-  BoltUnitOptionsBuildPending: 0
-  EnableErrorCallback: 0
-  SharedLibraryUpdateStage: 0
-  SharedLibraryTimeSinceStart: 0
-  CurrentVersion: 131601
-  HideSetupWizard: 1
-  LastEventReferenceScanVersion: 131601
-  Platforms:
-  - {fileID: 6080758768624254735}
-  - {fileID: -3100756610407417861}
-  - {fileID: 4404721561892614767}
-  - {fileID: -5046919928832263627}
-  - {fileID: 8805430367404492249}
-  - {fileID: 7362716019395857220}
-  - {fileID: 5314949752010729581}
-  - {fileID: 5055151945938315432}
-  - {fileID: 872153229760218409}
-  - {fileID: -4694168995181346541}
-  - {fileID: 4898413812033551334}
-  MigratedPlatforms: 0c000000150000000b0000000a00000009000000120000000800000005000000060000000200000001000000
---- !u!114 &872153229760218409
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: bc1f51bc35d549941904cf062bae93a3, type: 3}
-  m_Name: FMODStudioSettingsPlatform
-  m_EditorClassIdentifier: 
-  identifier: 0f8eb3f400726694eb47beb1a9f94ce8
-  parentIdentifier: default
-  active: 0
-  Properties:
-    LiveUpdate:
-      Value: 0
-      HasValue: 0
-    LiveUpdatePort:
-      Value: 0
-      HasValue: 0
-    Overlay:
-      Value: 0
-      HasValue: 0
-    Logging:
-      Value: 0
-      HasValue: 0
-    SampleRate:
-      Value: 0
-      HasValue: 0
-    BuildDirectory:
-      Value: 
-      HasValue: 0
-    SpeakerMode:
-      Value: 0
-      HasValue: 0
-    VirtualChannelCount:
-      Value: 0
-      HasValue: 0
-    RealChannelCount:
-      Value: 0
-      HasValue: 0
-    DSPBufferLength:
-      Value: 0
-      HasValue: 0
-    DSPBufferCount:
-      Value: 0
-      HasValue: 0
-    Plugins:
-      Value: []
-      HasValue: 0
-    StaticPlugins:
-      Value: []
-      HasValue: 0
-    CallbackHandler:
-      Value: {fileID: 0}
-      HasValue: 0
-  OutputTypeName: 
-  threadAffinities:
-    Value: []
-    HasValue: 0
-  displaySortOrder: 0
-  childIdentifiers: []
-  codecChannels:
-    Value: []
-    HasValue: 0
---- !u!114 &4404721561892614767
+--- !u!114 &-6313549966348010486
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -410,141 +67,7 @@ MonoBehaviour:
   codecChannels:
     Value: []
     HasValue: 0
---- !u!114 &4898413812033551334
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 97ba6cc2660c0ca498540d254701057a, type: 3}
-  m_Name: FMODStudioSettingsPlatform
-  m_EditorClassIdentifier: 
-  identifier: 2fea114e74ecf3c4f920e1d5cc1c4c40
-  parentIdentifier: default
-  active: 0
-  Properties:
-    LiveUpdate:
-      Value: 0
-      HasValue: 0
-    LiveUpdatePort:
-      Value: 0
-      HasValue: 0
-    Overlay:
-      Value: 0
-      HasValue: 0
-    Logging:
-      Value: 0
-      HasValue: 0
-    SampleRate:
-      Value: 0
-      HasValue: 0
-    BuildDirectory:
-      Value: 
-      HasValue: 0
-    SpeakerMode:
-      Value: 0
-      HasValue: 0
-    VirtualChannelCount:
-      Value: 0
-      HasValue: 0
-    RealChannelCount:
-      Value: 0
-      HasValue: 0
-    DSPBufferLength:
-      Value: 0
-      HasValue: 0
-    DSPBufferCount:
-      Value: 0
-      HasValue: 0
-    Plugins:
-      Value: []
-      HasValue: 0
-    StaticPlugins:
-      Value: []
-      HasValue: 0
-    CallbackHandler:
-      Value: {fileID: 0}
-      HasValue: 0
-  OutputTypeName: 
-  threadAffinities:
-    Value: []
-    HasValue: 0
-  displaySortOrder: 0
-  childIdentifiers: []
-  codecChannels:
-    Value: []
-    HasValue: 0
---- !u!114 &5055151945938315432
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 73549a74f689f0849a8271d9e908c514, type: 3}
-  m_Name: FMODStudioSettingsPlatform
-  m_EditorClassIdentifier: 
-  identifier: b7716510a1f36934c87976f3a81dbf3d
-  parentIdentifier: default
-  active: 0
-  Properties:
-    LiveUpdate:
-      Value: 0
-      HasValue: 0
-    LiveUpdatePort:
-      Value: 0
-      HasValue: 0
-    Overlay:
-      Value: 0
-      HasValue: 0
-    Logging:
-      Value: 0
-      HasValue: 0
-    SampleRate:
-      Value: 0
-      HasValue: 0
-    BuildDirectory:
-      Value: 
-      HasValue: 0
-    SpeakerMode:
-      Value: 0
-      HasValue: 0
-    VirtualChannelCount:
-      Value: 0
-      HasValue: 0
-    RealChannelCount:
-      Value: 0
-      HasValue: 0
-    DSPBufferLength:
-      Value: 0
-      HasValue: 0
-    DSPBufferCount:
-      Value: 0
-      HasValue: 0
-    Plugins:
-      Value: []
-      HasValue: 0
-    StaticPlugins:
-      Value: []
-      HasValue: 0
-    CallbackHandler:
-      Value: {fileID: 0}
-      HasValue: 0
-  OutputTypeName: 
-  threadAffinities:
-    Value: []
-    HasValue: 0
-  displaySortOrder: 0
-  childIdentifiers: []
-  codecChannels:
-    Value: []
-    HasValue: 0
---- !u!114 &5314949752010729581
+--- !u!114 &-6026719091998104224
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -611,74 +134,7 @@ MonoBehaviour:
   codecChannels:
     Value: []
     HasValue: 0
---- !u!114 &6080758768624254735
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 335f0a4b26fb46942858ea029e030d2a, type: 3}
-  m_Name: FMODStudioSettingsPlatform
-  m_EditorClassIdentifier: 
-  identifier: playInEditor
-  parentIdentifier: 
-  active: 1
-  Properties:
-    LiveUpdate:
-      Value: 0
-      HasValue: 1
-    LiveUpdatePort:
-      Value: 0
-      HasValue: 0
-    Overlay:
-      Value: 0
-      HasValue: 1
-    Logging:
-      Value: 0
-      HasValue: 0
-    SampleRate:
-      Value: 48000
-      HasValue: 1
-    BuildDirectory:
-      Value: 
-      HasValue: 0
-    SpeakerMode:
-      Value: 0
-      HasValue: 0
-    VirtualChannelCount:
-      Value: 1024
-      HasValue: 1
-    RealChannelCount:
-      Value: 256
-      HasValue: 1
-    DSPBufferLength:
-      Value: 0
-      HasValue: 0
-    DSPBufferCount:
-      Value: 0
-      HasValue: 0
-    Plugins:
-      Value: []
-      HasValue: 0
-    StaticPlugins:
-      Value: []
-      HasValue: 0
-    CallbackHandler:
-      Value: {fileID: 0}
-      HasValue: 0
-  OutputTypeName: 
-  threadAffinities:
-    Value: []
-    HasValue: 0
-  displaySortOrder: 0
-  childIdentifiers: []
-  codecChannels:
-    Value: []
-    HasValue: 0
---- !u!114 &7362716019395857220
+--- !u!114 &-5941705768878480554
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -745,7 +201,83 @@ MonoBehaviour:
   codecChannels:
     Value: []
     HasValue: 0
---- !u!114 &8805430367404492249
+--- !u!114 &-4932596033980205350
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9587379c972e4a54da1949613f11e1c6, type: 3}
+  m_Name: FMODStudioSettingsPlatform
+  m_EditorClassIdentifier: 
+  identifier: default
+  parentIdentifier: 
+  active: 1
+  Properties:
+    LiveUpdate:
+      Value: 0
+      HasValue: 0
+    LiveUpdatePort:
+      Value: 9264
+      HasValue: 1
+    Overlay:
+      Value: 0
+      HasValue: 0
+    Logging:
+      Value: 0
+      HasValue: 0
+    SampleRate:
+      Value: 0
+      HasValue: 0
+    BuildDirectory:
+      Value: 
+      HasValue: 0
+    SpeakerMode:
+      Value: 0
+      HasValue: 0
+    VirtualChannelCount:
+      Value: 0
+      HasValue: 0
+    RealChannelCount:
+      Value: 0
+      HasValue: 0
+    DSPBufferLength:
+      Value: 0
+      HasValue: 0
+    DSPBufferCount:
+      Value: 0
+      HasValue: 0
+    Plugins:
+      Value: []
+      HasValue: 1
+    StaticPlugins:
+      Value: []
+      HasValue: 1
+    CallbackHandler:
+      Value: {fileID: 0}
+      HasValue: 0
+  OutputTypeName: 
+  threadAffinities:
+    Value: []
+    HasValue: 0
+  displaySortOrder: 0
+  childIdentifiers:
+  - 2fea114e74ecf3c4f920e1d5cc1c4c40
+  - 46fbfdf3fc43db0458918377fd40293e
+  - 0f8eb3f400726694eb47beb1a9f94ce8
+  - b7716510a1f36934c87976f3a81dbf3d
+  - 52eb9df5db46521439908db3a29a1bbb
+  - e7a046c753c3c3d4aacc91f6597f310d
+  - 2c5177b11d81d824dbb064f9ac8527da
+  - fd7c55dab0fce234b8c25f6ffca523c1
+  - c88d16e5272a4e241b0ef0ac2e53b73d
+  codecChannels:
+    Value: []
+    HasValue: 0
+--- !u!114 &-3826176723006058031
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -788,6 +320,474 @@ MonoBehaviour:
     RealChannelCount:
       Value: 0
       HasValue: 0
+    DSPBufferLength:
+      Value: 0
+      HasValue: 0
+    DSPBufferCount:
+      Value: 0
+      HasValue: 0
+    Plugins:
+      Value: []
+      HasValue: 0
+    StaticPlugins:
+      Value: []
+      HasValue: 0
+    CallbackHandler:
+      Value: {fileID: 0}
+      HasValue: 0
+  OutputTypeName: 
+  threadAffinities:
+    Value: []
+    HasValue: 0
+  displaySortOrder: 0
+  childIdentifiers: []
+  codecChannels:
+    Value: []
+    HasValue: 0
+--- !u!114 &-3517109403337826430
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b87314b32fbe18943af496e4b47136c6, type: 3}
+  m_Name: FMODStudioSettingsPlatform
+  m_EditorClassIdentifier: 
+  identifier: 46fbfdf3fc43db0458918377fd40293e
+  parentIdentifier: default
+  active: 0
+  Properties:
+    LiveUpdate:
+      Value: 0
+      HasValue: 0
+    LiveUpdatePort:
+      Value: 0
+      HasValue: 0
+    Overlay:
+      Value: 0
+      HasValue: 0
+    Logging:
+      Value: 0
+      HasValue: 0
+    SampleRate:
+      Value: 0
+      HasValue: 0
+    BuildDirectory:
+      Value: 
+      HasValue: 0
+    SpeakerMode:
+      Value: 0
+      HasValue: 0
+    VirtualChannelCount:
+      Value: 0
+      HasValue: 0
+    RealChannelCount:
+      Value: 0
+      HasValue: 0
+    DSPBufferLength:
+      Value: 0
+      HasValue: 0
+    DSPBufferCount:
+      Value: 0
+      HasValue: 0
+    Plugins:
+      Value: []
+      HasValue: 0
+    StaticPlugins:
+      Value: []
+      HasValue: 0
+    CallbackHandler:
+      Value: {fileID: 0}
+      HasValue: 0
+  OutputTypeName: 
+  threadAffinities:
+    Value: []
+    HasValue: 0
+  displaySortOrder: 0
+  childIdentifiers: []
+  codecChannels:
+    Value: []
+    HasValue: 0
+--- !u!114 &-2240984734626688094
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 97ba6cc2660c0ca498540d254701057a, type: 3}
+  m_Name: FMODStudioSettingsPlatform
+  m_EditorClassIdentifier: 
+  identifier: 2fea114e74ecf3c4f920e1d5cc1c4c40
+  parentIdentifier: default
+  active: 0
+  Properties:
+    LiveUpdate:
+      Value: 0
+      HasValue: 0
+    LiveUpdatePort:
+      Value: 0
+      HasValue: 0
+    Overlay:
+      Value: 0
+      HasValue: 0
+    Logging:
+      Value: 0
+      HasValue: 0
+    SampleRate:
+      Value: 0
+      HasValue: 0
+    BuildDirectory:
+      Value: 
+      HasValue: 0
+    SpeakerMode:
+      Value: 0
+      HasValue: 0
+    VirtualChannelCount:
+      Value: 0
+      HasValue: 0
+    RealChannelCount:
+      Value: 0
+      HasValue: 0
+    DSPBufferLength:
+      Value: 0
+      HasValue: 0
+    DSPBufferCount:
+      Value: 0
+      HasValue: 0
+    Plugins:
+      Value: []
+      HasValue: 0
+    StaticPlugins:
+      Value: []
+      HasValue: 0
+    CallbackHandler:
+      Value: {fileID: 0}
+      HasValue: 0
+  OutputTypeName: 
+  threadAffinities:
+    Value: []
+    HasValue: 0
+  displaySortOrder: 0
+  childIdentifiers: []
+  codecChannels:
+    Value: []
+    HasValue: 0
+--- !u!114 &-595177012661494611
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 93a382382f106584e8f8f62412fee177, type: 3}
+  m_Name: FMODStudioSettingsPlatform
+  m_EditorClassIdentifier: 
+  identifier: fd7c55dab0fce234b8c25f6ffca523c1
+  parentIdentifier: default
+  active: 0
+  Properties:
+    LiveUpdate:
+      Value: 0
+      HasValue: 0
+    LiveUpdatePort:
+      Value: 0
+      HasValue: 0
+    Overlay:
+      Value: 0
+      HasValue: 0
+    Logging:
+      Value: 0
+      HasValue: 0
+    SampleRate:
+      Value: 0
+      HasValue: 0
+    BuildDirectory:
+      Value: 
+      HasValue: 0
+    SpeakerMode:
+      Value: 0
+      HasValue: 0
+    VirtualChannelCount:
+      Value: 0
+      HasValue: 0
+    RealChannelCount:
+      Value: 0
+      HasValue: 0
+    DSPBufferLength:
+      Value: 0
+      HasValue: 0
+    DSPBufferCount:
+      Value: 0
+      HasValue: 0
+    Plugins:
+      Value: []
+      HasValue: 0
+    StaticPlugins:
+      Value: []
+      HasValue: 0
+    CallbackHandler:
+      Value: {fileID: 0}
+      HasValue: 0
+  OutputTypeName: 
+  threadAffinities:
+    Value: []
+    HasValue: 0
+  displaySortOrder: 0
+  childIdentifiers: []
+  codecChannels:
+    Value: []
+    HasValue: 0
+--- !u!114 &-490722502629303949
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 73549a74f689f0849a8271d9e908c514, type: 3}
+  m_Name: FMODStudioSettingsPlatform
+  m_EditorClassIdentifier: 
+  identifier: b7716510a1f36934c87976f3a81dbf3d
+  parentIdentifier: default
+  active: 0
+  Properties:
+    LiveUpdate:
+      Value: 0
+      HasValue: 0
+    LiveUpdatePort:
+      Value: 0
+      HasValue: 0
+    Overlay:
+      Value: 0
+      HasValue: 0
+    Logging:
+      Value: 0
+      HasValue: 0
+    SampleRate:
+      Value: 0
+      HasValue: 0
+    BuildDirectory:
+      Value: 
+      HasValue: 0
+    SpeakerMode:
+      Value: 0
+      HasValue: 0
+    VirtualChannelCount:
+      Value: 0
+      HasValue: 0
+    RealChannelCount:
+      Value: 0
+      HasValue: 0
+    DSPBufferLength:
+      Value: 0
+      HasValue: 0
+    DSPBufferCount:
+      Value: 0
+      HasValue: 0
+    Plugins:
+      Value: []
+      HasValue: 0
+    StaticPlugins:
+      Value: []
+      HasValue: 0
+    CallbackHandler:
+      Value: {fileID: 0}
+      HasValue: 0
+  OutputTypeName: 
+  threadAffinities:
+    Value: []
+    HasValue: 0
+  displaySortOrder: 0
+  childIdentifiers: []
+  codecChannels:
+    Value: []
+    HasValue: 0
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eef8d824ea7b63742966aaa0e94ac383, type: 3}
+  m_Name: FMODStudioSettings
+  m_EditorClassIdentifier: 
+  switchSettingsMigration: 1
+  HasSourceProject: 0
+  HasPlatforms: 0
+  sourceProjectPath: 
+  sourceBankPath: CompiledAudio
+  sourceBankPathUnformatted: 
+  BankRefreshCooldown: 5
+  ShowBankRefreshWindow: 1
+  AutomaticEventLoading: 1
+  BankLoadType: 0
+  AutomaticSampleLoading: 0
+  EncryptionKey: 
+  ImportType: 0
+  TargetAssetPath: FMODBanks
+  TargetBankFolder: 
+  EventLinkage: 0
+  LoggingLevel: 2
+  SpeakerModeSettings: []
+  SampleRateSettings: []
+  LiveUpdateSettings: []
+  OverlaySettings: []
+  BankDirectorySettings: []
+  VirtualChannelSettings: []
+  RealChannelSettings: []
+  Plugins: []
+  MasterBanks:
+  - Master
+  Banks: []
+  BanksToLoad: []
+  LiveUpdatePort: 9264
+  EnableMemoryTracking: 0
+  AndroidUseOBB: 0
+  MeterChannelOrdering: 0
+  StopEventsOutsideMaxDistance: 0
+  BoltUnitOptionsBuildPending: 0
+  EnableErrorCallback: 0
+  SharedLibraryUpdateStage: 0
+  SharedLibraryTimeSinceStart: 0
+  CurrentVersion: 131601
+  HideSetupWizard: 0
+  LastEventReferenceScanVersion: 131601
+  Platforms:
+  - {fileID: -2240984734626688094}
+  - {fileID: -3517109403337826430}
+  - {fileID: 2344633823481697888}
+  - {fileID: -490722502629303949}
+  - {fileID: -6026719091998104224}
+  - {fileID: -5941705768878480554}
+  - {fileID: -3826176723006058031}
+  - {fileID: -595177012661494611}
+  - {fileID: -6313549966348010486}
+  - {fileID: -4932596033980205350}
+  - {fileID: 2959450943411115420}
+  MigratedPlatforms: 0c000000150000000b0000000a00000009000000120000000800000005000000060000000200000001000000
+--- !u!114 &2344633823481697888
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bc1f51bc35d549941904cf062bae93a3, type: 3}
+  m_Name: FMODStudioSettingsPlatform
+  m_EditorClassIdentifier: 
+  identifier: 0f8eb3f400726694eb47beb1a9f94ce8
+  parentIdentifier: default
+  active: 0
+  Properties:
+    LiveUpdate:
+      Value: 0
+      HasValue: 0
+    LiveUpdatePort:
+      Value: 0
+      HasValue: 0
+    Overlay:
+      Value: 0
+      HasValue: 0
+    Logging:
+      Value: 0
+      HasValue: 0
+    SampleRate:
+      Value: 0
+      HasValue: 0
+    BuildDirectory:
+      Value: 
+      HasValue: 0
+    SpeakerMode:
+      Value: 0
+      HasValue: 0
+    VirtualChannelCount:
+      Value: 0
+      HasValue: 0
+    RealChannelCount:
+      Value: 0
+      HasValue: 0
+    DSPBufferLength:
+      Value: 0
+      HasValue: 0
+    DSPBufferCount:
+      Value: 0
+      HasValue: 0
+    Plugins:
+      Value: []
+      HasValue: 0
+    StaticPlugins:
+      Value: []
+      HasValue: 0
+    CallbackHandler:
+      Value: {fileID: 0}
+      HasValue: 0
+  OutputTypeName: 
+  threadAffinities:
+    Value: []
+    HasValue: 0
+  displaySortOrder: 0
+  childIdentifiers: []
+  codecChannels:
+    Value: []
+    HasValue: 0
+--- !u!114 &2959450943411115420
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 335f0a4b26fb46942858ea029e030d2a, type: 3}
+  m_Name: FMODStudioSettingsPlatform
+  m_EditorClassIdentifier: 
+  identifier: playInEditor
+  parentIdentifier: 
+  active: 1
+  Properties:
+    LiveUpdate:
+      Value: 1
+      HasValue: 1
+    LiveUpdatePort:
+      Value: 0
+      HasValue: 0
+    Overlay:
+      Value: 1
+      HasValue: 1
+    Logging:
+      Value: 0
+      HasValue: 0
+    SampleRate:
+      Value: 48000
+      HasValue: 1
+    BuildDirectory:
+      Value: 
+      HasValue: 0
+    SpeakerMode:
+      Value: 0
+      HasValue: 0
+    VirtualChannelCount:
+      Value: 1024
+      HasValue: 1
+    RealChannelCount:
+      Value: 256
+      HasValue: 1
     DSPBufferLength:
       Value: 0
       HasValue: 0

--- a/Cauldron/Assets/Plugins/UniTask.meta
+++ b/Cauldron/Assets/Plugins/UniTask.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 797b8107133c620498926ade510c62a6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Editor.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7cc171727073b454fa742b066314d14d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Editor/SplitterGUILayout.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Editor/SplitterGUILayout.cs
@@ -1,0 +1,62 @@
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System;
+using System.Linq;
+using System.Reflection;
+using UnityEditor;
+using UnityEngine;
+
+namespace Cysharp.Threading.Tasks.Editor
+{
+    // reflection call of UnityEditor.SplitterGUILayout
+    internal static class SplitterGUILayout
+    {
+        static BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static;
+
+        static Lazy<Type> splitterStateType = new Lazy<Type>(() =>
+        {
+            var type = typeof(EditorWindow).Assembly.GetTypes().First(x => x.FullName == "UnityEditor.SplitterState");
+            return type;
+        });
+
+        static Lazy<ConstructorInfo> splitterStateCtor = new Lazy<ConstructorInfo>(() =>
+        {
+            var type = splitterStateType.Value;
+            return type.GetConstructor(flags, null, new Type[] { typeof(float[]), typeof(int[]), typeof(int[]) }, null);
+        });
+
+        static Lazy<Type> splitterGUILayoutType = new Lazy<Type>(() =>
+        {
+            var type = typeof(EditorWindow).Assembly.GetTypes().First(x => x.FullName == "UnityEditor.SplitterGUILayout");
+            return type;
+        });
+
+        static Lazy<MethodInfo> beginVerticalSplit = new Lazy<MethodInfo>(() =>
+        {
+            var type = splitterGUILayoutType.Value;
+            return type.GetMethod("BeginVerticalSplit", flags, null, new Type[] { splitterStateType.Value, typeof(GUILayoutOption[]) }, null);
+        });
+
+        static Lazy<MethodInfo> endVerticalSplit = new Lazy<MethodInfo>(() =>
+        {
+            var type = splitterGUILayoutType.Value;
+            return type.GetMethod("EndVerticalSplit", flags, null, Type.EmptyTypes, null);
+        });
+
+        public static object CreateSplitterState(float[] relativeSizes, int[] minSizes, int[] maxSizes)
+        {
+            return splitterStateCtor.Value.Invoke(new object[] { relativeSizes, minSizes, maxSizes });
+        }
+
+        public static void BeginVerticalSplit(object splitterState, params GUILayoutOption[] options)
+        {
+            beginVerticalSplit.Value.Invoke(null, new object[] { splitterState, options });
+        }
+
+        public static void EndVerticalSplit()
+        {
+            endVerticalSplit.Value.Invoke(null, Type.EmptyTypes);
+        }
+    }
+}
+

--- a/Cauldron/Assets/Plugins/UniTask/Editor/SplitterGUILayout.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Editor/SplitterGUILayout.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 40ef2e46f900131419e869398a8d3c9d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Editor/UniTask.Editor.asmdef
+++ b/Cauldron/Assets/Plugins/UniTask/Editor/UniTask.Editor.asmdef
@@ -1,0 +1,17 @@
+{
+    "name": "UniTask.Editor",
+    "references": [
+        "UniTask"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": false,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Cauldron/Assets/Plugins/UniTask/Editor/UniTask.Editor.asmdef.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Editor/UniTask.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4129704b5a1a13841ba16f230bf24a57
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Editor/UniTaskTrackerTreeView.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Editor/UniTaskTrackerTreeView.cs
@@ -1,0 +1,182 @@
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using UnityEngine;
+using UnityEditor;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System;
+using UnityEditor.IMGUI.Controls;
+using Cysharp.Threading.Tasks.Internal;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Cysharp.Threading.Tasks.Editor
+{
+    public class UniTaskTrackerViewItem : TreeViewItem
+    {
+        static Regex removeHref = new Regex("<a href.+>(.+)</a>", RegexOptions.Compiled);
+
+        public string TaskType { get; set; }
+        public string Elapsed { get; set; }
+        public string Status { get; set; }
+
+        string position;
+        public string Position
+        {
+            get { return position; }
+            set
+            {
+                position = value;
+                PositionFirstLine = GetFirstLine(position);
+            }
+        }
+
+        public string PositionFirstLine { get; private set; }
+
+        static string GetFirstLine(string str)
+        {
+            var sb = new StringBuilder();
+            for (int i = 0; i < str.Length; i++)
+            {
+                if (str[i] == '\r' || str[i] == '\n')
+                {
+                    break;
+                }
+                sb.Append(str[i]);
+            }
+
+            return removeHref.Replace(sb.ToString(), "$1");
+        }
+
+        public UniTaskTrackerViewItem(int id) : base(id)
+        {
+
+        }
+    }
+
+    public class UniTaskTrackerTreeView : TreeView
+    {
+        const string sortedColumnIndexStateKey = "UniTaskTrackerTreeView_sortedColumnIndex";
+
+        public IReadOnlyList<TreeViewItem> CurrentBindingItems;
+
+        public UniTaskTrackerTreeView()
+            : this(new TreeViewState(), new MultiColumnHeader(new MultiColumnHeaderState(new[]
+            {
+                new MultiColumnHeaderState.Column() { headerContent = new GUIContent("TaskType"), width = 20},
+                new MultiColumnHeaderState.Column() { headerContent = new GUIContent("Elapsed"), width = 10},
+                new MultiColumnHeaderState.Column() { headerContent = new GUIContent("Status"), width = 10},
+                new MultiColumnHeaderState.Column() { headerContent = new GUIContent("Position")},
+            })))
+        {
+        }
+
+        UniTaskTrackerTreeView(TreeViewState state, MultiColumnHeader header)
+            : base(state, header)
+        {
+            rowHeight = 20;
+            showAlternatingRowBackgrounds = true;
+            showBorder = true;
+            header.sortingChanged += Header_sortingChanged;
+
+            header.ResizeToFit();
+            Reload();
+
+            header.sortedColumnIndex = SessionState.GetInt(sortedColumnIndexStateKey, 1);
+        }
+
+        public void ReloadAndSort()
+        {
+            var currentSelected = this.state.selectedIDs;
+            Reload();
+            Header_sortingChanged(this.multiColumnHeader);
+            this.state.selectedIDs = currentSelected;
+        }
+
+        private void Header_sortingChanged(MultiColumnHeader multiColumnHeader)
+        {
+            SessionState.SetInt(sortedColumnIndexStateKey, multiColumnHeader.sortedColumnIndex);
+            var index = multiColumnHeader.sortedColumnIndex;
+            var ascending = multiColumnHeader.IsSortedAscending(multiColumnHeader.sortedColumnIndex);
+
+            var items = rootItem.children.Cast<UniTaskTrackerViewItem>();
+
+            IOrderedEnumerable<UniTaskTrackerViewItem> orderedEnumerable;
+            switch (index)
+            {
+                case 0:
+                    orderedEnumerable = ascending ? items.OrderBy(item => item.TaskType) : items.OrderByDescending(item => item.TaskType);
+                    break;
+                case 1:
+                    orderedEnumerable = ascending ? items.OrderBy(item => double.Parse(item.Elapsed)) : items.OrderByDescending(item => double.Parse(item.Elapsed));
+                    break;
+                case 2:
+                    orderedEnumerable = ascending ? items.OrderBy(item => item.Status) : items.OrderByDescending(item => item.Elapsed);
+                    break;
+                case 3:
+                    orderedEnumerable = ascending ? items.OrderBy(item => item.Position) : items.OrderByDescending(item => item.PositionFirstLine);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(index), index, null);
+            }
+
+            CurrentBindingItems = rootItem.children = orderedEnumerable.Cast<TreeViewItem>().ToList();
+            BuildRows(rootItem);
+        }
+
+        protected override TreeViewItem BuildRoot()
+        {
+            var root = new TreeViewItem { depth = -1 };
+
+            var children = new List<TreeViewItem>();
+
+            TaskTracker.ForEachActiveTask((trackingId, awaiterType, status, created, stackTrace) =>
+            {
+                children.Add(new UniTaskTrackerViewItem(trackingId) { TaskType = awaiterType, Status = status.ToString(), Elapsed = (DateTime.UtcNow - created).TotalSeconds.ToString("00.00"), Position = stackTrace });
+            });
+
+            CurrentBindingItems = children;
+            root.children = CurrentBindingItems as List<TreeViewItem>;
+            return root;
+        }
+
+        protected override bool CanMultiSelect(TreeViewItem item)
+        {
+            return false;
+        }
+
+        protected override void RowGUI(RowGUIArgs args)
+        {
+            var item = args.item as UniTaskTrackerViewItem;
+
+            for (var visibleColumnIndex = 0; visibleColumnIndex < args.GetNumVisibleColumns(); visibleColumnIndex++)
+            {
+                var rect = args.GetCellRect(visibleColumnIndex);
+                var columnIndex = args.GetColumn(visibleColumnIndex);
+
+                var labelStyle = args.selected ? EditorStyles.whiteLabel : EditorStyles.label;
+                labelStyle.alignment = TextAnchor.MiddleLeft;
+                switch (columnIndex)
+                {
+                    case 0:
+                        EditorGUI.LabelField(rect, item.TaskType, labelStyle);
+                        break;
+                    case 1:
+                        EditorGUI.LabelField(rect, item.Elapsed, labelStyle);
+                        break;
+                    case 2:
+                        EditorGUI.LabelField(rect, item.Status, labelStyle);
+                        break;
+                    case 3:
+                        EditorGUI.LabelField(rect, item.PositionFirstLine, labelStyle);
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(columnIndex), columnIndex, null);
+                }
+            }
+        }
+    }
+
+}
+

--- a/Cauldron/Assets/Plugins/UniTask/Editor/UniTaskTrackerTreeView.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Editor/UniTaskTrackerTreeView.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 52e2d973a2156674e8c1c9433ed031f7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Editor/UniTaskTrackerWindow.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Editor/UniTaskTrackerWindow.cs
@@ -1,0 +1,209 @@
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using UnityEngine;
+using UnityEditor;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System;
+using UnityEditor.IMGUI.Controls;
+using Cysharp.Threading.Tasks.Internal;
+
+namespace Cysharp.Threading.Tasks.Editor
+{
+    public class UniTaskTrackerWindow : EditorWindow
+    {
+        static int interval;
+
+        static UniTaskTrackerWindow window;
+
+        [MenuItem("Window/UniTask Tracker")]
+        public static void OpenWindow()
+        {
+            if (window != null)
+            {
+                window.Close();
+            }
+
+            // will called OnEnable(singleton instance will be set).
+            GetWindow<UniTaskTrackerWindow>("UniTask Tracker").Show();
+        }
+
+        static readonly GUILayoutOption[] EmptyLayoutOption = new GUILayoutOption[0];
+
+        UniTaskTrackerTreeView treeView;
+        object splitterState;
+
+        void OnEnable()
+        {
+            window = this; // set singleton.
+            splitterState = SplitterGUILayout.CreateSplitterState(new float[] { 75f, 25f }, new int[] { 32, 32 }, null);
+            treeView = new UniTaskTrackerTreeView();
+            TaskTracker.EditorEnableState.EnableAutoReload = EditorPrefs.GetBool(TaskTracker.EnableAutoReloadKey, false);
+            TaskTracker.EditorEnableState.EnableTracking = EditorPrefs.GetBool(TaskTracker.EnableTrackingKey, false);
+            TaskTracker.EditorEnableState.EnableStackTrace = EditorPrefs.GetBool(TaskTracker.EnableStackTraceKey, false);
+        }
+
+        void OnGUI()
+        {
+            // Head
+            RenderHeadPanel();
+
+            // Splittable
+            SplitterGUILayout.BeginVerticalSplit(this.splitterState, EmptyLayoutOption);
+            {
+                // Column Tabble
+                RenderTable();
+
+                // StackTrace details
+                RenderDetailsPanel();
+            }
+            SplitterGUILayout.EndVerticalSplit();
+        }
+
+        #region HeadPanel
+
+        public static bool EnableAutoReload => TaskTracker.EditorEnableState.EnableAutoReload;
+        public static bool EnableTracking => TaskTracker.EditorEnableState.EnableTracking;
+        public static bool EnableStackTrace => TaskTracker.EditorEnableState.EnableStackTrace;
+        static readonly GUIContent EnableAutoReloadHeadContent = EditorGUIUtility.TrTextContent("Enable AutoReload", "Reload automatically.", (Texture)null);
+        static readonly GUIContent ReloadHeadContent = EditorGUIUtility.TrTextContent("Reload", "Reload View.", (Texture)null);
+        static readonly GUIContent GCHeadContent = EditorGUIUtility.TrTextContent("GC.Collect", "Invoke GC.Collect.", (Texture)null);
+        static readonly GUIContent EnableTrackingHeadContent = EditorGUIUtility.TrTextContent("Enable Tracking", "Start to track async/await UniTask. Performance impact: low", (Texture)null);
+        static readonly GUIContent EnableStackTraceHeadContent = EditorGUIUtility.TrTextContent("Enable StackTrace", "Capture StackTrace when task is started. Performance impact: high", (Texture)null);
+
+        // [Enable Tracking] | [Enable StackTrace]
+        void RenderHeadPanel()
+        {
+            EditorGUILayout.BeginVertical(EmptyLayoutOption);
+            EditorGUILayout.BeginHorizontal(EditorStyles.toolbar, EmptyLayoutOption);
+
+            if (GUILayout.Toggle(EnableAutoReload, EnableAutoReloadHeadContent, EditorStyles.toolbarButton, EmptyLayoutOption) != EnableAutoReload)
+            {
+                TaskTracker.EditorEnableState.EnableAutoReload = !EnableAutoReload;
+            }
+
+            if (GUILayout.Toggle(EnableTracking, EnableTrackingHeadContent, EditorStyles.toolbarButton, EmptyLayoutOption) != EnableTracking)
+            {
+                TaskTracker.EditorEnableState.EnableTracking = !EnableTracking;
+            }
+
+            if (GUILayout.Toggle(EnableStackTrace, EnableStackTraceHeadContent, EditorStyles.toolbarButton, EmptyLayoutOption) != EnableStackTrace)
+            {
+                TaskTracker.EditorEnableState.EnableStackTrace = !EnableStackTrace;
+            }
+
+            GUILayout.FlexibleSpace();
+
+            if (GUILayout.Button(ReloadHeadContent, EditorStyles.toolbarButton, EmptyLayoutOption))
+            {
+                TaskTracker.CheckAndResetDirty();
+                treeView.ReloadAndSort();
+                Repaint();
+            }
+
+            if (GUILayout.Button(GCHeadContent, EditorStyles.toolbarButton, EmptyLayoutOption))
+            {
+                GC.Collect(0);
+            }
+
+            EditorGUILayout.EndHorizontal();
+            EditorGUILayout.EndVertical();
+        }
+
+        #endregion
+
+        #region TableColumn
+
+        Vector2 tableScroll;
+        GUIStyle tableListStyle;
+
+        void RenderTable()
+        {
+            if (tableListStyle == null)
+            {
+                tableListStyle = new GUIStyle("CN Box");
+                tableListStyle.margin.top = 0;
+                tableListStyle.padding.left = 3;
+            }
+
+            EditorGUILayout.BeginVertical(tableListStyle, EmptyLayoutOption);
+
+            this.tableScroll = EditorGUILayout.BeginScrollView(this.tableScroll, new GUILayoutOption[]
+            {
+                GUILayout.ExpandWidth(true),
+                GUILayout.MaxWidth(2000f)
+            });
+            var controlRect = EditorGUILayout.GetControlRect(new GUILayoutOption[]
+            {
+                GUILayout.ExpandHeight(true),
+                GUILayout.ExpandWidth(true)
+            });
+
+
+            treeView?.OnGUI(controlRect);
+
+            EditorGUILayout.EndScrollView();
+            EditorGUILayout.EndVertical();
+        }
+
+        private void Update()
+        {
+            if (EnableAutoReload)
+            {
+                if (interval++ % 120 == 0)
+                {
+                    if (TaskTracker.CheckAndResetDirty())
+                    {
+                        treeView.ReloadAndSort();
+                        Repaint();
+                    }
+                }
+            }
+        }
+
+        #endregion
+
+        #region Details
+
+        static GUIStyle detailsStyle;
+        Vector2 detailsScroll;
+
+        void RenderDetailsPanel()
+        {
+            if (detailsStyle == null)
+            {
+                detailsStyle = new GUIStyle("CN Message");
+                detailsStyle.wordWrap = false;
+                detailsStyle.stretchHeight = true;
+                detailsStyle.margin.right = 15;
+            }
+
+            string message = "";
+            var selected = treeView.state.selectedIDs;
+            if (selected.Count > 0)
+            {
+                var first = selected[0];
+                var item = treeView.CurrentBindingItems.FirstOrDefault(x => x.id == first) as UniTaskTrackerViewItem;
+                if (item != null)
+                {
+                    message = item.Position;
+                }
+            }
+
+            detailsScroll = EditorGUILayout.BeginScrollView(this.detailsScroll, EmptyLayoutOption);
+            var vector = detailsStyle.CalcSize(new GUIContent(message));
+            EditorGUILayout.SelectableLabel(message, detailsStyle, new GUILayoutOption[]
+            {
+                GUILayout.ExpandHeight(true),
+                GUILayout.ExpandWidth(true),
+                GUILayout.MinWidth(vector.x),
+                GUILayout.MinHeight(vector.y)
+            });
+            EditorGUILayout.EndScrollView();
+        }
+
+        #endregion
+    }
+}
+

--- a/Cauldron/Assets/Plugins/UniTask/Editor/UniTaskTrackerWindow.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Editor/UniTaskTrackerWindow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5bee3e3860e37484aa3b861bf76d129f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 66e4b90cb04523847946dbd353478c48
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/AsyncLazy.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/AsyncLazy.cs
@@ -1,0 +1,245 @@
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks
+{
+    public class AsyncLazy
+    {
+        static Action<object> continuation = SetCompletionSource;
+
+        Func<UniTask> taskFactory;
+        UniTaskCompletionSource completionSource;
+        UniTask.Awaiter awaiter;
+
+        object syncLock;
+        bool initialized;
+
+        public AsyncLazy(Func<UniTask> taskFactory)
+        {
+            this.taskFactory = taskFactory;
+            this.completionSource = new UniTaskCompletionSource();
+            this.syncLock = new object();
+            this.initialized = false;
+        }
+
+        internal AsyncLazy(UniTask task)
+        {
+            this.taskFactory = null;
+            this.completionSource = new UniTaskCompletionSource();
+            this.syncLock = null;
+            this.initialized = true;
+
+            var awaiter = task.GetAwaiter();
+            if (awaiter.IsCompleted)
+            {
+                SetCompletionSource(awaiter);
+            }
+            else
+            {
+                this.awaiter = awaiter;
+                awaiter.SourceOnCompleted(continuation, this);
+            }
+        }
+
+        public UniTask Task
+        {
+            get
+            {
+                EnsureInitialized();
+                return completionSource.Task;
+            }
+        }
+
+
+        public UniTask.Awaiter GetAwaiter() => Task.GetAwaiter();
+
+        void EnsureInitialized()
+        {
+            if (Volatile.Read(ref initialized))
+            {
+                return;
+            }
+
+            EnsureInitializedCore();
+        }
+
+        void EnsureInitializedCore()
+        {
+            lock (syncLock)
+            {
+                if (!Volatile.Read(ref initialized))
+                {
+                    var f = Interlocked.Exchange(ref taskFactory, null);
+                    if (f != null)
+                    {
+                        var task = f();
+                        var awaiter = task.GetAwaiter();
+                        if (awaiter.IsCompleted)
+                        {
+                            SetCompletionSource(awaiter);
+                        }
+                        else
+                        {
+                            this.awaiter = awaiter;
+                            awaiter.SourceOnCompleted(continuation, this);
+                        }
+
+                        Volatile.Write(ref initialized, true);
+                    }
+                }
+            }
+        }
+
+        void SetCompletionSource(in UniTask.Awaiter awaiter)
+        {
+            try
+            {
+                awaiter.GetResult();
+                completionSource.TrySetResult();
+            }
+            catch (Exception ex)
+            {
+                completionSource.TrySetException(ex);
+            }
+        }
+
+        static void SetCompletionSource(object state)
+        {
+            var self = (AsyncLazy)state;
+            try
+            {
+                self.awaiter.GetResult();
+                self.completionSource.TrySetResult();
+            }
+            catch (Exception ex)
+            {
+                self.completionSource.TrySetException(ex);
+            }
+            finally
+            {
+                self.awaiter = default;
+            }
+        }
+    }
+
+    public class AsyncLazy<T>
+    {
+        static Action<object> continuation = SetCompletionSource;
+
+        Func<UniTask<T>> taskFactory;
+        UniTaskCompletionSource<T> completionSource;
+        UniTask<T>.Awaiter awaiter;
+
+        object syncLock;
+        bool initialized;
+
+        public AsyncLazy(Func<UniTask<T>> taskFactory)
+        {
+            this.taskFactory = taskFactory;
+            this.completionSource = new UniTaskCompletionSource<T>();
+            this.syncLock = new object();
+            this.initialized = false;
+        }
+
+        internal AsyncLazy(UniTask<T> task)
+        {
+            this.taskFactory = null;
+            this.completionSource = new UniTaskCompletionSource<T>();
+            this.syncLock = null;
+            this.initialized = true;
+
+            var awaiter = task.GetAwaiter();
+            if (awaiter.IsCompleted)
+            {
+                SetCompletionSource(awaiter);
+            }
+            else
+            {
+                this.awaiter = awaiter;
+                awaiter.SourceOnCompleted(continuation, this);
+            }
+        }
+
+        public UniTask<T> Task
+        {
+            get
+            {
+                EnsureInitialized();
+                return completionSource.Task;
+            }
+        }
+
+
+        public UniTask<T>.Awaiter GetAwaiter() => Task.GetAwaiter();
+
+        void EnsureInitialized()
+        {
+            if (Volatile.Read(ref initialized))
+            {
+                return;
+            }
+
+            EnsureInitializedCore();
+        }
+
+        void EnsureInitializedCore()
+        {
+            lock (syncLock)
+            {
+                if (!Volatile.Read(ref initialized))
+                {
+                    var f = Interlocked.Exchange(ref taskFactory, null);
+                    if (f != null)
+                    {
+                        var task = f();
+                        var awaiter = task.GetAwaiter();
+                        if (awaiter.IsCompleted)
+                        {
+                            SetCompletionSource(awaiter);
+                        }
+                        else
+                        {
+                            this.awaiter = awaiter;
+                            awaiter.SourceOnCompleted(continuation, this);
+                        }
+
+                        Volatile.Write(ref initialized, true);
+                    }
+                }
+            }
+        }
+
+        void SetCompletionSource(in UniTask<T>.Awaiter awaiter)
+        {
+            try
+            {
+                var result = awaiter.GetResult();
+                completionSource.TrySetResult(result);
+            }
+            catch (Exception ex)
+            {
+                completionSource.TrySetException(ex);
+            }
+        }
+
+        static void SetCompletionSource(object state)
+        {
+            var self = (AsyncLazy<T>)state;
+            try
+            {
+                var result = self.awaiter.GetResult();
+                self.completionSource.TrySetResult(result);
+            }
+            catch (Exception ex)
+            {
+                self.completionSource.TrySetException(ex);
+            }
+            finally
+            {
+                self.awaiter = default;
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/AsyncLazy.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/AsyncLazy.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 01d1404ca421466419a7db7340ff5e77
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/AsyncReactiveProperty.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/AsyncReactiveProperty.cs
@@ -1,0 +1,644 @@
+﻿using System;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks
+{
+    public interface IReadOnlyAsyncReactiveProperty<T> : IUniTaskAsyncEnumerable<T>
+    {
+        T Value { get; }
+        IUniTaskAsyncEnumerable<T> WithoutCurrent();
+        UniTask<T> WaitAsync(CancellationToken cancellationToken = default);
+    }
+
+    public interface IAsyncReactiveProperty<T> : IReadOnlyAsyncReactiveProperty<T>
+    {
+        new T Value { get; set; }
+    }
+
+    [Serializable]
+    public class AsyncReactiveProperty<T> : IAsyncReactiveProperty<T>, IDisposable
+    {
+        TriggerEvent<T> triggerEvent;
+
+#if UNITY_2018_3_OR_NEWER
+        [UnityEngine.SerializeField]
+#endif
+        T latestValue;
+
+        public T Value
+        {
+            get
+            {
+                return latestValue;
+            }
+            set
+            {
+                this.latestValue = value;
+                triggerEvent.SetResult(value);
+            }
+        }
+
+        public AsyncReactiveProperty(T value)
+        {
+            this.latestValue = value;
+            this.triggerEvent = default;
+        }
+
+        public IUniTaskAsyncEnumerable<T> WithoutCurrent()
+        {
+            return new WithoutCurrentEnumerable(this);
+        }
+
+        public IUniTaskAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken)
+        {
+            return new Enumerator(this, cancellationToken, true);
+        }
+
+        public void Dispose()
+        {
+            triggerEvent.SetCompleted();
+        }
+
+        public static implicit operator T(AsyncReactiveProperty<T> value)
+        {
+            return value.Value;
+        }
+
+        public override string ToString()
+        {
+            if (isValueType) return latestValue.ToString();
+            return latestValue?.ToString();
+        }
+
+        public UniTask<T> WaitAsync(CancellationToken cancellationToken = default)
+        {
+            return new UniTask<T>(WaitAsyncSource.Create(this, cancellationToken, out var token), token);
+        }
+
+        static bool isValueType;
+
+        static AsyncReactiveProperty()
+        {
+            isValueType = typeof(T).IsValueType;
+        }
+
+        sealed class WaitAsyncSource : IUniTaskSource<T>, ITriggerHandler<T>, ITaskPoolNode<WaitAsyncSource>
+        {
+            static Action<object> cancellationCallback = CancellationCallback;
+
+            static TaskPool<WaitAsyncSource> pool;
+            WaitAsyncSource nextNode;
+            ref WaitAsyncSource ITaskPoolNode<WaitAsyncSource>.NextNode => ref nextNode;
+
+            static WaitAsyncSource()
+            {
+                TaskPool.RegisterSizeGetter(typeof(WaitAsyncSource), () => pool.Size);
+            }
+
+            AsyncReactiveProperty<T> parent;
+            CancellationToken cancellationToken;
+            CancellationTokenRegistration cancellationTokenRegistration;
+            UniTaskCompletionSourceCore<T> core;
+
+            WaitAsyncSource()
+            {
+            }
+
+            public static IUniTaskSource<T> Create(AsyncReactiveProperty<T> parent, CancellationToken cancellationToken, out short token)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return AutoResetUniTaskCompletionSource<T>.CreateFromCanceled(cancellationToken, out token);
+                }
+
+                if (!pool.TryPop(out var result))
+                {
+                    result = new WaitAsyncSource();
+                }
+
+                result.parent = parent;
+                result.cancellationToken = cancellationToken;
+
+                if (cancellationToken.CanBeCanceled)
+                {
+                    result.cancellationTokenRegistration = cancellationToken.RegisterWithoutCaptureExecutionContext(cancellationCallback, result);
+                }
+
+                result.parent.triggerEvent.Add(result);
+
+                TaskTracker.TrackActiveTask(result, 3);
+
+                token = result.core.Version;
+                return result;
+            }
+
+            bool TryReturn()
+            {
+                TaskTracker.RemoveTracking(this);
+                core.Reset();
+                cancellationTokenRegistration.Dispose();
+                cancellationTokenRegistration = default;
+                parent.triggerEvent.Remove(this);
+                parent = null;
+                cancellationToken = default;
+                return pool.TryPush(this);
+            }
+
+            static void CancellationCallback(object state)
+            {
+                var self = (WaitAsyncSource)state;
+                self.OnCanceled(self.cancellationToken);
+            }
+
+            // IUniTaskSource
+
+            public T GetResult(short token)
+            {
+                try
+                {
+                    return core.GetResult(token);
+                }
+                finally
+                {
+                    TryReturn();
+                }
+            }
+
+            void IUniTaskSource.GetResult(short token)
+            {
+                GetResult(token);
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            // ITriggerHandler
+
+            ITriggerHandler<T> ITriggerHandler<T>.Prev { get; set; }
+            ITriggerHandler<T> ITriggerHandler<T>.Next { get; set; }
+
+            public void OnCanceled(CancellationToken cancellationToken)
+            {
+                core.TrySetCanceled(cancellationToken);
+            }
+
+            public void OnCompleted()
+            {
+                // Complete as Cancel.
+                core.TrySetCanceled(CancellationToken.None);
+            }
+
+            public void OnError(Exception ex)
+            {
+                core.TrySetException(ex);
+            }
+
+            public void OnNext(T value)
+            {
+                core.TrySetResult(value);
+            }
+        }
+
+        sealed class WithoutCurrentEnumerable : IUniTaskAsyncEnumerable<T>
+        {
+            readonly AsyncReactiveProperty<T> parent;
+
+            public WithoutCurrentEnumerable(AsyncReactiveProperty<T> parent)
+            {
+                this.parent = parent;
+            }
+
+            public IUniTaskAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+            {
+                return new Enumerator(parent, cancellationToken, false);
+            }
+        }
+
+        sealed class Enumerator : MoveNextSource, IUniTaskAsyncEnumerator<T>, ITriggerHandler<T>
+        {
+            static Action<object> cancellationCallback = CancellationCallback;
+
+            readonly AsyncReactiveProperty<T> parent;
+            readonly CancellationToken cancellationToken;
+            readonly CancellationTokenRegistration cancellationTokenRegistration;
+            T value;
+            bool isDisposed;
+            bool firstCall;
+
+            public Enumerator(AsyncReactiveProperty<T> parent, CancellationToken cancellationToken, bool publishCurrentValue)
+            {
+                this.parent = parent;
+                this.cancellationToken = cancellationToken;
+                this.firstCall = publishCurrentValue;
+
+                parent.triggerEvent.Add(this);
+                TaskTracker.TrackActiveTask(this, 3);
+
+                if (cancellationToken.CanBeCanceled)
+                {
+                    cancellationTokenRegistration = cancellationToken.RegisterWithoutCaptureExecutionContext(cancellationCallback, this);
+                }
+            }
+
+            public T Current => value;
+
+            ITriggerHandler<T> ITriggerHandler<T>.Prev { get; set; }
+            ITriggerHandler<T> ITriggerHandler<T>.Next { get; set; }
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                // raise latest value on first call.
+                if (firstCall)
+                {
+                    firstCall = false;
+                    value = parent.Value;
+                    return CompletedTasks.True;
+                }
+
+                completionSource.Reset();
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            public UniTask DisposeAsync()
+            {
+                if (!isDisposed)
+                {
+                    isDisposed = true;
+                    TaskTracker.RemoveTracking(this);
+                    completionSource.TrySetCanceled(cancellationToken);
+                    parent.triggerEvent.Remove(this);
+                }
+                return default;
+            }
+
+            public void OnNext(T value)
+            {
+                this.value = value;
+                completionSource.TrySetResult(true);
+            }
+
+            public void OnCanceled(CancellationToken cancellationToken)
+            {
+                DisposeAsync().Forget();
+            }
+
+            public void OnCompleted()
+            {
+                completionSource.TrySetResult(false);
+            }
+
+            public void OnError(Exception ex)
+            {
+                completionSource.TrySetException(ex);
+            }
+
+            static void CancellationCallback(object state)
+            {
+                var self = (Enumerator)state;
+                self.DisposeAsync().Forget();
+            }
+        }
+    }
+
+    public class ReadOnlyAsyncReactiveProperty<T> : IReadOnlyAsyncReactiveProperty<T>, IDisposable
+    {
+        TriggerEvent<T> triggerEvent;
+
+        T latestValue;
+        IUniTaskAsyncEnumerator<T> enumerator;
+
+        public T Value
+        {
+            get
+            {
+                return latestValue;
+            }
+        }
+
+        public ReadOnlyAsyncReactiveProperty(T initialValue, IUniTaskAsyncEnumerable<T> source, CancellationToken cancellationToken)
+        {
+            latestValue = initialValue;
+            ConsumeEnumerator(source, cancellationToken).Forget();
+        }
+
+        public ReadOnlyAsyncReactiveProperty(IUniTaskAsyncEnumerable<T> source, CancellationToken cancellationToken)
+        {
+            ConsumeEnumerator(source, cancellationToken).Forget();
+        }
+
+        async UniTaskVoid ConsumeEnumerator(IUniTaskAsyncEnumerable<T> source, CancellationToken cancellationToken)
+        {
+            enumerator = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await enumerator.MoveNextAsync())
+                {
+                    var value = enumerator.Current;
+                    this.latestValue = value;
+                    triggerEvent.SetResult(value);
+                }
+            }
+            finally
+            {
+                await enumerator.DisposeAsync();
+                enumerator = null;
+            }
+        }
+
+        public IUniTaskAsyncEnumerable<T> WithoutCurrent()
+        {
+            return new WithoutCurrentEnumerable(this);
+        }
+
+        public IUniTaskAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken)
+        {
+            return new Enumerator(this, cancellationToken, true);
+        }
+
+        public void Dispose()
+        {
+            if (enumerator != null)
+            {
+                enumerator.DisposeAsync().Forget();
+            }
+
+            triggerEvent.SetCompleted();
+        }
+
+        public static implicit operator T(ReadOnlyAsyncReactiveProperty<T> value)
+        {
+            return value.Value;
+        }
+
+        public override string ToString()
+        {
+            if (isValueType) return latestValue.ToString();
+            return latestValue?.ToString();
+        }
+
+        public UniTask<T> WaitAsync(CancellationToken cancellationToken = default)
+        {
+            return new UniTask<T>(WaitAsyncSource.Create(this, cancellationToken, out var token), token);
+        }
+
+        static bool isValueType;
+
+        static ReadOnlyAsyncReactiveProperty()
+        {
+            isValueType = typeof(T).IsValueType;
+        }
+
+        sealed class WaitAsyncSource : IUniTaskSource<T>, ITriggerHandler<T>, ITaskPoolNode<WaitAsyncSource>
+        {
+            static Action<object> cancellationCallback = CancellationCallback;
+
+            static TaskPool<WaitAsyncSource> pool;
+            WaitAsyncSource nextNode;
+            ref WaitAsyncSource ITaskPoolNode<WaitAsyncSource>.NextNode => ref nextNode;
+
+            static WaitAsyncSource()
+            {
+                TaskPool.RegisterSizeGetter(typeof(WaitAsyncSource), () => pool.Size);
+            }
+
+            ReadOnlyAsyncReactiveProperty<T> parent;
+            CancellationToken cancellationToken;
+            CancellationTokenRegistration cancellationTokenRegistration;
+            UniTaskCompletionSourceCore<T> core;
+
+            WaitAsyncSource()
+            {
+            }
+
+            public static IUniTaskSource<T> Create(ReadOnlyAsyncReactiveProperty<T> parent, CancellationToken cancellationToken, out short token)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return AutoResetUniTaskCompletionSource<T>.CreateFromCanceled(cancellationToken, out token);
+                }
+
+                if (!pool.TryPop(out var result))
+                {
+                    result = new WaitAsyncSource();
+                }
+
+                result.parent = parent;
+                result.cancellationToken = cancellationToken;
+
+                if (cancellationToken.CanBeCanceled)
+                {
+                    result.cancellationTokenRegistration = cancellationToken.RegisterWithoutCaptureExecutionContext(cancellationCallback, result);
+                }
+
+                result.parent.triggerEvent.Add(result);
+
+                TaskTracker.TrackActiveTask(result, 3);
+
+                token = result.core.Version;
+                return result;
+            }
+
+            bool TryReturn()
+            {
+                TaskTracker.RemoveTracking(this);
+                core.Reset();
+                cancellationTokenRegistration.Dispose();
+                cancellationTokenRegistration = default;
+                parent.triggerEvent.Remove(this);
+                parent = null;
+                cancellationToken = default;
+                return pool.TryPush(this);
+            }
+
+            static void CancellationCallback(object state)
+            {
+                var self = (WaitAsyncSource)state;
+                self.OnCanceled(self.cancellationToken);
+            }
+
+            // IUniTaskSource
+
+            public T GetResult(short token)
+            {
+                try
+                {
+                    return core.GetResult(token);
+                }
+                finally
+                {
+                    TryReturn();
+                }
+            }
+
+            void IUniTaskSource.GetResult(short token)
+            {
+                GetResult(token);
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            // ITriggerHandler
+
+            ITriggerHandler<T> ITriggerHandler<T>.Prev { get; set; }
+            ITriggerHandler<T> ITriggerHandler<T>.Next { get; set; }
+
+            public void OnCanceled(CancellationToken cancellationToken)
+            {
+                core.TrySetCanceled(cancellationToken);
+            }
+
+            public void OnCompleted()
+            {
+                // Complete as Cancel.
+                core.TrySetCanceled(CancellationToken.None);
+            }
+
+            public void OnError(Exception ex)
+            {
+                core.TrySetException(ex);
+            }
+
+            public void OnNext(T value)
+            {
+                core.TrySetResult(value);
+            }
+        }
+
+        sealed class WithoutCurrentEnumerable : IUniTaskAsyncEnumerable<T>
+        {
+            readonly ReadOnlyAsyncReactiveProperty<T> parent;
+
+            public WithoutCurrentEnumerable(ReadOnlyAsyncReactiveProperty<T> parent)
+            {
+                this.parent = parent;
+            }
+
+            public IUniTaskAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+            {
+                return new Enumerator(parent, cancellationToken, false);
+            }
+        }
+
+        sealed class Enumerator : MoveNextSource, IUniTaskAsyncEnumerator<T>, ITriggerHandler<T>
+        {
+            static Action<object> cancellationCallback = CancellationCallback;
+
+            readonly ReadOnlyAsyncReactiveProperty<T> parent;
+            readonly CancellationToken cancellationToken;
+            readonly CancellationTokenRegistration cancellationTokenRegistration;
+            T value;
+            bool isDisposed;
+            bool firstCall;
+
+            public Enumerator(ReadOnlyAsyncReactiveProperty<T> parent, CancellationToken cancellationToken, bool publishCurrentValue)
+            {
+                this.parent = parent;
+                this.cancellationToken = cancellationToken;
+                this.firstCall = publishCurrentValue;
+
+                parent.triggerEvent.Add(this);
+                TaskTracker.TrackActiveTask(this, 3);
+
+                if (cancellationToken.CanBeCanceled)
+                {
+                    cancellationTokenRegistration = cancellationToken.RegisterWithoutCaptureExecutionContext(cancellationCallback, this);
+                }
+            }
+
+            public T Current => value;
+            ITriggerHandler<T> ITriggerHandler<T>.Prev { get; set; }
+            ITriggerHandler<T> ITriggerHandler<T>.Next { get; set; }
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                // raise latest value on first call.
+                if (firstCall)
+                {
+                    firstCall = false;
+                    value = parent.Value;
+                    return CompletedTasks.True;
+                }
+
+                completionSource.Reset();
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            public UniTask DisposeAsync()
+            {
+                if (!isDisposed)
+                {
+                    isDisposed = true;
+                    TaskTracker.RemoveTracking(this);
+                    completionSource.TrySetCanceled(cancellationToken);
+                    parent.triggerEvent.Remove(this);
+                }
+                return default;
+            }
+
+            public void OnNext(T value)
+            {
+                this.value = value;
+                completionSource.TrySetResult(true);
+            }
+
+            public void OnCanceled(CancellationToken cancellationToken)
+            {
+                DisposeAsync().Forget();
+            }
+
+            public void OnCompleted()
+            {
+                completionSource.TrySetResult(false);
+            }
+
+            public void OnError(Exception ex)
+            {
+                completionSource.TrySetException(ex);
+            }
+
+            static void CancellationCallback(object state)
+            {
+                var self = (Enumerator)state;
+                self.DisposeAsync().Forget();
+            }
+        }
+    }
+
+    public static class StateExtensions
+    {
+        public static ReadOnlyAsyncReactiveProperty<T> ToReadOnlyAsyncReactiveProperty<T>(this IUniTaskAsyncEnumerable<T> source, CancellationToken cancellationToken)
+        {
+            return new ReadOnlyAsyncReactiveProperty<T>(source, cancellationToken);
+        }
+
+        public static ReadOnlyAsyncReactiveProperty<T> ToReadOnlyAsyncReactiveProperty<T>(this IUniTaskAsyncEnumerable<T> source, T initialValue, CancellationToken cancellationToken)
+        {
+            return new ReadOnlyAsyncReactiveProperty<T>(initialValue, source, cancellationToken);
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/AsyncReactiveProperty.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/AsyncReactiveProperty.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8ef320b87f537ee4fb2282e765dc6166
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/AsyncUnit.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/AsyncUnit.cs
@@ -1,0 +1,26 @@
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or 
+
+using System;
+
+namespace Cysharp.Threading.Tasks
+{
+    public readonly struct AsyncUnit : IEquatable<AsyncUnit>
+    {
+        public static readonly AsyncUnit Default = new AsyncUnit();
+
+        public override int GetHashCode()
+        {
+            return 0;
+        }
+
+        public bool Equals(AsyncUnit other)
+        {
+            return true;
+        }
+
+        public override string ToString()
+        {
+            return "()";
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/AsyncUnit.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/AsyncUnit.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4f95ac245430d304bb5128d13b6becc8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/CancellationTokenEqualityComparer.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/CancellationTokenEqualityComparer.cs
@@ -1,0 +1,23 @@
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks
+{
+    public class CancellationTokenEqualityComparer : IEqualityComparer<CancellationToken>
+    {
+        public static readonly IEqualityComparer<CancellationToken> Default = new CancellationTokenEqualityComparer();
+
+        public bool Equals(CancellationToken x, CancellationToken y)
+        {
+            return x.Equals(y);
+        }
+
+        public int GetHashCode(CancellationToken obj)
+        {
+            return obj.GetHashCode();
+        }
+    }
+}
+

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/CancellationTokenEqualityComparer.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/CancellationTokenEqualityComparer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7d739f510b125b74fa7290ac4335e46e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/CancellationTokenExtensions.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/CancellationTokenExtensions.cs
@@ -1,0 +1,182 @@
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks
+{
+    public static class CancellationTokenExtensions
+    {
+        static readonly Action<object> cancellationTokenCallback = Callback;
+        static readonly Action<object> disposeCallback = DisposeCallback;
+
+        public static CancellationToken ToCancellationToken(this UniTask task)
+        {
+            var cts = new CancellationTokenSource();
+            ToCancellationTokenCore(task, cts).Forget();
+            return cts.Token;
+        }
+
+        public static CancellationToken ToCancellationToken(this UniTask task, CancellationToken linkToken)
+        {
+            if (linkToken.IsCancellationRequested)
+            {
+                return linkToken;
+            }
+
+            if (!linkToken.CanBeCanceled)
+            {
+                return ToCancellationToken(task);
+            }
+
+            var cts = CancellationTokenSource.CreateLinkedTokenSource(linkToken);
+            ToCancellationTokenCore(task, cts).Forget();
+
+            return cts.Token;
+        }
+
+        public static CancellationToken ToCancellationToken<T>(this UniTask<T> task)
+        {
+            return ToCancellationToken(task.AsUniTask());
+        }
+
+        public static CancellationToken ToCancellationToken<T>(this UniTask<T> task, CancellationToken linkToken)
+        {
+            return ToCancellationToken(task.AsUniTask(), linkToken);
+        }
+
+        static async UniTaskVoid ToCancellationTokenCore(UniTask task, CancellationTokenSource cts)
+        {
+            try
+            {
+                await task;
+            }
+            catch (Exception ex)
+            {
+                UniTaskScheduler.PublishUnobservedTaskException(ex);
+            }
+            cts.Cancel();
+            cts.Dispose();
+        }
+
+        public static (UniTask, CancellationTokenRegistration) ToUniTask(this CancellationToken cancellationToken)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return (UniTask.FromCanceled(cancellationToken), default(CancellationTokenRegistration));
+            }
+
+            var promise = new UniTaskCompletionSource();
+            return (promise.Task, cancellationToken.RegisterWithoutCaptureExecutionContext(cancellationTokenCallback, promise));
+        }
+
+        static void Callback(object state)
+        {
+            var promise = (UniTaskCompletionSource)state;
+            promise.TrySetResult();
+        }
+
+        public static CancellationTokenAwaitable WaitUntilCanceled(this CancellationToken cancellationToken)
+        {
+            return new CancellationTokenAwaitable(cancellationToken);
+        }
+
+        public static CancellationTokenRegistration RegisterWithoutCaptureExecutionContext(this CancellationToken cancellationToken, Action callback)
+        {
+            var restoreFlow = false;
+            if (!ExecutionContext.IsFlowSuppressed())
+            {
+                ExecutionContext.SuppressFlow();
+                restoreFlow = true;
+            }
+
+            try
+            {
+                return cancellationToken.Register(callback, false);
+            }
+            finally
+            {
+                if (restoreFlow)
+                {
+                    ExecutionContext.RestoreFlow();
+                }
+            }
+        }
+
+        public static CancellationTokenRegistration RegisterWithoutCaptureExecutionContext(this CancellationToken cancellationToken, Action<object> callback, object state)
+        {
+            var restoreFlow = false;
+            if (!ExecutionContext.IsFlowSuppressed())
+            {
+                ExecutionContext.SuppressFlow();
+                restoreFlow = true;
+            }
+
+            try
+            {
+                return cancellationToken.Register(callback, state, false);
+            }
+            finally
+            {
+                if (restoreFlow)
+                {
+                    ExecutionContext.RestoreFlow();
+                }
+            }
+        }
+
+        public static CancellationTokenRegistration AddTo(this IDisposable disposable, CancellationToken cancellationToken)
+        {
+            return cancellationToken.RegisterWithoutCaptureExecutionContext(disposeCallback, disposable);
+        }
+
+        static void DisposeCallback(object state)
+        {
+            var d = (IDisposable)state;
+            d.Dispose();
+        }
+    }
+
+    public struct CancellationTokenAwaitable
+    {
+        CancellationToken cancellationToken;
+
+        public CancellationTokenAwaitable(CancellationToken cancellationToken)
+        {
+            this.cancellationToken = cancellationToken;
+        }
+
+        public Awaiter GetAwaiter()
+        {
+            return new Awaiter(cancellationToken);
+        }
+
+        public struct Awaiter : ICriticalNotifyCompletion
+        {
+            CancellationToken cancellationToken;
+
+            public Awaiter(CancellationToken cancellationToken)
+            {
+                this.cancellationToken = cancellationToken;
+            }
+
+            public bool IsCompleted => !cancellationToken.CanBeCanceled || cancellationToken.IsCancellationRequested;
+
+            public void GetResult()
+            {
+            }
+
+            public void OnCompleted(Action continuation)
+            {
+                UnsafeOnCompleted(continuation);
+            }
+
+            public void UnsafeOnCompleted(Action continuation)
+            {
+                cancellationToken.RegisterWithoutCaptureExecutionContext(continuation);
+            }
+        }
+    }
+}
+

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/CancellationTokenExtensions.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/CancellationTokenExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4be7209f04146bd45ac5ee775a5f7c26
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/CancellationTokenSourceExtensions.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/CancellationTokenSourceExtensions.cs
@@ -1,0 +1,44 @@
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System.Threading;
+using UnityEngine;
+using Cysharp.Threading.Tasks.Triggers;
+using System;
+using Cysharp.Threading.Tasks.Internal;
+
+namespace Cysharp.Threading.Tasks
+{
+
+    public static partial class CancellationTokenSourceExtensions
+    {
+        readonly static Action<object> CancelCancellationTokenSourceStateDelegate = new Action<object>(CancelCancellationTokenSourceState);
+
+        static void CancelCancellationTokenSourceState(object state)
+        {
+            var cts = (CancellationTokenSource)state;
+            cts.Cancel();
+        }
+
+        public static IDisposable CancelAfterSlim(this CancellationTokenSource cts, int millisecondsDelay, DelayType delayType = DelayType.DeltaTime, PlayerLoopTiming delayTiming = PlayerLoopTiming.Update)
+        {
+            return CancelAfterSlim(cts, TimeSpan.FromMilliseconds(millisecondsDelay), delayType, delayTiming);
+        }
+
+        public static IDisposable CancelAfterSlim(this CancellationTokenSource cts, TimeSpan delayTimeSpan, DelayType delayType = DelayType.DeltaTime, PlayerLoopTiming delayTiming = PlayerLoopTiming.Update)
+        {
+            return PlayerLoopTimer.StartNew(delayTimeSpan, false, delayType, delayTiming, cts.Token, CancelCancellationTokenSourceStateDelegate, cts);
+        }
+
+        public static void RegisterRaiseCancelOnDestroy(this CancellationTokenSource cts, Component component)
+        {
+            RegisterRaiseCancelOnDestroy(cts, component.gameObject);
+        }
+
+        public static void RegisterRaiseCancelOnDestroy(this CancellationTokenSource cts, GameObject gameObject)
+        {
+            var trigger = gameObject.GetAsyncDestroyTrigger();
+            trigger.CancellationToken.RegisterWithoutCaptureExecutionContext(CancelCancellationTokenSourceStateDelegate, cts);
+        }
+    }
+}
+

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/CancellationTokenSourceExtensions.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/CancellationTokenSourceExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 22d85d07f1e70ab42a7a4c25bd65e661
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Channel.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Channel.cs
@@ -1,0 +1,450 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks
+{
+    public static class Channel
+    {
+        public static Channel<T> CreateSingleConsumerUnbounded<T>()
+        {
+            return new SingleConsumerUnboundedChannel<T>();
+        }
+    }
+
+    public abstract class Channel<TWrite, TRead>
+    {
+        public ChannelReader<TRead> Reader { get; protected set; }
+        public ChannelWriter<TWrite> Writer { get; protected set; }
+
+        public static implicit operator ChannelReader<TRead>(Channel<TWrite, TRead> channel) => channel.Reader;
+        public static implicit operator ChannelWriter<TWrite>(Channel<TWrite, TRead> channel) => channel.Writer;
+    }
+
+    public abstract class Channel<T> : Channel<T, T>
+    {
+    }
+
+    public abstract class ChannelReader<T>
+    {
+        public abstract bool TryRead(out T item);
+        public abstract UniTask<bool> WaitToReadAsync(CancellationToken cancellationToken = default(CancellationToken));
+
+        public abstract UniTask Completion { get; }
+
+        public virtual UniTask<T> ReadAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (this.TryRead(out var item))
+            {
+                return UniTask.FromResult(item);
+            }
+
+            return ReadAsyncCore(cancellationToken);
+        }
+
+        async UniTask<T> ReadAsyncCore(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (await WaitToReadAsync(cancellationToken))
+            {
+                if (TryRead(out var item))
+                {
+                    return item;
+                }
+            }
+
+            throw new ChannelClosedException();
+        }
+
+        public abstract IUniTaskAsyncEnumerable<T> ReadAllAsync(CancellationToken cancellationToken = default(CancellationToken));
+    }
+
+    public abstract class ChannelWriter<T>
+    {
+        public abstract bool TryWrite(T item);
+        public abstract bool TryComplete(Exception error = null);
+
+        public void Complete(Exception error = null)
+        {
+            if (!TryComplete(error))
+            {
+                throw new ChannelClosedException();
+            }
+        }
+    }
+
+    public partial class ChannelClosedException : InvalidOperationException
+    {
+        public ChannelClosedException() :
+            base("Channel is already closed.")
+        { }
+
+        public ChannelClosedException(string message) : base(message) { }
+
+        public ChannelClosedException(Exception innerException) :
+            base("Channel is already closed", innerException)
+        { }
+
+        public ChannelClosedException(string message, Exception innerException) : base(message, innerException) { }
+    }
+
+    internal class SingleConsumerUnboundedChannel<T> : Channel<T>
+    {
+        readonly Queue<T> items;
+        readonly SingleConsumerUnboundedChannelReader readerSource;
+        UniTaskCompletionSource completedTaskSource;
+        UniTask completedTask;
+
+        Exception completionError;
+        bool closed;
+
+        public SingleConsumerUnboundedChannel()
+        {
+            items = new Queue<T>();
+            Writer = new SingleConsumerUnboundedChannelWriter(this);
+            readerSource = new SingleConsumerUnboundedChannelReader(this);
+            Reader = readerSource;
+        }
+
+        sealed class SingleConsumerUnboundedChannelWriter : ChannelWriter<T>
+        {
+            readonly SingleConsumerUnboundedChannel<T> parent;
+
+            public SingleConsumerUnboundedChannelWriter(SingleConsumerUnboundedChannel<T> parent)
+            {
+                this.parent = parent;
+            }
+
+            public override bool TryWrite(T item)
+            {
+                bool waiting;
+                lock (parent.items)
+                {
+                    if (parent.closed) return false;
+
+                    parent.items.Enqueue(item);
+                    waiting = parent.readerSource.isWaiting;
+                }
+
+                if (waiting)
+                {
+                    parent.readerSource.SingalContinuation();
+                }
+
+                return true;
+            }
+
+            public override bool TryComplete(Exception error = null)
+            {
+                bool waiting;
+                lock (parent.items)
+                {
+                    if (parent.closed) return false;
+                    parent.closed = true;
+                    waiting = parent.readerSource.isWaiting;
+
+                    if (parent.items.Count == 0)
+                    {
+                        if (error == null)
+                        {
+                            if (parent.completedTaskSource != null)
+                            {
+                                parent.completedTaskSource.TrySetResult();
+                            }
+                            else
+                            {
+                                parent.completedTask = UniTask.CompletedTask;
+                            }
+                        }
+                        else
+                        {
+                            if (parent.completedTaskSource != null)
+                            {
+                                parent.completedTaskSource.TrySetException(error);
+                            }
+                            else
+                            {
+                                parent.completedTask = UniTask.FromException(error);
+                            }
+                        }
+
+                        if (waiting)
+                        {
+                            parent.readerSource.SingalCompleted(error);
+                        }
+                    }
+
+                    parent.completionError = error;
+                }
+
+                return true;
+            }
+        }
+
+        sealed class SingleConsumerUnboundedChannelReader : ChannelReader<T>, IUniTaskSource<bool>
+        {
+            readonly Action<object> CancellationCallbackDelegate = CancellationCallback;
+            readonly SingleConsumerUnboundedChannel<T> parent;
+
+            CancellationToken cancellationToken;
+            CancellationTokenRegistration cancellationTokenRegistration;
+            UniTaskCompletionSourceCore<bool> core;
+            internal bool isWaiting;
+
+            public SingleConsumerUnboundedChannelReader(SingleConsumerUnboundedChannel<T> parent)
+            {
+                this.parent = parent;
+
+                TaskTracker.TrackActiveTask(this, 4);
+            }
+
+            public override UniTask Completion
+            {
+                get
+                {
+                    if (parent.completedTaskSource != null) return parent.completedTaskSource.Task;
+
+                    if (parent.closed)
+                    {
+                        return parent.completedTask;
+                    }
+
+                    parent.completedTaskSource = new UniTaskCompletionSource();
+                    return parent.completedTaskSource.Task;
+                }
+            }
+
+            public override bool TryRead(out T item)
+            {
+                lock (parent.items)
+                {
+                    if (parent.items.Count != 0)
+                    {
+                        item = parent.items.Dequeue();
+
+                        // complete when all value was consumed.
+                        if (parent.closed && parent.items.Count == 0)
+                        {
+                            if (parent.completionError != null)
+                            {
+                                if (parent.completedTaskSource != null)
+                                {
+                                    parent.completedTaskSource.TrySetException(parent.completionError);
+                                }
+                                else
+                                {
+                                    parent.completedTask = UniTask.FromException(parent.completionError);
+                                }
+                            }
+                            else
+                            {
+                                if (parent.completedTaskSource != null)
+                                {
+                                    parent.completedTaskSource.TrySetResult();
+                                }
+                                else
+                                {
+                                    parent.completedTask = UniTask.CompletedTask;
+                                }
+                            }
+                        }
+                    }
+                    else
+                    {
+                        item = default;
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+
+            public override UniTask<bool> WaitToReadAsync(CancellationToken cancellationToken)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return UniTask.FromCanceled<bool>(cancellationToken);
+                }
+
+                lock (parent.items)
+                {
+                    if (parent.items.Count != 0)
+                    {
+                        return CompletedTasks.True;
+                    }
+
+                    if (parent.closed)
+                    {
+                        if (parent.completionError == null)
+                        {
+                            return CompletedTasks.False;
+                        }
+                        else
+                        {
+                            return UniTask.FromException<bool>(parent.completionError);
+                        }
+                    }
+
+                    cancellationTokenRegistration.Dispose();
+
+                    core.Reset();
+                    isWaiting = true;
+
+                    this.cancellationToken = cancellationToken;
+                    if (this.cancellationToken.CanBeCanceled)
+                    {
+                        cancellationTokenRegistration = this.cancellationToken.RegisterWithoutCaptureExecutionContext(CancellationCallbackDelegate, this);
+                    }
+
+                    return new UniTask<bool>(this, core.Version);
+                }
+            }
+
+            public void SingalContinuation()
+            {
+                core.TrySetResult(true);
+            }
+
+            public void SingalCancellation(CancellationToken cancellationToken)
+            {
+                TaskTracker.RemoveTracking(this);
+                core.TrySetCanceled(cancellationToken);
+            }
+
+            public void SingalCompleted(Exception error)
+            {
+                if (error != null)
+                {
+                    TaskTracker.RemoveTracking(this);
+                    core.TrySetException(error);
+                }
+                else
+                {
+                    TaskTracker.RemoveTracking(this);
+                    core.TrySetResult(false);
+                }
+            }
+
+            public override IUniTaskAsyncEnumerable<T> ReadAllAsync(CancellationToken cancellationToken = default)
+            {
+                return new ReadAllAsyncEnumerable(this, cancellationToken);
+            }
+
+            bool IUniTaskSource<bool>.GetResult(short token)
+            {
+                return core.GetResult(token);
+            }
+
+            void IUniTaskSource.GetResult(short token)
+            {
+                core.GetResult(token);
+            }
+
+            UniTaskStatus IUniTaskSource.GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            void IUniTaskSource.OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+
+            UniTaskStatus IUniTaskSource.UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            static void CancellationCallback(object state)
+            {
+                var self = (SingleConsumerUnboundedChannelReader)state;
+                self.SingalCancellation(self.cancellationToken);
+            }
+
+            sealed class ReadAllAsyncEnumerable : IUniTaskAsyncEnumerable<T>, IUniTaskAsyncEnumerator<T>
+            {
+                readonly Action<object> CancellationCallback1Delegate = CancellationCallback1;
+                readonly Action<object> CancellationCallback2Delegate = CancellationCallback2;
+
+                readonly SingleConsumerUnboundedChannelReader parent;
+                CancellationToken cancellationToken1;
+                CancellationToken cancellationToken2;
+                CancellationTokenRegistration cancellationTokenRegistration1;
+                CancellationTokenRegistration cancellationTokenRegistration2;
+
+                T current;
+                bool cacheValue;
+                bool running;
+
+                public ReadAllAsyncEnumerable(SingleConsumerUnboundedChannelReader parent, CancellationToken cancellationToken)
+                {
+                    this.parent = parent;
+                    this.cancellationToken1 = cancellationToken;
+                }
+
+                public IUniTaskAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+                {
+                    if (running)
+                    {
+                        throw new InvalidOperationException("Enumerator is already running, does not allow call GetAsyncEnumerator twice.");
+                    }
+
+                    if (this.cancellationToken1 != cancellationToken)
+                    {
+                        this.cancellationToken2 = cancellationToken;
+                    }
+
+                    if (this.cancellationToken1.CanBeCanceled)
+                    {
+                        this.cancellationTokenRegistration1 =  this.cancellationToken1.RegisterWithoutCaptureExecutionContext(CancellationCallback1Delegate, this);
+                    }
+
+                    if (this.cancellationToken2.CanBeCanceled)
+                    {
+                        this.cancellationTokenRegistration2 = this.cancellationToken2.RegisterWithoutCaptureExecutionContext(CancellationCallback2Delegate, this);
+                    }
+
+                    running = true;
+                    return this;
+                }
+
+                public T Current
+                {
+                    get
+                    {
+                        if (cacheValue)
+                        {
+                            return current;
+                        }
+                        parent.TryRead(out current);
+                        return current;
+                    }
+                }
+
+                public UniTask<bool> MoveNextAsync()
+                {
+                    cacheValue = false;
+                    return parent.WaitToReadAsync(CancellationToken.None); // ok to use None, registered in ctor.
+                }
+
+                public UniTask DisposeAsync()
+                {
+                    cancellationTokenRegistration1.Dispose();
+                    cancellationTokenRegistration2.Dispose();
+                    return default;
+                }
+
+                static void CancellationCallback1(object state)
+                {
+                    var self = (ReadAllAsyncEnumerable)state;
+                    self.parent.SingalCancellation(self.cancellationToken1);
+                }
+
+                static void CancellationCallback2(object state)
+                {
+                    var self = (ReadAllAsyncEnumerable)state;
+                    self.parent.SingalCancellation(self.cancellationToken2);
+                }
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Channel.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Channel.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5ceb3107bbdd1f14eb39091273798360
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/CompilerServices.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/CompilerServices.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6fc76fc9ed937cd4baa494f65503c49f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/CompilerServices/AsyncMethodBuilderAttribute.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/CompilerServices/AsyncMethodBuilderAttribute.cs
@@ -1,0 +1,17 @@
+﻿
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+#pragma warning disable CS0436
+
+namespace System.Runtime.CompilerServices
+{
+    internal sealed class AsyncMethodBuilderAttribute : Attribute
+    {
+        public Type BuilderType { get; }
+
+        public AsyncMethodBuilderAttribute(Type builderType)
+        {
+            BuilderType = builderType;
+        }
+    }
+}
+

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/CompilerServices/AsyncMethodBuilderAttribute.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/CompilerServices/AsyncMethodBuilderAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 02ce354d37b10454e8376062f7cbe57a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/CompilerServices/AsyncUniTaskMethodBuilder.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/CompilerServices/AsyncUniTaskMethodBuilder.cs
@@ -1,0 +1,269 @@
+﻿
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Security;
+
+namespace Cysharp.Threading.Tasks.CompilerServices
+{
+    [StructLayout(LayoutKind.Auto)]
+    public struct AsyncUniTaskMethodBuilder
+    {
+        IStateMachineRunnerPromise runnerPromise;
+        Exception ex;
+
+        // 1. Static Create method.
+        [DebuggerHidden]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static AsyncUniTaskMethodBuilder Create()
+        {
+            return default;
+        }
+
+        // 2. TaskLike Task property.
+        public UniTask Task
+        {
+            [DebuggerHidden]
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                if (runnerPromise != null)
+                {
+                    return runnerPromise.Task;
+                }
+                else if (ex != null)
+                {
+                    return UniTask.FromException(ex);
+                }
+                else
+                {
+                    return UniTask.CompletedTask;
+                }
+            }
+        }
+
+        // 3. SetException
+        [DebuggerHidden]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void SetException(Exception exception)
+        {
+            if (runnerPromise == null)
+            {
+                ex = exception;
+            }
+            else
+            {
+                runnerPromise.SetException(exception);
+            }
+        }
+
+        // 4. SetResult
+        [DebuggerHidden]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void SetResult()
+        {
+            if (runnerPromise != null)
+            {
+                runnerPromise.SetResult();
+            }
+        }
+
+        // 5. AwaitOnCompleted
+        [DebuggerHidden]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine)
+            where TAwaiter : INotifyCompletion
+            where TStateMachine : IAsyncStateMachine
+        {
+            if (runnerPromise == null)
+            {
+                AsyncUniTask<TStateMachine>.SetStateMachine(ref stateMachine, ref runnerPromise);
+            }
+
+            awaiter.OnCompleted(runnerPromise.MoveNext);
+        }
+
+        // 6. AwaitUnsafeOnCompleted
+        [DebuggerHidden]
+        [SecuritySafeCritical]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine)
+            where TAwaiter : ICriticalNotifyCompletion
+            where TStateMachine : IAsyncStateMachine
+        {
+            if (runnerPromise == null)
+            {
+                AsyncUniTask<TStateMachine>.SetStateMachine(ref stateMachine, ref runnerPromise);
+            }
+
+            awaiter.UnsafeOnCompleted(runnerPromise.MoveNext);
+        }
+
+        // 7. Start
+        [DebuggerHidden]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Start<TStateMachine>(ref TStateMachine stateMachine)
+            where TStateMachine : IAsyncStateMachine
+        {
+            stateMachine.MoveNext();
+        }
+
+        // 8. SetStateMachine
+        [DebuggerHidden]
+        public void SetStateMachine(IAsyncStateMachine stateMachine)
+        {
+            // don't use boxed stateMachine.
+        }
+
+#if DEBUG || !UNITY_2018_3_OR_NEWER
+        // Important for IDE debugger.
+        object debuggingId;
+        private object ObjectIdForDebugger
+        {
+            get
+            {
+                if (debuggingId == null)
+                {
+                    debuggingId = new object();
+                }
+                return debuggingId;
+            }
+        }
+#endif
+    }
+
+    [StructLayout(LayoutKind.Auto)]
+    public struct AsyncUniTaskMethodBuilder<T>
+    {
+        IStateMachineRunnerPromise<T> runnerPromise;
+        Exception ex;
+        T result;
+
+        // 1. Static Create method.
+        [DebuggerHidden]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static AsyncUniTaskMethodBuilder<T> Create()
+        {
+            return default;
+        }
+
+        // 2. TaskLike Task property.
+        public UniTask<T> Task
+        {
+            [DebuggerHidden]
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                if (runnerPromise != null)
+                {
+                    return runnerPromise.Task;
+                }
+                else if (ex != null)
+                {
+                    return UniTask.FromException<T>(ex);
+                }
+                else
+                {
+                    return UniTask.FromResult(result);
+                }
+            }
+        }
+
+        // 3. SetException
+        [DebuggerHidden]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void SetException(Exception exception)
+        {
+            if (runnerPromise == null)
+            {
+                ex = exception;
+            }
+            else
+            {
+                runnerPromise.SetException(exception);
+            }
+        }
+
+        // 4. SetResult
+        [DebuggerHidden]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void SetResult(T result)
+        {
+            if (runnerPromise == null)
+            {
+                this.result = result;
+            }
+            else
+            {
+                runnerPromise.SetResult(result);
+            }
+        }
+
+        // 5. AwaitOnCompleted
+        [DebuggerHidden]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine)
+            where TAwaiter : INotifyCompletion
+            where TStateMachine : IAsyncStateMachine
+        {
+            if (runnerPromise == null)
+            {
+                AsyncUniTask<TStateMachine, T>.SetStateMachine(ref stateMachine, ref runnerPromise);
+            }
+
+            awaiter.OnCompleted(runnerPromise.MoveNext);
+        }
+
+        // 6. AwaitUnsafeOnCompleted
+        [DebuggerHidden]
+        [SecuritySafeCritical]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine)
+            where TAwaiter : ICriticalNotifyCompletion
+            where TStateMachine : IAsyncStateMachine
+        {
+            if (runnerPromise == null)
+            {
+                AsyncUniTask<TStateMachine, T>.SetStateMachine(ref stateMachine, ref runnerPromise);
+            }
+
+            awaiter.UnsafeOnCompleted(runnerPromise.MoveNext);
+        }
+
+        // 7. Start
+        [DebuggerHidden]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Start<TStateMachine>(ref TStateMachine stateMachine)
+            where TStateMachine : IAsyncStateMachine
+        {
+            stateMachine.MoveNext();
+        }
+
+        // 8. SetStateMachine
+        [DebuggerHidden]
+        public void SetStateMachine(IAsyncStateMachine stateMachine)
+        {
+            // don't use boxed stateMachine.
+        }
+
+#if DEBUG || !UNITY_2018_3_OR_NEWER
+        // Important for IDE debugger.
+        object debuggingId;
+        private object ObjectIdForDebugger
+        {
+            get
+            {
+                if (debuggingId == null)
+                {
+                    debuggingId = new object();
+                }
+                return debuggingId;
+            }
+        }
+#endif
+
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/CompilerServices/AsyncUniTaskMethodBuilder.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/CompilerServices/AsyncUniTaskMethodBuilder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 68d72a45afdec574ebc26e7de2c38330
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/CompilerServices/AsyncUniTaskVoidMethodBuilder.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/CompilerServices/AsyncUniTaskVoidMethodBuilder.cs
@@ -1,0 +1,137 @@
+﻿
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Security;
+
+namespace Cysharp.Threading.Tasks.CompilerServices
+{
+    [StructLayout(LayoutKind.Auto)]
+    public struct AsyncUniTaskVoidMethodBuilder
+    {
+        IStateMachineRunner runner;
+
+        // 1. Static Create method.
+        [DebuggerHidden]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static AsyncUniTaskVoidMethodBuilder Create()
+        {
+            return default;
+        }
+
+        // 2. TaskLike Task property(void)
+        public UniTaskVoid Task
+        {
+            [DebuggerHidden]
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                return default;
+            }
+        }
+
+        // 3. SetException
+        [DebuggerHidden]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void SetException(Exception exception)
+        {
+            // runner is finished, return first.
+            if (runner != null)
+            {
+#if ENABLE_IL2CPP
+                // workaround for IL2CPP bug.
+                PlayerLoopHelper.AddContinuation(PlayerLoopTiming.LastPostLateUpdate, runner.ReturnAction);
+#else
+                runner.Return();
+#endif
+                runner = null;
+            }
+
+            UniTaskScheduler.PublishUnobservedTaskException(exception);
+        }
+
+        // 4. SetResult
+        [DebuggerHidden]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void SetResult()
+        {
+            // runner is finished, return.
+            if (runner != null)
+            {
+#if ENABLE_IL2CPP
+                // workaround for IL2CPP bug.
+                PlayerLoopHelper.AddContinuation(PlayerLoopTiming.LastPostLateUpdate, runner.ReturnAction);
+#else
+                runner.Return();
+#endif
+                runner = null;
+            }
+        }
+
+        // 5. AwaitOnCompleted
+        [DebuggerHidden]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine)
+            where TAwaiter : INotifyCompletion
+            where TStateMachine : IAsyncStateMachine
+        {
+            if (runner == null)
+            {
+                AsyncUniTaskVoid<TStateMachine>.SetStateMachine(ref stateMachine, ref runner);
+            }
+
+            awaiter.OnCompleted(runner.MoveNext);
+        }
+
+        // 6. AwaitUnsafeOnCompleted
+        [DebuggerHidden]
+        [SecuritySafeCritical]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine)
+            where TAwaiter : ICriticalNotifyCompletion
+            where TStateMachine : IAsyncStateMachine
+        {
+            if (runner == null)
+            {
+                AsyncUniTaskVoid<TStateMachine>.SetStateMachine(ref stateMachine, ref runner);
+            }
+
+            awaiter.UnsafeOnCompleted(runner.MoveNext);
+        }
+
+        // 7. Start
+        [DebuggerHidden]
+        public void Start<TStateMachine>(ref TStateMachine stateMachine)
+            where TStateMachine : IAsyncStateMachine
+        {
+            stateMachine.MoveNext();
+        }
+
+        // 8. SetStateMachine
+        [DebuggerHidden]
+        public void SetStateMachine(IAsyncStateMachine stateMachine)
+        {
+            // don't use boxed stateMachine.
+        }
+
+#if DEBUG || !UNITY_2018_3_OR_NEWER
+        // Important for IDE debugger.
+        object debuggingId;
+        private object ObjectIdForDebugger
+        {
+            get
+            {
+                if (debuggingId == null)
+                {
+                    debuggingId = new object();
+                }
+                return debuggingId;
+            }
+        }
+#endif
+    }
+}
+

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/CompilerServices/AsyncUniTaskVoidMethodBuilder.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/CompilerServices/AsyncUniTaskVoidMethodBuilder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e891aaac17b933a47a9d7fa3b8e1226f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/CompilerServices/StateMachineRunner.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/CompilerServices/StateMachineRunner.cs
@@ -1,0 +1,380 @@
+﻿#pragma warning disable CS1591
+
+using Cysharp.Threading.Tasks.Internal;
+using System;
+using System.Linq;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace Cysharp.Threading.Tasks.CompilerServices
+{
+    // #ENABLE_IL2CPP in this file is to avoid bug of IL2CPP VM.
+    // Issue is tracked on https://issuetracker.unity3d.com/issues/il2cpp-incorrect-results-when-calling-a-method-from-outside-class-in-a-struct
+    // but currently it is labeled `Won't Fix`.
+
+    internal interface IStateMachineRunner
+    {
+        Action MoveNext { get; }
+        void Return();
+
+#if ENABLE_IL2CPP
+        Action ReturnAction { get; }
+#endif
+    }
+
+    internal interface IStateMachineRunnerPromise : IUniTaskSource
+    {
+        Action MoveNext { get; }
+        UniTask Task { get; }
+        void SetResult();
+        void SetException(Exception exception);
+    }
+
+    internal interface IStateMachineRunnerPromise<T> : IUniTaskSource<T>
+    {
+        Action MoveNext { get; }
+        UniTask<T> Task { get; }
+        void SetResult(T result);
+        void SetException(Exception exception);
+    }
+
+    internal static class StateMachineUtility
+    {
+        // Get AsyncStateMachine internal state to check IL2CPP bug
+        public static int GetState(IAsyncStateMachine stateMachine)
+        {
+            var info = stateMachine.GetType().GetFields(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+                .First(x => x.Name.EndsWith("__state"));
+            return (int)info.GetValue(stateMachine);
+        }
+    }
+
+    internal sealed class AsyncUniTaskVoid<TStateMachine> : IStateMachineRunner, ITaskPoolNode<AsyncUniTaskVoid<TStateMachine>>, IUniTaskSource
+        where TStateMachine : IAsyncStateMachine
+    {
+        static TaskPool<AsyncUniTaskVoid<TStateMachine>> pool;
+
+#if ENABLE_IL2CPP
+        public Action ReturnAction { get; }
+#endif
+
+        TStateMachine stateMachine;
+
+        public Action MoveNext { get; }
+
+        public AsyncUniTaskVoid()
+        {
+            MoveNext = Run;
+#if ENABLE_IL2CPP
+            ReturnAction = Return;
+#endif
+        }
+
+        public static void SetStateMachine(ref TStateMachine stateMachine, ref IStateMachineRunner runnerFieldRef)
+        {
+            if (!pool.TryPop(out var result))
+            {
+                result = new AsyncUniTaskVoid<TStateMachine>();
+            }
+            TaskTracker.TrackActiveTask(result, 3);
+
+            runnerFieldRef = result; // set runner before copied.
+            result.stateMachine = stateMachine; // copy struct StateMachine(in release build).
+        }
+
+        static AsyncUniTaskVoid()
+        {
+            TaskPool.RegisterSizeGetter(typeof(AsyncUniTaskVoid<TStateMachine>), () => pool.Size);
+        }
+
+        AsyncUniTaskVoid<TStateMachine> nextNode;
+        public ref AsyncUniTaskVoid<TStateMachine> NextNode => ref nextNode;
+
+        public void Return()
+        {
+            TaskTracker.RemoveTracking(this);
+            stateMachine = default;
+            pool.TryPush(this);
+        }
+
+        [DebuggerHidden]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        void Run()
+        {
+            stateMachine.MoveNext();
+        }
+
+        // dummy interface implementation for TaskTracker.
+
+        UniTaskStatus IUniTaskSource.GetStatus(short token)
+        {
+            return UniTaskStatus.Pending;
+        }
+
+        UniTaskStatus IUniTaskSource.UnsafeGetStatus()
+        {
+            return UniTaskStatus.Pending;
+        }
+
+        void IUniTaskSource.OnCompleted(Action<object> continuation, object state, short token)
+        {
+        }
+
+        void IUniTaskSource.GetResult(short token)
+        {
+        }
+    }
+
+    internal sealed class AsyncUniTask<TStateMachine> : IStateMachineRunnerPromise, IUniTaskSource, ITaskPoolNode<AsyncUniTask<TStateMachine>>
+        where TStateMachine : IAsyncStateMachine
+    {
+        static TaskPool<AsyncUniTask<TStateMachine>> pool;
+
+#if ENABLE_IL2CPP
+        readonly Action returnDelegate;  
+#endif
+        public Action MoveNext { get; }
+
+        TStateMachine stateMachine;
+        UniTaskCompletionSourceCore<AsyncUnit> core;
+
+        AsyncUniTask()
+        {
+            MoveNext = Run;
+#if ENABLE_IL2CPP
+            returnDelegate = Return;
+#endif
+        }
+
+        public static void SetStateMachine(ref TStateMachine stateMachine, ref IStateMachineRunnerPromise runnerPromiseFieldRef)
+        {
+            if (!pool.TryPop(out var result))
+            {
+                result = new AsyncUniTask<TStateMachine>();
+            }
+            TaskTracker.TrackActiveTask(result, 3);
+
+            runnerPromiseFieldRef = result; // set runner before copied.
+            result.stateMachine = stateMachine; // copy struct StateMachine(in release build).
+        }
+
+        AsyncUniTask<TStateMachine> nextNode;
+        public ref AsyncUniTask<TStateMachine> NextNode => ref nextNode;
+
+        static AsyncUniTask()
+        {
+            TaskPool.RegisterSizeGetter(typeof(AsyncUniTask<TStateMachine>), () => pool.Size);
+        }
+
+        void Return()
+        {
+            TaskTracker.RemoveTracking(this);
+            core.Reset();
+            stateMachine = default;
+            pool.TryPush(this);
+        }
+
+        bool TryReturn()
+        {
+            TaskTracker.RemoveTracking(this);
+            core.Reset();
+            stateMachine = default;
+            return pool.TryPush(this);
+        }
+
+        [DebuggerHidden]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        void Run()
+        {
+            stateMachine.MoveNext();
+        }
+
+        public UniTask Task
+        {
+            [DebuggerHidden]
+            get
+            {
+                return new UniTask(this, core.Version);
+            }
+        }
+
+        [DebuggerHidden]
+        public void SetResult()
+        {
+            core.TrySetResult(AsyncUnit.Default);
+        }
+
+        [DebuggerHidden]
+        public void SetException(Exception exception)
+        {
+            core.TrySetException(exception);
+        }
+
+        [DebuggerHidden]
+        public void GetResult(short token)
+        {
+            try
+            {
+                core.GetResult(token);
+            }
+            finally
+            {
+#if ENABLE_IL2CPP
+                // workaround for IL2CPP bug.
+                PlayerLoopHelper.AddContinuation(PlayerLoopTiming.LastPostLateUpdate, returnDelegate);
+#else
+                TryReturn();
+#endif
+            }
+        }
+
+        [DebuggerHidden]
+        public UniTaskStatus GetStatus(short token)
+        {
+            return core.GetStatus(token);
+        }
+
+        [DebuggerHidden]
+        public UniTaskStatus UnsafeGetStatus()
+        {
+            return core.UnsafeGetStatus();
+        }
+
+        [DebuggerHidden]
+        public void OnCompleted(Action<object> continuation, object state, short token)
+        {
+            core.OnCompleted(continuation, state, token);
+        }
+    }
+
+    internal sealed class AsyncUniTask<TStateMachine, T> : IStateMachineRunnerPromise<T>, IUniTaskSource<T>, ITaskPoolNode<AsyncUniTask<TStateMachine, T>>
+        where TStateMachine : IAsyncStateMachine
+    {
+        static TaskPool<AsyncUniTask<TStateMachine, T>> pool;
+
+#if ENABLE_IL2CPP
+        readonly Action returnDelegate;  
+#endif
+
+        public Action MoveNext { get; }
+
+        TStateMachine stateMachine;
+        UniTaskCompletionSourceCore<T> core;
+
+        AsyncUniTask()
+        {
+            MoveNext = Run;
+#if ENABLE_IL2CPP
+            returnDelegate = Return;
+#endif
+        }
+
+        public static void SetStateMachine(ref TStateMachine stateMachine, ref IStateMachineRunnerPromise<T> runnerPromiseFieldRef)
+        {
+            if (!pool.TryPop(out var result))
+            {
+                result = new AsyncUniTask<TStateMachine, T>();
+            }
+            TaskTracker.TrackActiveTask(result, 3);
+
+            runnerPromiseFieldRef = result; // set runner before copied.
+            result.stateMachine = stateMachine; // copy struct StateMachine(in release build).
+        }
+
+        AsyncUniTask<TStateMachine, T> nextNode;
+        public ref AsyncUniTask<TStateMachine, T> NextNode => ref nextNode;
+
+        static AsyncUniTask()
+        {
+            TaskPool.RegisterSizeGetter(typeof(AsyncUniTask<TStateMachine, T>), () => pool.Size);
+        }
+
+        void Return()
+        {
+            TaskTracker.RemoveTracking(this);
+            core.Reset();
+            stateMachine = default;
+            pool.TryPush(this);
+        }
+
+        bool TryReturn()
+        {
+            TaskTracker.RemoveTracking(this);
+            core.Reset();
+            stateMachine = default;
+            return pool.TryPush(this);
+        }
+
+        [DebuggerHidden]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        void Run()
+        {
+            // UnityEngine.Debug.Log($"MoveNext State:" + StateMachineUtility.GetState(stateMachine));
+            stateMachine.MoveNext();
+        }
+
+        public UniTask<T> Task
+        {
+            [DebuggerHidden]
+            get
+            {
+                return new UniTask<T>(this, core.Version);
+            }
+        }
+
+        [DebuggerHidden]
+        public void SetResult(T result)
+        {
+            core.TrySetResult(result);
+        }
+
+        [DebuggerHidden]
+        public void SetException(Exception exception)
+        {
+            core.TrySetException(exception);
+        }
+
+        [DebuggerHidden]
+        public T GetResult(short token)
+        {
+            try
+            {
+                return core.GetResult(token);
+            }
+            finally
+            {
+#if ENABLE_IL2CPP
+                // workaround for IL2CPP bug.
+                PlayerLoopHelper.AddContinuation(PlayerLoopTiming.LastPostLateUpdate, returnDelegate);
+#else
+                TryReturn();
+#endif
+            }
+        }
+
+        [DebuggerHidden]
+        void IUniTaskSource.GetResult(short token)
+        {
+            GetResult(token);
+        }
+
+        [DebuggerHidden]
+        public UniTaskStatus GetStatus(short token)
+        {
+            return core.GetStatus(token);
+        }
+
+        [DebuggerHidden]
+        public UniTaskStatus UnsafeGetStatus()
+        {
+            return core.UnsafeGetStatus();
+        }
+
+        [DebuggerHidden]
+        public void OnCompleted(Action<object> continuation, object state, short token)
+        {
+            core.OnCompleted(continuation, state, token);
+        }
+    }
+}
+

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/CompilerServices/StateMachineRunner.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/CompilerServices/StateMachineRunner.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 98649642833cabf44a9dc060ce4c84a1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/EnumerableAsyncExtensions.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/EnumerableAsyncExtensions.cs
@@ -1,0 +1,34 @@
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System;
+using System.Collections.Generic;
+
+namespace Cysharp.Threading.Tasks
+{
+    public static class EnumerableAsyncExtensions
+    {
+        // overload resolver - .Select(async x => { }) : IEnumerable<UniTask<T>>
+
+        public static IEnumerable<UniTask> Select<T>(this IEnumerable<T> source, Func<T, UniTask> selector)
+        {
+            return System.Linq.Enumerable.Select(source, selector);
+        }
+
+        public static IEnumerable<UniTask<TR>> Select<T, TR>(this IEnumerable<T> source, Func<T, UniTask<TR>> selector)
+        {
+            return System.Linq.Enumerable.Select(source, selector);
+        }
+
+        public static IEnumerable<UniTask> Select<T>(this IEnumerable<T> source, Func<T, int, UniTask> selector)
+        {
+            return System.Linq.Enumerable.Select(source, selector);
+        }
+
+        public static IEnumerable<UniTask<TR>> Select<T, TR>(this IEnumerable<T> source, Func<T, int, UniTask<TR>> selector)
+        {
+            return System.Linq.Enumerable.Select(source, selector);
+        }
+    }
+}
+
+

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/EnumerableAsyncExtensions.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/EnumerableAsyncExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ff50260d74bd54c4b92cf99895549445
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/EnumeratorAsyncExtensions.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/EnumeratorAsyncExtensions.cs
@@ -1,0 +1,287 @@
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System;
+using System.Collections;
+using System.Reflection;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using Cysharp.Threading.Tasks.Internal;
+using UnityEngine;
+
+namespace Cysharp.Threading.Tasks
+{
+    public static class EnumeratorAsyncExtensions
+    {
+        public static UniTask.Awaiter GetAwaiter<T>(this T enumerator)
+            where T : IEnumerator
+        {
+            var e = (IEnumerator)enumerator;
+            Error.ThrowArgumentNullException(e, nameof(enumerator));
+            return new UniTask(EnumeratorPromise.Create(e, PlayerLoopTiming.Update, CancellationToken.None, out var token), token).GetAwaiter();
+        }
+
+        public static UniTask WithCancellation(this IEnumerator enumerator, CancellationToken cancellationToken)
+        {
+            Error.ThrowArgumentNullException(enumerator, nameof(enumerator));
+            return new UniTask(EnumeratorPromise.Create(enumerator, PlayerLoopTiming.Update, cancellationToken, out var token), token);
+        }
+
+        public static UniTask ToUniTask(this IEnumerator enumerator, PlayerLoopTiming timing = PlayerLoopTiming.Update, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Error.ThrowArgumentNullException(enumerator, nameof(enumerator));
+            return new UniTask(EnumeratorPromise.Create(enumerator, timing, cancellationToken, out var token), token);
+        }
+
+        public static UniTask ToUniTask(this IEnumerator enumerator, MonoBehaviour coroutineRunner)
+        {
+            var source = AutoResetUniTaskCompletionSource.Create();
+            coroutineRunner.StartCoroutine(Core(enumerator, coroutineRunner, source));
+            return source.Task;
+        }
+
+        static IEnumerator Core(IEnumerator inner, MonoBehaviour coroutineRunner, AutoResetUniTaskCompletionSource source)
+        {
+            yield return coroutineRunner.StartCoroutine(inner);
+            source.TrySetResult();
+        }
+
+        sealed class EnumeratorPromise : IUniTaskSource, IPlayerLoopItem, ITaskPoolNode<EnumeratorPromise>
+        {
+            static TaskPool<EnumeratorPromise> pool;
+            EnumeratorPromise nextNode;
+            public ref EnumeratorPromise NextNode => ref nextNode;
+
+            static EnumeratorPromise()
+            {
+                TaskPool.RegisterSizeGetter(typeof(EnumeratorPromise), () => pool.Size);
+            }
+
+            IEnumerator innerEnumerator;
+            CancellationToken cancellationToken;
+            int initialFrame;
+            bool loopRunning;
+            bool calledGetResult;
+
+            UniTaskCompletionSourceCore<object> core;
+
+            EnumeratorPromise()
+            {
+            }
+
+            public static IUniTaskSource Create(IEnumerator innerEnumerator, PlayerLoopTiming timing, CancellationToken cancellationToken, out short token)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return AutoResetUniTaskCompletionSource.CreateFromCanceled(cancellationToken, out token);
+                }
+
+                if (!pool.TryPop(out var result))
+                {
+                    result = new EnumeratorPromise();
+                }
+                TaskTracker.TrackActiveTask(result, 3);
+
+                result.innerEnumerator = ConsumeEnumerator(innerEnumerator);
+                result.cancellationToken = cancellationToken;
+                result.loopRunning = true;
+                result.calledGetResult = false;
+                result.initialFrame = -1;
+
+                token = result.core.Version;
+
+                // run immediately.
+                if (result.MoveNext())
+                {
+                    PlayerLoopHelper.AddAction(timing, result);
+                }
+                
+                return result;
+            }
+
+            public void GetResult(short token)
+            {
+                try
+                {
+                    calledGetResult = true;
+                    core.GetResult(token);
+                }
+                finally
+                {
+                    if (!loopRunning)
+                    {
+                        TryReturn();
+                    }
+                }
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+
+            public bool MoveNext()
+            {
+                if (calledGetResult)
+                {
+                    loopRunning = false;
+                    TryReturn();
+                    return false;
+                }
+
+                if (innerEnumerator == null) // invalid status, returned but loop running?
+                {
+                    return false;
+                }
+
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    loopRunning = false;
+                    core.TrySetCanceled(cancellationToken);
+                    return false;
+                }
+
+                if (initialFrame == -1)
+                {
+                    // Time can not touch in threadpool.
+                    if (PlayerLoopHelper.IsMainThread)
+                    {
+                        initialFrame = Time.frameCount;
+                    }
+                }
+                else if (initialFrame == Time.frameCount)
+                {
+                    return true; // already executed in first frame, skip.
+                }
+
+                try
+                {
+                    if (innerEnumerator.MoveNext())
+                    {
+                        return true;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    loopRunning = false;
+                    core.TrySetException(ex);
+                    return false;
+                }
+
+                loopRunning = false;
+                core.TrySetResult(null);
+                return false;
+            }
+
+            bool TryReturn()
+            {
+                TaskTracker.RemoveTracking(this);
+                core.Reset();
+                innerEnumerator = default;
+                cancellationToken = default;
+
+                return pool.TryPush(this);
+            }
+
+            // Unwrap YieldInstructions
+
+            static IEnumerator ConsumeEnumerator(IEnumerator enumerator)
+            {
+                while (enumerator.MoveNext())
+                {
+                    var current = enumerator.Current;
+                    if (current == null)
+                    {
+                        yield return null;
+                    }
+                    else if (current is CustomYieldInstruction cyi)
+                    {
+                        // WWW, WaitForSecondsRealtime
+                        while (cyi.keepWaiting)
+                        {
+                            yield return null;
+                        }
+                    }
+                    else if (current is YieldInstruction)
+                    {
+                        IEnumerator innerCoroutine = null;
+                        switch (current)
+                        {
+                            case AsyncOperation ao:
+                                innerCoroutine = UnwrapWaitAsyncOperation(ao);
+                                break;
+                            case WaitForSeconds wfs:
+                                innerCoroutine = UnwrapWaitForSeconds(wfs);
+                                break;
+                        }
+                        if (innerCoroutine != null)
+                        {
+                            while (innerCoroutine.MoveNext())
+                            {
+                                yield return null;
+                            }
+                        }
+                        else
+                        {
+                            goto WARN;
+                        }
+                    }
+                    else if (current is IEnumerator e3)
+                    {
+                        var e4 = ConsumeEnumerator(e3);
+                        while (e4.MoveNext())
+                        {
+                            yield return null;
+                        }
+                    }
+                    else
+                    {
+                        goto WARN;
+                    }
+
+                    continue;
+
+                    WARN:
+                    // WaitForEndOfFrame, WaitForFixedUpdate, others.
+                    UnityEngine.Debug.LogWarning($"yield {current.GetType().Name} is not supported on await IEnumerator or IEnumerator.ToUniTask(), please use ToUniTask(MonoBehaviour coroutineRunner) instead.");
+                    yield return null;
+                }
+            }
+
+            static readonly FieldInfo waitForSeconds_Seconds = typeof(WaitForSeconds).GetField("m_Seconds", BindingFlags.Instance | BindingFlags.GetField | BindingFlags.NonPublic);
+
+            static IEnumerator UnwrapWaitForSeconds(WaitForSeconds waitForSeconds)
+            {
+                var second = (float)waitForSeconds_Seconds.GetValue(waitForSeconds);
+                var elapsed = 0.0f;
+                while (true)
+                {
+                    yield return null;
+
+                    elapsed += Time.deltaTime;
+                    if (elapsed >= second)
+                    {
+                        break;
+                    }
+                };
+            }
+
+            static IEnumerator UnwrapWaitAsyncOperation(AsyncOperation asyncOperation)
+            {
+                while (!asyncOperation.isDone)
+                {
+                    yield return null;
+                }
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/EnumeratorAsyncExtensions.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/EnumeratorAsyncExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bc661232f11e4a741af54ba1c175d5ee
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/ExceptionExtensions.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/ExceptionExtensions.cs
@@ -1,0 +1,14 @@
+﻿
+using System;
+
+namespace Cysharp.Threading.Tasks
+{
+    public static class ExceptionExtensions
+    {
+        public static bool IsOperationCanceledException(this Exception exception)
+        {
+            return exception is OperationCanceledException;
+        }
+    }
+}
+

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/ExceptionExtensions.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/ExceptionExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 930800098504c0d46958ce23a0495202
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/External.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/External.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a1605b5dec413434cb83901d42cb89ce
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/External/Addressables.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/External/Addressables.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 70313f17126afea44b10e0f1bea9d15f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/External/Addressables/AddressablesAsyncExtensions.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/External/Addressables/AddressablesAsyncExtensions.cs
@@ -1,0 +1,401 @@
+﻿// asmdef Version Defines, enabled when com.unity.addressables is imported.
+
+#if UNITASK_ADDRESSABLE_SUPPORT
+
+using Cysharp.Threading.Tasks.Internal;
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using UnityEngine.ResourceManagement.AsyncOperations;
+
+namespace Cysharp.Threading.Tasks
+{
+    public static class AddressablesAsyncExtensions
+    {
+#region AsyncOperationHandle
+
+        public static UniTask.Awaiter GetAwaiter(this AsyncOperationHandle handle)
+        {
+            return ToUniTask(handle).GetAwaiter();
+        }
+
+        public static UniTask WithCancellation(this AsyncOperationHandle handle, CancellationToken cancellationToken)
+        {
+            return ToUniTask(handle, cancellationToken: cancellationToken);
+        }
+
+        public static UniTask ToUniTask(this AsyncOperationHandle handle, IProgress<float> progress = null, PlayerLoopTiming timing = PlayerLoopTiming.Update, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested) return UniTask.FromCanceled(cancellationToken);
+
+            if (!handle.IsValid())
+            {
+                // autoReleaseHandle:true handle is invalid(immediately internal handle == null) so return completed.
+                return UniTask.CompletedTask;
+            }
+
+            if (handle.IsDone)
+            {
+                if (handle.Status == AsyncOperationStatus.Failed)
+                {
+                    return UniTask.FromException(handle.OperationException);
+                }
+                return UniTask.CompletedTask;
+            }
+
+            return new UniTask(AsyncOperationHandleConfiguredSource.Create(handle, timing, progress, cancellationToken, out var token), token);
+        }
+
+        public struct AsyncOperationHandleAwaiter : ICriticalNotifyCompletion
+        {
+            AsyncOperationHandle handle;
+            Action<AsyncOperationHandle> continuationAction;
+
+            public AsyncOperationHandleAwaiter(AsyncOperationHandle handle)
+            {
+                this.handle = handle;
+                this.continuationAction = null;
+            }
+
+            public bool IsCompleted => handle.IsDone;
+
+            public void GetResult()
+            {
+                if (continuationAction != null)
+                {
+                    handle.Completed -= continuationAction;
+                    continuationAction = null;
+                }
+
+                if (handle.Status == AsyncOperationStatus.Failed)
+                {
+                    var e = handle.OperationException;
+                    handle = default;
+                    ExceptionDispatchInfo.Capture(e).Throw();
+                }
+
+                var result = handle.Result;
+                handle = default;
+            }
+
+            public void OnCompleted(Action continuation)
+            {
+                UnsafeOnCompleted(continuation);
+            }
+
+            public void UnsafeOnCompleted(Action continuation)
+            {
+                Error.ThrowWhenContinuationIsAlreadyRegistered(continuationAction);
+                continuationAction = PooledDelegate<AsyncOperationHandle>.Create(continuation);
+                handle.Completed += continuationAction;
+            }
+        }
+
+        sealed class AsyncOperationHandleConfiguredSource : IUniTaskSource, IPlayerLoopItem, ITaskPoolNode<AsyncOperationHandleConfiguredSource>
+        {
+            static TaskPool<AsyncOperationHandleConfiguredSource> pool;
+            AsyncOperationHandleConfiguredSource nextNode;
+            public ref AsyncOperationHandleConfiguredSource NextNode => ref nextNode;
+
+            static AsyncOperationHandleConfiguredSource()
+            {
+                TaskPool.RegisterSizeGetter(typeof(AsyncOperationHandleConfiguredSource), () => pool.Size);
+            }
+
+            readonly Action<AsyncOperationHandle> continuationAction;
+            AsyncOperationHandle handle;
+            CancellationToken cancellationToken;
+            IProgress<float> progress;
+            bool completed;
+
+            UniTaskCompletionSourceCore<AsyncUnit> core;
+
+            AsyncOperationHandleConfiguredSource()
+            {
+                continuationAction = Continuation;
+            }
+
+            public static IUniTaskSource Create(AsyncOperationHandle handle, PlayerLoopTiming timing, IProgress<float> progress, CancellationToken cancellationToken, out short token)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return AutoResetUniTaskCompletionSource.CreateFromCanceled(cancellationToken, out token);
+                }
+
+                if (!pool.TryPop(out var result))
+                {
+                    result = new AsyncOperationHandleConfiguredSource();
+                }
+
+                result.handle = handle;
+                result.progress = progress;
+                result.cancellationToken = cancellationToken;
+                result.completed = false;
+
+                TaskTracker.TrackActiveTask(result, 3);
+
+                PlayerLoopHelper.AddAction(timing, result);
+
+                handle.Completed += result.continuationAction;
+
+                token = result.core.Version;
+                return result;
+            }
+
+            void Continuation(AsyncOperationHandle _)
+            {
+                handle.Completed -= continuationAction;
+
+                if (completed)
+                {
+                    TryReturn();
+                }
+                else
+                {
+                    completed = true;
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        core.TrySetCanceled(cancellationToken);
+                    }
+                    else if (handle.Status == AsyncOperationStatus.Failed)
+                    {
+                        core.TrySetException(handle.OperationException);
+                    }
+                    else
+                    {
+                        core.TrySetResult(AsyncUnit.Default);
+                    }
+                }
+            }
+
+            public void GetResult(short token)
+            {
+                core.GetResult(token);
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+
+            public bool MoveNext()
+            {
+                if (completed)
+                {
+                    TryReturn();
+                    return false;
+                }
+
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    completed = true;
+                    core.TrySetCanceled(cancellationToken);
+                    return false;
+                }
+
+                if (progress != null && handle.IsValid())
+                {
+                    progress.Report(handle.PercentComplete);
+                }
+
+                return true;
+            }
+
+            bool TryReturn()
+            {
+                TaskTracker.RemoveTracking(this);
+                core.Reset();
+                handle = default;
+                progress = default;
+                cancellationToken = default;
+                return pool.TryPush(this);
+            }
+        }
+
+#endregion
+
+#region AsyncOperationHandle_T
+
+        public static UniTask<T>.Awaiter GetAwaiter<T>(this AsyncOperationHandle<T> handle)
+        {
+            return ToUniTask(handle).GetAwaiter();
+        }
+
+        public static UniTask<T> WithCancellation<T>(this AsyncOperationHandle<T> handle, CancellationToken cancellationToken)
+        {
+            return ToUniTask(handle, cancellationToken: cancellationToken);
+        }
+
+        public static UniTask<T> ToUniTask<T>(this AsyncOperationHandle<T> handle, IProgress<float> progress = null, PlayerLoopTiming timing = PlayerLoopTiming.Update, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested) return UniTask.FromCanceled<T>(cancellationToken);
+
+            if (!handle.IsValid())
+            {
+                throw new Exception("Attempting to use an invalid operation handle");
+            }
+
+            if (handle.IsDone)
+            {
+                if (handle.Status == AsyncOperationStatus.Failed)
+                {
+                    return UniTask.FromException<T>(handle.OperationException);
+                }
+                return UniTask.FromResult(handle.Result);
+            }
+
+            return new UniTask<T>(AsyncOperationHandleConfiguredSource<T>.Create(handle, timing, progress, cancellationToken, out var token), token);
+        }
+
+        sealed class AsyncOperationHandleConfiguredSource<T> : IUniTaskSource<T>, IPlayerLoopItem, ITaskPoolNode<AsyncOperationHandleConfiguredSource<T>>
+        {
+            static TaskPool<AsyncOperationHandleConfiguredSource<T>> pool;
+            AsyncOperationHandleConfiguredSource<T> nextNode;
+            public ref AsyncOperationHandleConfiguredSource<T> NextNode => ref nextNode;
+
+            static AsyncOperationHandleConfiguredSource()
+            {
+                TaskPool.RegisterSizeGetter(typeof(AsyncOperationHandleConfiguredSource<T>), () => pool.Size);
+            }
+
+            readonly Action<AsyncOperationHandle<T>> continuationAction;
+            AsyncOperationHandle<T> handle;
+            CancellationToken cancellationToken;
+            IProgress<float> progress;
+            bool completed;
+
+            UniTaskCompletionSourceCore<T> core;
+
+            AsyncOperationHandleConfiguredSource()
+            {
+                continuationAction = Continuation;
+            }
+
+            public static IUniTaskSource<T> Create(AsyncOperationHandle<T> handle, PlayerLoopTiming timing, IProgress<float> progress, CancellationToken cancellationToken, out short token)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return AutoResetUniTaskCompletionSource<T>.CreateFromCanceled(cancellationToken, out token);
+                }
+
+                if (!pool.TryPop(out var result))
+                {
+                    result = new AsyncOperationHandleConfiguredSource<T>();
+                }
+
+                result.handle = handle;
+                result.cancellationToken = cancellationToken;
+                result.completed = false;
+                result.progress = progress;
+
+                TaskTracker.TrackActiveTask(result, 3);
+
+                PlayerLoopHelper.AddAction(timing, result);
+
+                handle.Completed += result.continuationAction;
+
+                token = result.core.Version;
+                return result;
+            }
+
+            void Continuation(AsyncOperationHandle<T> argHandle)
+            {
+                handle.Completed -= continuationAction;
+
+                if (completed)
+                {
+                    TryReturn();
+                }
+                else
+                {
+                    completed = true;
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        core.TrySetCanceled(cancellationToken);
+                    }
+                    else if (argHandle.Status == AsyncOperationStatus.Failed)
+                    {
+                        core.TrySetException(argHandle.OperationException);
+                    }
+                    else
+                    {
+                        core.TrySetResult(argHandle.Result);
+                    }
+                }
+            }
+
+            public T GetResult(short token)
+            {
+                return core.GetResult(token);
+            }
+
+            void IUniTaskSource.GetResult(short token)
+            {
+                GetResult(token);
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+
+            public bool MoveNext()
+            {
+                if (completed)
+                {
+                    TryReturn();
+                    return false;
+                }
+
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    completed = true;
+                    core.TrySetCanceled(cancellationToken);
+                    return false;
+                }
+
+                if (progress != null && handle.IsValid())
+                {
+                    progress.Report(handle.PercentComplete);
+                }
+
+                return true;
+            }
+
+            bool TryReturn()
+            {
+                TaskTracker.RemoveTracking(this);
+                core.Reset();
+                handle = default;
+                progress = default;
+                cancellationToken = default;
+                return pool.TryPush(this);
+            }
+        }
+
+#endregion
+    }
+}
+
+#endif

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/External/Addressables/AddressablesAsyncExtensions.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/External/Addressables/AddressablesAsyncExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3dc6441f9094f354b931dc3c79fb99e5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/External/Addressables/UniTask.Addressables.asmdef
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/External/Addressables/UniTask.Addressables.asmdef
@@ -1,0 +1,27 @@
+{
+    "name": "UniTask.Addressables",
+    "references": [
+        "UniTask",
+        "Unity.ResourceManager"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.addressables",
+            "expression": "",
+            "define": "UNITASK_ADDRESSABLE_SUPPORT"
+        },
+	{
+            "name": "com.unity.addressables.cn",
+            "expression": "",
+            "define": "UNITASK_ADDRESSABLE_SUPPORT"
+        }
+    ],
+    "noEngineReferences": false
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/External/Addressables/UniTask.Addressables.asmdef.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/External/Addressables/UniTask.Addressables.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 593a5b492d29ac6448b1ebf7f035ef33
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/External/DOTween.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/External/DOTween.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2dfc81677c9048c4681e5c6a4573ecc8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/External/DOTween/DOTweenAsyncExtensions.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/External/DOTween/DOTweenAsyncExtensions.cs
@@ -1,0 +1,470 @@
+﻿// asmdef Version Defines, enabled when com.demigiant.dotween is imported.
+
+#if UNITASK_DOTWEEN_SUPPORT
+
+using Cysharp.Threading.Tasks.Internal;
+using DG.Tweening;
+using System;
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks
+{
+    public enum TweenCancelBehaviour
+    {
+        Kill,
+        KillWithCompleteCallback,
+        Complete,
+        CompleteWithSequenceCallback,
+        CancelAwait,
+
+        // AndCancelAwait
+        KillAndCancelAwait,
+        KillWithCompleteCallbackAndCancelAwait,
+        CompleteAndCancelAwait,
+        CompleteWithSequenceCallbackAndCancelAwait
+    }
+
+    public static class DOTweenAsyncExtensions
+    {
+        enum CallbackType
+        {
+            Kill,
+            Complete,
+            Pause,
+            Play,
+            Rewind,
+            StepComplete
+        }
+
+        public static TweenAwaiter GetAwaiter(this Tween tween)
+        {
+            return new TweenAwaiter(tween);
+        }
+
+        public static UniTask WithCancellation(this Tween tween, CancellationToken cancellationToken)
+        {
+            Error.ThrowArgumentNullException(tween, nameof(tween));
+
+            if (!tween.IsActive()) return UniTask.CompletedTask;
+            return new UniTask(TweenConfiguredSource.Create(tween, TweenCancelBehaviour.Kill, cancellationToken, CallbackType.Kill, out var token), token);
+        }
+
+        public static UniTask ToUniTask(this Tween tween, TweenCancelBehaviour tweenCancelBehaviour = TweenCancelBehaviour.Kill, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(tween, nameof(tween));
+
+            if (!tween.IsActive()) return UniTask.CompletedTask;
+            return new UniTask(TweenConfiguredSource.Create(tween, tweenCancelBehaviour, cancellationToken, CallbackType.Kill, out var token), token);
+        }
+
+        public static UniTask AwaitForComplete(this Tween tween, TweenCancelBehaviour tweenCancelBehaviour = TweenCancelBehaviour.Kill, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(tween, nameof(tween));
+
+            if (!tween.IsActive()) return UniTask.CompletedTask;
+            return new UniTask(TweenConfiguredSource.Create(tween, tweenCancelBehaviour, cancellationToken, CallbackType.Complete, out var token), token);
+        }
+
+        public static UniTask AwaitForPause(this Tween tween, TweenCancelBehaviour tweenCancelBehaviour = TweenCancelBehaviour.Kill, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(tween, nameof(tween));
+
+            if (!tween.IsActive()) return UniTask.CompletedTask;
+            return new UniTask(TweenConfiguredSource.Create(tween, tweenCancelBehaviour, cancellationToken, CallbackType.Pause, out var token), token);
+        }
+
+        public static UniTask AwaitForPlay(this Tween tween, TweenCancelBehaviour tweenCancelBehaviour = TweenCancelBehaviour.Kill, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(tween, nameof(tween));
+
+            if (!tween.IsActive()) return UniTask.CompletedTask;
+            return new UniTask(TweenConfiguredSource.Create(tween, tweenCancelBehaviour, cancellationToken, CallbackType.Play, out var token), token);
+        }
+
+        public static UniTask AwaitForRewind(this Tween tween, TweenCancelBehaviour tweenCancelBehaviour = TweenCancelBehaviour.Kill, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(tween, nameof(tween));
+
+            if (!tween.IsActive()) return UniTask.CompletedTask;
+            return new UniTask(TweenConfiguredSource.Create(tween, tweenCancelBehaviour, cancellationToken, CallbackType.Rewind, out var token), token);
+        }
+
+        public static UniTask AwaitForStepComplete(this Tween tween, TweenCancelBehaviour tweenCancelBehaviour = TweenCancelBehaviour.Kill, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(tween, nameof(tween));
+
+            if (!tween.IsActive()) return UniTask.CompletedTask;
+            return new UniTask(TweenConfiguredSource.Create(tween, tweenCancelBehaviour, cancellationToken, CallbackType.StepComplete, out var token), token);
+        }
+
+        public struct TweenAwaiter : ICriticalNotifyCompletion
+        {
+            readonly Tween tween;
+
+            // killed(non active) as completed.
+            public bool IsCompleted => !tween.IsActive();
+
+            public TweenAwaiter(Tween tween)
+            {
+                this.tween = tween;
+            }
+
+            public TweenAwaiter GetAwaiter()
+            {
+                return this;
+            }
+
+            public void GetResult()
+            {
+            }
+
+            public void OnCompleted(System.Action continuation)
+            {
+                UnsafeOnCompleted(continuation);
+            }
+
+            public void UnsafeOnCompleted(System.Action continuation)
+            {
+                // onKill is called after OnCompleted, both Complete(false/true) and Kill(false/true).
+                tween.onKill = PooledTweenCallback.Create(continuation);
+            }
+        }
+
+        sealed class TweenConfiguredSource : IUniTaskSource, ITaskPoolNode<TweenConfiguredSource>
+        {
+            static TaskPool<TweenConfiguredSource> pool;
+            TweenConfiguredSource nextNode;
+            public ref TweenConfiguredSource NextNode => ref nextNode;
+
+            static TweenConfiguredSource()
+            {
+                TaskPool.RegisterSizeGetter(typeof(TweenConfiguredSource), () => pool.Size);
+            }
+
+            readonly TweenCallback onCompleteCallbackDelegate;
+            readonly TweenCallback onUpdateDelegate;
+
+            Tween tween;
+            TweenCancelBehaviour cancelBehaviour;
+            CancellationToken cancellationToken;
+            CallbackType callbackType;
+            bool canceled;
+
+            TweenCallback originalUpdateAction;
+            TweenCallback originalCompleteAction;
+            UniTaskCompletionSourceCore<AsyncUnit> core;
+
+            TweenConfiguredSource()
+            {
+                onCompleteCallbackDelegate = OnCompleteCallbackDelegate;
+                onUpdateDelegate = OnUpdate;
+            }
+
+            public static IUniTaskSource Create(Tween tween, TweenCancelBehaviour cancelBehaviour, CancellationToken cancellationToken, CallbackType callbackType, out short token)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    DoCancelBeforeCreate(tween, cancelBehaviour);
+                    return AutoResetUniTaskCompletionSource.CreateFromCanceled(cancellationToken, out token);
+                }
+
+                if (!pool.TryPop(out var result))
+                {
+                    result = new TweenConfiguredSource();
+                }
+
+                result.tween = tween;
+                result.cancelBehaviour = cancelBehaviour;
+                result.cancellationToken = cancellationToken;
+                result.callbackType = callbackType;
+
+                result.originalUpdateAction = tween.onUpdate;
+                result.canceled = false;
+
+                if (result.originalUpdateAction == result.onUpdateDelegate)
+                {
+                    result.originalUpdateAction = null;
+                }
+
+                tween.onUpdate = result.onUpdateDelegate;
+
+                switch (callbackType)
+                {
+                    case CallbackType.Kill:
+                        result.originalCompleteAction = tween.onKill;
+                        tween.onKill = result.onCompleteCallbackDelegate;
+                        break;
+                    case CallbackType.Complete:
+                        result.originalCompleteAction = tween.onComplete;
+                        tween.onComplete = result.onCompleteCallbackDelegate;
+                        break;
+                    case CallbackType.Pause:
+                        result.originalCompleteAction = tween.onPause;
+                        tween.onPause = result.onCompleteCallbackDelegate;
+                        break;
+                    case CallbackType.Play:
+                        result.originalCompleteAction = tween.onPlay;
+                        tween.onPlay = result.onCompleteCallbackDelegate;
+                        break;
+                    case CallbackType.Rewind:
+                        result.originalCompleteAction = tween.onRewind;
+                        tween.onRewind = result.onCompleteCallbackDelegate;
+                        break;
+                    case CallbackType.StepComplete:
+                        result.originalCompleteAction = tween.onStepComplete;
+                        tween.onStepComplete = result.onCompleteCallbackDelegate;
+                        break;
+                    default:
+                        break;
+                }
+
+                if (result.originalCompleteAction == result.onCompleteCallbackDelegate)
+                {
+                    result.originalCompleteAction = null;
+                }
+
+                TaskTracker.TrackActiveTask(result, 3);
+
+                token = result.core.Version;
+                return result;
+            }
+
+            void OnCompleteCallbackDelegate()
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    if (this.cancelBehaviour == TweenCancelBehaviour.KillAndCancelAwait
+                        || this.cancelBehaviour == TweenCancelBehaviour.KillWithCompleteCallbackAndCancelAwait
+                        || this.cancelBehaviour == TweenCancelBehaviour.CompleteAndCancelAwait
+                        || this.cancelBehaviour == TweenCancelBehaviour.CompleteWithSequenceCallbackAndCancelAwait
+                        || this.cancelBehaviour == TweenCancelBehaviour.CancelAwait)
+                    {
+                        canceled = true;
+                    }
+                }
+                if (canceled)
+                {
+                    core.TrySetCanceled(cancellationToken);
+                }
+                else
+                {
+                    originalCompleteAction?.Invoke();
+                    core.TrySetResult(AsyncUnit.Default);
+                }
+            }
+
+            void OnUpdate()
+            {
+                originalUpdateAction?.Invoke();
+
+                if (!cancellationToken.IsCancellationRequested)
+                {
+                    return;
+                }
+
+                switch (this.cancelBehaviour)
+                {
+                    case TweenCancelBehaviour.Kill:
+                    default:
+                        this.tween.Kill(false);
+                        break;
+                    case TweenCancelBehaviour.KillAndCancelAwait:
+                        this.canceled = true;
+                        this.tween.Kill(false);
+                        break;
+                    case TweenCancelBehaviour.KillWithCompleteCallback:
+                        this.tween.Kill(true);
+                        break;
+                    case TweenCancelBehaviour.KillWithCompleteCallbackAndCancelAwait:
+                        this.canceled = true;
+                        this.tween.Kill(true);
+                        break;
+                    case TweenCancelBehaviour.Complete:
+                        this.tween.Complete(false);
+                        break;
+                    case TweenCancelBehaviour.CompleteAndCancelAwait:
+                        this.canceled = true;
+                        this.tween.Complete(false);
+                        break;
+                    case TweenCancelBehaviour.CompleteWithSequenceCallback:
+                        this.tween.Complete(true);
+                        break;
+                    case TweenCancelBehaviour.CompleteWithSequenceCallbackAndCancelAwait:
+                        this.canceled = true;
+                        this.tween.Complete(true);
+                        break;
+                    case TweenCancelBehaviour.CancelAwait:
+                        // restore to original callback
+                        switch (callbackType)
+                        {
+                            case CallbackType.Kill:
+                                tween.onKill = originalCompleteAction;
+                                break;
+                            case CallbackType.Complete:
+                                tween.onComplete = originalCompleteAction;
+                                break;
+                            case CallbackType.Pause:
+                                tween.onPause = originalCompleteAction;
+                                break;
+                            case CallbackType.Play:
+                                tween.onPlay = originalCompleteAction;
+                                break;
+                            case CallbackType.Rewind:
+                                tween.onRewind = originalCompleteAction;
+                                break;
+                            case CallbackType.StepComplete:
+                                tween.onStepComplete = originalCompleteAction;
+                                break;
+                            default:
+                                break;
+                        }
+
+                        this.core.TrySetCanceled(this.cancellationToken);
+                        break;
+                }
+            }
+
+            static void DoCancelBeforeCreate(Tween tween, TweenCancelBehaviour tweenCancelBehaviour)
+            {
+
+                switch (tweenCancelBehaviour)
+                {
+                    case TweenCancelBehaviour.Kill:
+                    default:
+                        tween.Kill(false);
+                        break;
+                    case TweenCancelBehaviour.KillAndCancelAwait:
+                        tween.Kill(false);
+                        break;
+                    case TweenCancelBehaviour.KillWithCompleteCallback:
+                        tween.Kill(true);
+                        break;
+                    case TweenCancelBehaviour.KillWithCompleteCallbackAndCancelAwait:
+                        tween.Kill(true);
+                        break;
+                    case TweenCancelBehaviour.Complete:
+                        tween.Complete(false);
+                        break;
+                    case TweenCancelBehaviour.CompleteAndCancelAwait:
+                        tween.Complete(false);
+                        break;
+                    case TweenCancelBehaviour.CompleteWithSequenceCallback:
+                        tween.Complete(true);
+                        break;
+                    case TweenCancelBehaviour.CompleteWithSequenceCallbackAndCancelAwait:
+                        tween.Complete(true);
+                        break;
+                    case TweenCancelBehaviour.CancelAwait:
+                        break;
+                }
+            }
+
+            public void GetResult(short token)
+            {
+                try
+                {
+                    core.GetResult(token);
+                }
+                finally
+                {
+                    TryReturn();
+                }
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+
+            bool TryReturn()
+            {
+                TaskTracker.RemoveTracking(this);
+                core.Reset();
+                tween.onUpdate = originalUpdateAction;
+
+                switch (callbackType)
+                {
+                    case CallbackType.Kill:
+                        tween.onKill = originalCompleteAction;
+                        break;
+                    case CallbackType.Complete:
+                        tween.onComplete = originalCompleteAction;
+                        break;
+                    case CallbackType.Pause:
+                        tween.onPause = originalCompleteAction;
+                        break;
+                    case CallbackType.Play:
+                        tween.onPlay = originalCompleteAction;
+                        break;
+                    case CallbackType.Rewind:
+                        tween.onRewind = originalCompleteAction;
+                        break;
+                    case CallbackType.StepComplete:
+                        tween.onStepComplete = originalCompleteAction;
+                        break;
+                    default:
+                        break;
+                }
+
+                tween = default;
+                cancellationToken = default;
+                originalUpdateAction = default;
+                originalCompleteAction = default;
+                return pool.TryPush(this);
+            }
+        }
+    }
+
+    sealed class PooledTweenCallback
+    {
+        static readonly ConcurrentQueue<PooledTweenCallback> pool = new ConcurrentQueue<PooledTweenCallback>();
+
+        readonly TweenCallback runDelegate;
+
+        Action continuation;
+
+
+        PooledTweenCallback()
+        {
+            runDelegate = Run;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static TweenCallback Create(Action continuation)
+        {
+            if (!pool.TryDequeue(out var item))
+            {
+                item = new PooledTweenCallback();
+            }
+
+            item.continuation = continuation;
+            return item.runDelegate;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        void Run()
+        {
+            var call = continuation;
+            continuation = null;
+            if (call != null)
+            {
+                pool.Enqueue(this);
+                call.Invoke();
+            }
+        }
+    }
+}
+
+#endif

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/External/DOTween/DOTweenAsyncExtensions.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/External/DOTween/DOTweenAsyncExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1f448d5bc5b232e4f98d89d5d1832e8e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/External/DOTween/UniTask.DOTween.asmdef
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/External/DOTween/UniTask.DOTween.asmdef
@@ -1,0 +1,22 @@
+{
+    "name": "UniTask.DOTween",
+    "references": [
+        "UniTask",
+        "DOTween.Modules"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [
+        {
+            "name": "com.demigiant.dotween",
+            "expression": "",
+            "define": "UNITASK_DOTWEEN_SUPPORT"
+        }
+    ],
+    "noEngineReferences": false
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/External/DOTween/UniTask.DOTween.asmdef.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/External/DOTween/UniTask.DOTween.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 029c1c1b674aaae47a6841a0b89ad80e
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/External/TextMeshPro.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/External/TextMeshPro.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1c9a91ed9e01d3447b98f0b4d30ee499
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/External/TextMeshPro/TextMeshProAsyncExtensions.InputField.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/External/TextMeshPro/TextMeshProAsyncExtensions.InputField.cs
@@ -1,0 +1,224 @@
+﻿#if UNITASK_TEXTMESHPRO_SUPPORT
+
+using System;
+using System.Threading;
+using TMPro;
+
+namespace Cysharp.Threading.Tasks
+{
+    public static partial class TextMeshProAsyncExtensions
+    {
+        public static IAsyncValueChangedEventHandler<string> GetAsyncValueChangedEventHandler(this TMP_InputField inputField)
+        {
+            return new AsyncUnityEventHandler<string>(inputField.onValueChanged, inputField.GetCancellationTokenOnDestroy(), false);
+        }
+
+        public static IAsyncValueChangedEventHandler<string> GetAsyncValueChangedEventHandler(this TMP_InputField inputField, CancellationToken cancellationToken)
+        {
+            return new AsyncUnityEventHandler<string>(inputField.onValueChanged, cancellationToken, false);
+        }
+
+        public static UniTask<string> OnValueChangedAsync(this TMP_InputField inputField)
+        {
+            return new AsyncUnityEventHandler<string>(inputField.onValueChanged, inputField.GetCancellationTokenOnDestroy(), true).OnInvokeAsync();
+        }
+
+        public static UniTask<string> OnValueChangedAsync(this TMP_InputField inputField, CancellationToken cancellationToken)
+        {
+            return new AsyncUnityEventHandler<string>(inputField.onValueChanged, cancellationToken, true).OnInvokeAsync();
+        }
+
+        public static IUniTaskAsyncEnumerable<string> OnValueChangedAsAsyncEnumerable(this TMP_InputField inputField)
+        {
+            return new UnityEventHandlerAsyncEnumerable<string>(inputField.onValueChanged, inputField.GetCancellationTokenOnDestroy());
+        }
+
+        public static IUniTaskAsyncEnumerable<string> OnValueChangedAsAsyncEnumerable(this TMP_InputField inputField, CancellationToken cancellationToken)
+        {
+            return new UnityEventHandlerAsyncEnumerable<string>(inputField.onValueChanged, cancellationToken);
+        }
+
+        public static IAsyncEndEditEventHandler<string> GetAsyncEndEditEventHandler(this TMP_InputField inputField)
+        {
+            return new AsyncUnityEventHandler<string>(inputField.onEndEdit, inputField.GetCancellationTokenOnDestroy(), false);
+        }
+
+        public static IAsyncEndEditEventHandler<string> GetAsyncEndEditEventHandler(this TMP_InputField inputField, CancellationToken cancellationToken)
+        {
+            return new AsyncUnityEventHandler<string>(inputField.onEndEdit, cancellationToken, false);
+        }
+
+        public static UniTask<string> OnEndEditAsync(this TMP_InputField inputField)
+        {
+            return new AsyncUnityEventHandler<string>(inputField.onEndEdit, inputField.GetCancellationTokenOnDestroy(), true).OnInvokeAsync();
+        }
+
+        public static UniTask<string> OnEndEditAsync(this TMP_InputField inputField, CancellationToken cancellationToken)
+        {
+            return new AsyncUnityEventHandler<string>(inputField.onEndEdit, cancellationToken, true).OnInvokeAsync();
+        }
+
+        public static IUniTaskAsyncEnumerable<string> OnEndEditAsAsyncEnumerable(this TMP_InputField inputField)
+        {
+            return new UnityEventHandlerAsyncEnumerable<string>(inputField.onEndEdit, inputField.GetCancellationTokenOnDestroy());
+        }
+
+        public static IUniTaskAsyncEnumerable<string> OnEndEditAsAsyncEnumerable(this TMP_InputField inputField, CancellationToken cancellationToken)
+        {
+            return new UnityEventHandlerAsyncEnumerable<string>(inputField.onEndEdit, cancellationToken);
+        }
+
+        public static IAsyncEndTextSelectionEventHandler<(string, int, int)> GetAsyncEndTextSelectionEventHandler(this TMP_InputField inputField)
+        {
+            return new AsyncUnityEventHandler<(string, int, int)>(new TextSelectionEventConverter(inputField.onEndTextSelection), inputField.GetCancellationTokenOnDestroy(), false);
+        }
+
+        public static IAsyncEndTextSelectionEventHandler<(string, int, int)> GetAsyncEndTextSelectionEventHandler(this TMP_InputField inputField, CancellationToken cancellationToken)
+        {
+            return new AsyncUnityEventHandler<(string, int, int)>(new TextSelectionEventConverter(inputField.onEndTextSelection), cancellationToken, false);
+        }
+
+        public static UniTask<(string, int, int)> OnEndTextSelectionAsync(this TMP_InputField inputField)
+        {
+            return new AsyncUnityEventHandler<(string, int, int)>(new TextSelectionEventConverter(inputField.onEndTextSelection), inputField.GetCancellationTokenOnDestroy(), true).OnInvokeAsync();
+        }
+
+        public static UniTask<(string, int, int)> OnEndTextSelectionAsync(this TMP_InputField inputField, CancellationToken cancellationToken)
+        {
+            return new AsyncUnityEventHandler<(string, int, int)>(new TextSelectionEventConverter(inputField.onEndTextSelection), cancellationToken, true).OnInvokeAsync();
+        }
+
+        public static IUniTaskAsyncEnumerable<(string, int, int)> OnEndTextSelectionAsAsyncEnumerable(this TMP_InputField inputField)
+        {
+            return new UnityEventHandlerAsyncEnumerable<(string, int, int)>(new TextSelectionEventConverter(inputField.onEndTextSelection), inputField.GetCancellationTokenOnDestroy());
+        }
+
+        public static IUniTaskAsyncEnumerable<(string, int, int)> OnEndTextSelectionAsAsyncEnumerable(this TMP_InputField inputField, CancellationToken cancellationToken)
+        {
+            return new UnityEventHandlerAsyncEnumerable<(string, int, int)>(new TextSelectionEventConverter(inputField.onEndTextSelection), cancellationToken);
+        }
+
+        public static IAsyncTextSelectionEventHandler<(string, int, int)> GetAsyncTextSelectionEventHandler(this TMP_InputField inputField)
+        {
+            return new AsyncUnityEventHandler<(string, int, int)>(new TextSelectionEventConverter(inputField.onTextSelection), inputField.GetCancellationTokenOnDestroy(), false);
+        }
+
+        public static IAsyncTextSelectionEventHandler<(string, int, int)> GetAsyncTextSelectionEventHandler(this TMP_InputField inputField, CancellationToken cancellationToken)
+        {
+            return new AsyncUnityEventHandler<(string, int, int)>(new TextSelectionEventConverter(inputField.onTextSelection), cancellationToken, false);
+        }
+
+        public static UniTask<(string, int, int)> OnTextSelectionAsync(this TMP_InputField inputField)
+        {
+            return new AsyncUnityEventHandler<(string, int, int)>(new TextSelectionEventConverter(inputField.onTextSelection), inputField.GetCancellationTokenOnDestroy(), true).OnInvokeAsync();
+        }
+
+        public static UniTask<(string, int, int)> OnTextSelectionAsync(this TMP_InputField inputField, CancellationToken cancellationToken)
+        {
+            return new AsyncUnityEventHandler<(string, int, int)>(new TextSelectionEventConverter(inputField.onTextSelection), cancellationToken, true).OnInvokeAsync();
+        }
+
+        public static IUniTaskAsyncEnumerable<(string, int, int)> OnTextSelectionAsAsyncEnumerable(this TMP_InputField inputField)
+        {
+            return new UnityEventHandlerAsyncEnumerable<(string, int, int)>(new TextSelectionEventConverter(inputField.onTextSelection), inputField.GetCancellationTokenOnDestroy());
+        }
+
+        public static IUniTaskAsyncEnumerable<(string, int, int)> OnTextSelectionAsAsyncEnumerable(this TMP_InputField inputField, CancellationToken cancellationToken)
+        {
+            return new UnityEventHandlerAsyncEnumerable<(string, int, int)>(new TextSelectionEventConverter(inputField.onTextSelection), cancellationToken);
+        }
+
+        public static IAsyncDeselectEventHandler<string> GetAsyncDeselectEventHandler(this TMP_InputField inputField)
+        {
+            return new AsyncUnityEventHandler<string>(inputField.onDeselect, inputField.GetCancellationTokenOnDestroy(), false);
+        }
+
+        public static IAsyncDeselectEventHandler<string> GetAsyncDeselectEventHandler(this TMP_InputField inputField, CancellationToken cancellationToken)
+        {
+            return new AsyncUnityEventHandler<string>(inputField.onDeselect, cancellationToken, false);
+        }
+
+        public static UniTask<string> OnDeselectAsync(this TMP_InputField inputField)
+        {
+            return new AsyncUnityEventHandler<string>(inputField.onDeselect, inputField.GetCancellationTokenOnDestroy(), true).OnInvokeAsync();
+        }
+
+        public static UniTask<string> OnDeselectAsync(this TMP_InputField inputField, CancellationToken cancellationToken)
+        {
+            return new AsyncUnityEventHandler<string>(inputField.onDeselect, cancellationToken, true).OnInvokeAsync();
+        }
+
+        public static IUniTaskAsyncEnumerable<string> OnDeselectAsAsyncEnumerable(this TMP_InputField inputField)
+        {
+            return new UnityEventHandlerAsyncEnumerable<string>(inputField.onDeselect, inputField.GetCancellationTokenOnDestroy());
+        }
+
+        public static IUniTaskAsyncEnumerable<string> OnDeselectAsAsyncEnumerable(this TMP_InputField inputField, CancellationToken cancellationToken)
+        {
+            return new UnityEventHandlerAsyncEnumerable<string>(inputField.onDeselect, cancellationToken);
+        }
+
+        public static IAsyncSelectEventHandler<string> GetAsyncSelectEventHandler(this TMP_InputField inputField)
+        {
+            return new AsyncUnityEventHandler<string>(inputField.onSelect, inputField.GetCancellationTokenOnDestroy(), false);
+        }
+
+        public static IAsyncSelectEventHandler<string> GetAsyncSelectEventHandler(this TMP_InputField inputField, CancellationToken cancellationToken)
+        {
+            return new AsyncUnityEventHandler<string>(inputField.onSelect, cancellationToken, false);
+        }
+
+        public static UniTask<string> OnSelectAsync(this TMP_InputField inputField)
+        {
+            return new AsyncUnityEventHandler<string>(inputField.onSelect, inputField.GetCancellationTokenOnDestroy(), true).OnInvokeAsync();
+        }
+
+        public static UniTask<string> OnSelectAsync(this TMP_InputField inputField, CancellationToken cancellationToken)
+        {
+            return new AsyncUnityEventHandler<string>(inputField.onSelect, cancellationToken, true).OnInvokeAsync();
+        }
+
+        public static IUniTaskAsyncEnumerable<string> OnSelectAsAsyncEnumerable(this TMP_InputField inputField)
+        {
+            return new UnityEventHandlerAsyncEnumerable<string>(inputField.onSelect, inputField.GetCancellationTokenOnDestroy());
+        }
+
+        public static IUniTaskAsyncEnumerable<string> OnSelectAsAsyncEnumerable(this TMP_InputField inputField, CancellationToken cancellationToken)
+        {
+            return new UnityEventHandlerAsyncEnumerable<string>(inputField.onSelect, cancellationToken);
+        }
+
+        public static IAsyncSubmitEventHandler<string> GetAsyncSubmitEventHandler(this TMP_InputField inputField)
+        {
+            return new AsyncUnityEventHandler<string>(inputField.onSubmit, inputField.GetCancellationTokenOnDestroy(), false);
+        }
+
+        public static IAsyncSubmitEventHandler<string> GetAsyncSubmitEventHandler(this TMP_InputField inputField, CancellationToken cancellationToken)
+        {
+            return new AsyncUnityEventHandler<string>(inputField.onSubmit, cancellationToken, false);
+        }
+
+        public static UniTask<string> OnSubmitAsync(this TMP_InputField inputField)
+        {
+            return new AsyncUnityEventHandler<string>(inputField.onSubmit, inputField.GetCancellationTokenOnDestroy(), true).OnInvokeAsync();
+        }
+
+        public static UniTask<string> OnSubmitAsync(this TMP_InputField inputField, CancellationToken cancellationToken)
+        {
+            return new AsyncUnityEventHandler<string>(inputField.onSubmit, cancellationToken, true).OnInvokeAsync();
+        }
+
+        public static IUniTaskAsyncEnumerable<string> OnSubmitAsAsyncEnumerable(this TMP_InputField inputField)
+        {
+            return new UnityEventHandlerAsyncEnumerable<string>(inputField.onSubmit, inputField.GetCancellationTokenOnDestroy());
+        }
+
+        public static IUniTaskAsyncEnumerable<string> OnSubmitAsAsyncEnumerable(this TMP_InputField inputField, CancellationToken cancellationToken)
+        {
+            return new UnityEventHandlerAsyncEnumerable<string>(inputField.onSubmit, cancellationToken);
+        }
+
+    }
+}
+
+#endif

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/External/TextMeshPro/TextMeshProAsyncExtensions.InputField.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/External/TextMeshPro/TextMeshProAsyncExtensions.InputField.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 79f4f2475e0b2c44e97ed1dee760627b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/External/TextMeshPro/TextMeshProAsyncExtensions.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/External/TextMeshPro/TextMeshProAsyncExtensions.cs
@@ -1,0 +1,130 @@
+﻿#if UNITASK_TEXTMESHPRO_SUPPORT
+
+using System;
+using System.Threading;
+using TMPro;
+using UnityEngine.Events;
+
+namespace Cysharp.Threading.Tasks
+{
+    public static partial class TextMeshProAsyncExtensions
+    {
+        // <string> -> Text
+        public static void BindTo(this IUniTaskAsyncEnumerable<string> source, TMP_Text text, bool rebindOnError = true)
+        {
+            BindToCore(source, text, text.GetCancellationTokenOnDestroy(), rebindOnError).Forget();
+        }
+
+        public static void BindTo(this IUniTaskAsyncEnumerable<string> source, TMP_Text text, CancellationToken cancellationToken, bool rebindOnError = true)
+        {
+            BindToCore(source, text, cancellationToken, rebindOnError).Forget();
+        }
+
+        static async UniTaskVoid BindToCore(IUniTaskAsyncEnumerable<string> source, TMP_Text text, CancellationToken cancellationToken, bool rebindOnError)
+        {
+            var repeat = false;
+            BIND_AGAIN:
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (true)
+                {
+                    bool moveNext;
+                    try
+                    {
+                        moveNext = await e.MoveNextAsync();
+                        repeat = false;
+                    }
+                    catch (Exception ex)
+                    {
+                        if (ex is OperationCanceledException) return;
+
+                        if (rebindOnError && !repeat)
+                        {
+                            repeat = true;
+                            goto BIND_AGAIN;
+                        }
+                        else
+                        {
+                            throw;
+                        }
+                    }
+
+                    if (!moveNext) return;
+
+                    text.text = e.Current;
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+        }
+
+        // <T> -> Text
+
+        public static void BindTo<T>(this IUniTaskAsyncEnumerable<T> source, TMP_Text text, bool rebindOnError = true)
+        {
+            BindToCore(source, text, text.GetCancellationTokenOnDestroy(), rebindOnError).Forget();
+        }
+
+        public static void BindTo<T>(this IUniTaskAsyncEnumerable<T> source, TMP_Text text, CancellationToken cancellationToken, bool rebindOnError = true)
+        {
+            BindToCore(source, text, cancellationToken, rebindOnError).Forget();
+        }
+
+        public static void BindTo<T>(this AsyncReactiveProperty<T> source, TMP_Text text, bool rebindOnError = true)
+        {
+            BindToCore(source, text, text.GetCancellationTokenOnDestroy(), rebindOnError).Forget();
+        }
+
+        static async UniTaskVoid BindToCore<T>(IUniTaskAsyncEnumerable<T> source, TMP_Text text, CancellationToken cancellationToken, bool rebindOnError)
+        {
+            var repeat = false;
+            BIND_AGAIN:
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (true)
+                {
+                    bool moveNext;
+                    try
+                    {
+                        moveNext = await e.MoveNextAsync();
+                        repeat = false;
+                    }
+                    catch (Exception ex)
+                    {
+                        if (ex is OperationCanceledException) return;
+
+                        if (rebindOnError && !repeat)
+                        {
+                            repeat = true;
+                            goto BIND_AGAIN;
+                        }
+                        else
+                        {
+                            throw;
+                        }
+                    }
+
+                    if (!moveNext) return;
+
+                    text.text = e.Current.ToString();
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/External/TextMeshPro/TextMeshProAsyncExtensions.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/External/TextMeshPro/TextMeshProAsyncExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b6ba480edafb67d4e91bb10feb64fae5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/External/TextMeshPro/UniTask.TextMeshPro.asmdef
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/External/TextMeshPro/UniTask.TextMeshPro.asmdef
@@ -1,0 +1,22 @@
+{
+    "name": "UniTask.TextMeshPro",
+    "references": [
+        "UniTask",
+        "Unity.TextMeshPro"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.textmeshpro",
+            "expression": "",
+            "define": "UNITASK_TEXTMESHPRO_SUPPORT"
+        }
+    ],
+    "noEngineReferences": false
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/External/TextMeshPro/UniTask.TextMeshPro.asmdef.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/External/TextMeshPro/UniTask.TextMeshPro.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: dc47925d1a5fa2946bdd37746b2b5d48
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/IUniTaskAsyncEnumerable.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/IUniTaskAsyncEnumerable.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks
+{
+    public interface IUniTaskAsyncEnumerable<out T>
+    {
+        IUniTaskAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default);
+    }
+
+    public interface IUniTaskAsyncEnumerator<out T> : IUniTaskAsyncDisposable
+    {
+        T Current { get; }
+        UniTask<bool> MoveNextAsync();
+    }
+
+    public interface IUniTaskAsyncDisposable
+    {
+        UniTask DisposeAsync();
+    }
+
+    public interface IUniTaskOrderedAsyncEnumerable<TElement> : IUniTaskAsyncEnumerable<TElement>
+    {
+        IUniTaskOrderedAsyncEnumerable<TElement> CreateOrderedEnumerable<TKey>(Func<TElement, TKey> keySelector, IComparer<TKey> comparer, bool descending);
+        IUniTaskOrderedAsyncEnumerable<TElement> CreateOrderedEnumerable<TKey>(Func<TElement, UniTask<TKey>> keySelector, IComparer<TKey> comparer, bool descending);
+        IUniTaskOrderedAsyncEnumerable<TElement> CreateOrderedEnumerable<TKey>(Func<TElement, CancellationToken, UniTask<TKey>> keySelector, IComparer<TKey> comparer, bool descending);
+    }
+
+    public interface IConnectableUniTaskAsyncEnumerable<out T> : IUniTaskAsyncEnumerable<T>
+    {
+        IDisposable Connect();
+    }
+
+    // don't use AsyncGrouping.
+    //public interface IUniTaskAsyncGrouping<out TKey, out TElement> : IUniTaskAsyncEnumerable<TElement>
+    //{
+    //    TKey Key { get; }
+    //}
+
+    public static class UniTaskAsyncEnumerableExtensions
+    {
+        public static UniTaskCancelableAsyncEnumerable<T> WithCancellation<T>(this IUniTaskAsyncEnumerable<T> source, CancellationToken cancellationToken)
+        {
+            return new UniTaskCancelableAsyncEnumerable<T>(source, cancellationToken);
+        }
+    }
+
+    [StructLayout(LayoutKind.Auto)]
+    public readonly struct UniTaskCancelableAsyncEnumerable<T>
+    {
+        private readonly IUniTaskAsyncEnumerable<T> enumerable;
+        private readonly CancellationToken cancellationToken;
+
+        internal UniTaskCancelableAsyncEnumerable(IUniTaskAsyncEnumerable<T> enumerable, CancellationToken cancellationToken)
+        {
+            this.enumerable = enumerable;
+            this.cancellationToken = cancellationToken;
+        }
+
+        public Enumerator GetAsyncEnumerator()
+        {
+            return new Enumerator(enumerable.GetAsyncEnumerator(cancellationToken));
+        }
+
+        [StructLayout(LayoutKind.Auto)]
+        public readonly struct Enumerator
+        {
+            private readonly IUniTaskAsyncEnumerator<T> enumerator;
+
+            internal Enumerator(IUniTaskAsyncEnumerator<T> enumerator)
+            {
+                this.enumerator = enumerator;
+            }
+
+            public T Current => enumerator.Current;
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                return enumerator.MoveNextAsync();
+            }
+
+
+            public UniTask DisposeAsync()
+            {
+                return enumerator.DisposeAsync();
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/IUniTaskAsyncEnumerable.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/IUniTaskAsyncEnumerable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b20cf9f02ac585948a4372fa4ee06504
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/IUniTaskSource.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/IUniTaskSource.cs
@@ -1,0 +1,124 @@
+﻿#pragma warning disable CS1591
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Cysharp.Threading.Tasks
+{
+    public enum UniTaskStatus
+    {
+        /// <summary>The operation has not yet completed.</summary>
+        Pending = 0,
+        /// <summary>The operation completed successfully.</summary>
+        Succeeded = 1,
+        /// <summary>The operation completed with an error.</summary>
+        Faulted = 2,
+        /// <summary>The operation completed due to cancellation.</summary>
+        Canceled = 3
+    }
+
+    // similar as IValueTaskSource
+    public interface IUniTaskSource
+#if !UNITY_2018_3_OR_NEWER && !NETSTANDARD2_0
+        : System.Threading.Tasks.Sources.IValueTaskSource
+#pragma warning disable CS0108
+#endif
+    {
+        UniTaskStatus GetStatus(short token);
+        void OnCompleted(Action<object> continuation, object state, short token);
+        void GetResult(short token);
+
+        UniTaskStatus UnsafeGetStatus(); // only for debug use.
+
+#if !UNITY_2018_3_OR_NEWER && !NETSTANDARD2_0
+#pragma warning restore CS0108
+
+        System.Threading.Tasks.Sources.ValueTaskSourceStatus System.Threading.Tasks.Sources.IValueTaskSource.GetStatus(short token)
+        {
+            return (System.Threading.Tasks.Sources.ValueTaskSourceStatus)(int)((IUniTaskSource)this).GetStatus(token);
+        }
+
+        void System.Threading.Tasks.Sources.IValueTaskSource.GetResult(short token)
+        {
+            ((IUniTaskSource)this).GetResult(token);
+        }
+
+        void System.Threading.Tasks.Sources.IValueTaskSource.OnCompleted(Action<object> continuation, object state, short token, System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags flags)
+        {
+            // ignore flags, always none.
+            ((IUniTaskSource)this).OnCompleted(continuation, state, token);
+        }
+
+#endif
+    }
+
+    public interface IUniTaskSource<out T> : IUniTaskSource
+#if !UNITY_2018_3_OR_NEWER && !NETSTANDARD2_0
+        , System.Threading.Tasks.Sources.IValueTaskSource<T>
+#endif
+    {
+        new T GetResult(short token);
+
+#if !UNITY_2018_3_OR_NEWER && !NETSTANDARD2_0
+
+        new public UniTaskStatus GetStatus(short token)
+        {
+            return ((IUniTaskSource)this).GetStatus(token);
+        }
+
+        new public void OnCompleted(Action<object> continuation, object state, short token)
+        {
+            ((IUniTaskSource)this).OnCompleted(continuation, state, token);
+        }
+
+        System.Threading.Tasks.Sources.ValueTaskSourceStatus System.Threading.Tasks.Sources.IValueTaskSource<T>.GetStatus(short token)
+        {
+            return (System.Threading.Tasks.Sources.ValueTaskSourceStatus)(int)((IUniTaskSource)this).GetStatus(token);
+        }
+
+        T System.Threading.Tasks.Sources.IValueTaskSource<T>.GetResult(short token)
+        {
+            return ((IUniTaskSource<T>)this).GetResult(token);
+        }
+
+        void System.Threading.Tasks.Sources.IValueTaskSource<T>.OnCompleted(Action<object> continuation, object state, short token, System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags flags)
+        {
+            // ignore flags, always none.
+            ((IUniTaskSource)this).OnCompleted(continuation, state, token);
+        }
+
+#endif
+    }
+
+    public static class UniTaskStatusExtensions
+    {
+        /// <summary>status != Pending.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsCompleted(this UniTaskStatus status)
+        {
+            return status != UniTaskStatus.Pending;
+        }
+
+        /// <summary>status == Succeeded.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsCompletedSuccessfully(this UniTaskStatus status)
+        {
+            return status == UniTaskStatus.Succeeded;
+        }
+
+        /// <summary>status == Canceled.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsCanceled(this UniTaskStatus status)
+        {
+            return status == UniTaskStatus.Canceled;
+        }
+
+        /// <summary>status == Faulted.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsFaulted(this UniTaskStatus status)
+        {
+            return status == UniTaskStatus.Faulted;
+        }
+    }
+}
+

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/IUniTaskSource.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/IUniTaskSource.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3e4d023d8404ab742b5e808c98097c3c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Internal.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Internal.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2afe36150a2e01f4ca5219ae20f6afa7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/ArrayPool.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/ArrayPool.cs
@@ -1,0 +1,150 @@
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Internal
+{
+    // Same interface as System.Buffers.ArrayPool<T> but only provides Shared.
+
+    internal sealed class ArrayPool<T>
+    {
+        // Same size as System.Buffers.DefaultArrayPool<T>
+        const int DefaultMaxNumberOfArraysPerBucket = 50;
+
+        static readonly T[] EmptyArray = new T[0];
+
+        public static readonly ArrayPool<T> Shared = new ArrayPool<T>();
+
+        readonly MinimumQueue<T[]>[] buckets;
+        readonly SpinLock[] locks;
+
+        ArrayPool()
+        {
+            // see: GetQueueIndex
+            buckets = new MinimumQueue<T[]>[18];
+            locks = new SpinLock[18];
+            for (int i = 0; i < buckets.Length; i++)
+            {
+                buckets[i] = new MinimumQueue<T[]>(4);
+                locks[i] = new SpinLock(false);
+            }
+        }
+
+        public T[] Rent(int minimumLength)
+        {
+            if (minimumLength < 0)
+            {
+                throw new ArgumentOutOfRangeException("minimumLength");
+            }
+            else if (minimumLength == 0)
+            {
+                return EmptyArray;
+            }
+
+            var size = CalculateSize(minimumLength);
+            var index = GetQueueIndex(size);
+            if (index != -1)
+            {
+                var q = buckets[index];
+                var lockTaken = false;
+                try
+                {
+                    locks[index].Enter(ref lockTaken);
+
+                    if (q.Count != 0)
+                    {
+                        return q.Dequeue();
+                    }
+                }
+                finally
+                {
+                    if (lockTaken) locks[index].Exit(false);
+                }
+            }
+
+            return new T[size];
+        }
+
+        public void Return(T[] array, bool clearArray = false)
+        {
+            if (array == null || array.Length == 0)
+            {
+                return;
+            }
+
+            var index = GetQueueIndex(array.Length);
+            if (index != -1)
+            {
+                if (clearArray)
+                {
+                    Array.Clear(array, 0, array.Length);
+                }
+
+                var q = buckets[index];
+                var lockTaken = false;
+
+                try
+                {
+                    locks[index].Enter(ref lockTaken);
+
+                    if (q.Count > DefaultMaxNumberOfArraysPerBucket)
+                    {
+                        return;
+                    }
+
+                    q.Enqueue(array);
+                }
+                finally
+                {
+                    if (lockTaken) locks[index].Exit(false);
+                }
+            }
+        }
+
+        static int CalculateSize(int size)
+        {
+            size--;
+            size |= size >> 1;
+            size |= size >> 2;
+            size |= size >> 4;
+            size |= size >> 8;
+            size |= size >> 16;
+            size += 1;
+
+            if (size < 8)
+            {
+                size = 8;
+            }
+
+            return size;
+        }
+
+        static int GetQueueIndex(int size)
+        {
+            switch (size)
+            {
+                case 8: return 0;
+                case 16: return 1;
+                case 32: return 2;
+                case 64: return 3;
+                case 128: return 4;
+                case 256: return 5;
+                case 512: return 6;
+                case 1024: return 7;
+                case 2048: return 8;
+                case 4096: return 9;
+                case 8192: return 10;
+                case 16384: return 11;
+                case 32768: return 12;
+                case 65536: return 13;
+                case 131072: return 14;
+                case 262144: return 15;
+                case 524288: return 16;
+                case 1048576: return 17; // max array length
+                default:
+                    return -1;
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/ArrayPool.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/ArrayPool.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: f83ebad81fb89fb4882331616ca6d248
+timeCreated: 1532361008
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/ArrayPoolUtil.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/ArrayPoolUtil.cs
@@ -1,0 +1,115 @@
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace Cysharp.Threading.Tasks.Internal
+{
+    internal static class ArrayPoolUtil
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static void EnsureCapacity<T>(ref T[] array, int index, ArrayPool<T> pool)
+        {
+            if (array.Length <= index)
+            {
+                EnsureCapacityCore(ref array, index, pool);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void EnsureCapacityCore<T>(ref T[] array, int index, ArrayPool<T> pool)
+        {
+            if (array.Length <= index)
+            {
+                var newSize = array.Length * 2;
+                var newArray = pool.Rent((index < newSize) ? newSize : (index * 2));
+                Array.Copy(array, 0, newArray, 0, array.Length);
+
+                pool.Return(array, clearArray: !RuntimeHelpersAbstraction.IsWellKnownNoReferenceContainsType<T>());
+
+                array = newArray;
+            }
+        }
+
+        public static RentArray<T> Materialize<T>(IEnumerable<T> source)
+        {
+            if (source is T[] array)
+            {
+                return new RentArray<T>(array, array.Length, null);
+            }
+
+            var defaultCount = 32;
+            if (source is ICollection<T> coll)
+            {
+                if (coll.Count == 0)
+                {
+                    return new RentArray<T>(Array.Empty<T>(), 0, null);
+                }
+
+                defaultCount = coll.Count;
+                var pool = ArrayPool<T>.Shared;
+                var buffer = pool.Rent(defaultCount);
+                coll.CopyTo(buffer, 0);
+                return new RentArray<T>(buffer, coll.Count, pool);
+            }
+            else if (source is IReadOnlyCollection<T> rcoll)
+            {
+                defaultCount = rcoll.Count;
+            }
+
+            if (defaultCount == 0)
+            {
+                return new RentArray<T>(Array.Empty<T>(), 0, null);
+            }
+
+            {
+                var pool = ArrayPool<T>.Shared;
+
+                var index = 0;
+                var buffer = pool.Rent(defaultCount);
+                foreach (var item in source)
+                {
+                    EnsureCapacity(ref buffer, index, pool);
+                    buffer[index++] = item;
+                }
+
+                return new RentArray<T>(buffer, index, pool);
+            }
+        }
+
+        public struct RentArray<T> : IDisposable
+        {
+            public readonly T[] Array;
+            public readonly int Length;
+            ArrayPool<T> pool;
+
+            public RentArray(T[] array, int length, ArrayPool<T> pool)
+            {
+                this.Array = array;
+                this.Length = length;
+                this.pool = pool;
+            }
+
+            public void Dispose()
+            {
+                DisposeManually(!RuntimeHelpersAbstraction.IsWellKnownNoReferenceContainsType<T>());
+            }
+
+            public void DisposeManually(bool clearArray)
+            {
+                if (pool != null)
+                {
+                    if (clearArray)
+                    {
+                        System.Array.Clear(Array, 0, Length);
+                    }
+
+                    pool.Return(Array, clearArray: false);
+                    pool = null;
+                }
+            }
+        }
+    }
+}
+

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/ArrayPoolUtil.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/ArrayPoolUtil.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 424cc208fb61d4e448b08fcfa0eee25e
+timeCreated: 1532361007
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/ArrayUtil.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/ArrayUtil.cs
@@ -1,0 +1,73 @@
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace Cysharp.Threading.Tasks.Internal
+{
+    internal static class ArrayUtil
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void EnsureCapacity<T>(ref T[] array, int index)
+        {
+            if (array.Length <= index)
+            {
+                EnsureCore(ref array, index);
+            }
+        }
+
+        // rare case, no inlining.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void EnsureCore<T>(ref T[] array, int index)
+        {
+            var newSize = array.Length * 2;
+            var newArray = new T[(index < newSize) ? newSize : (index * 2)];
+            Array.Copy(array, 0, newArray, 0, array.Length);
+
+            array = newArray;
+        }
+
+        /// <summary>
+        /// Optimizing utility to avoid .ToArray() that creates buffer copy(cut to just size).
+        /// </summary>
+        public static (T[] array, int length) Materialize<T>(IEnumerable<T> source)
+        {
+            if (source is T[] array)
+            {
+                return (array, array.Length);
+            }
+
+            var defaultCount = 4;
+            if (source is ICollection<T> coll)
+            {
+                defaultCount = coll.Count;
+                var buffer = new T[defaultCount];
+                coll.CopyTo(buffer, 0);
+                return (buffer, defaultCount);
+            }
+            else if (source is IReadOnlyCollection<T> rcoll)
+            {
+                defaultCount = rcoll.Count;
+            }
+
+            if (defaultCount == 0)
+            {
+                return (Array.Empty<T>(), 0);
+            }
+
+            {
+                var index = 0;
+                var buffer = new T[defaultCount];
+                foreach (var item in source)
+                {
+                    EnsureCapacity(ref buffer, index);
+                    buffer[index++] = item;
+                }
+
+                return (buffer, index);
+            }
+        }
+    }
+}
+

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/ArrayUtil.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/ArrayUtil.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 23146a82ec99f2542a87971c8d3d7988
+timeCreated: 1532361007
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/ContinuationQueue.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/ContinuationQueue.cs
@@ -1,0 +1,225 @@
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Internal
+{
+    internal sealed class ContinuationQueue
+    {
+        const int MaxArrayLength = 0X7FEFFFFF;
+        const int InitialSize = 16;
+
+        readonly PlayerLoopTiming timing;
+
+        SpinLock gate = new SpinLock(false);
+        bool dequing = false;
+
+        int actionListCount = 0;
+        Action[] actionList = new Action[InitialSize];
+
+        int waitingListCount = 0;
+        Action[] waitingList = new Action[InitialSize];
+
+        public ContinuationQueue(PlayerLoopTiming timing)
+        {
+            this.timing = timing;
+        }
+
+        public void Enqueue(Action continuation)
+        {
+            bool lockTaken = false;
+            try
+            {
+                gate.Enter(ref lockTaken);
+
+                if (dequing)
+                {
+                    // Ensure Capacity
+                    if (waitingList.Length == waitingListCount)
+                    {
+                        var newLength = waitingListCount * 2;
+                        if ((uint)newLength > MaxArrayLength) newLength = MaxArrayLength;
+
+                        var newArray = new Action[newLength];
+                        Array.Copy(waitingList, newArray, waitingListCount);
+                        waitingList = newArray;
+                    }
+                    waitingList[waitingListCount] = continuation;
+                    waitingListCount++;
+                }
+                else
+                {
+                    // Ensure Capacity
+                    if (actionList.Length == actionListCount)
+                    {
+                        var newLength = actionListCount * 2;
+                        if ((uint)newLength > MaxArrayLength) newLength = MaxArrayLength;
+
+                        var newArray = new Action[newLength];
+                        Array.Copy(actionList, newArray, actionListCount);
+                        actionList = newArray;
+                    }
+                    actionList[actionListCount] = continuation;
+                    actionListCount++;
+                }
+            }
+            finally
+            {
+                if (lockTaken) gate.Exit(false);
+            }
+        }
+
+        public int Clear()
+        {
+            var rest = actionListCount + waitingListCount;
+
+            actionListCount = 0;
+            actionList = new Action[InitialSize];
+
+            waitingListCount = 0;
+            waitingList = new Action[InitialSize];
+
+            return rest;
+        }
+
+        // delegate entrypoint.
+        public void Run()
+        {
+            // for debugging, create named stacktrace.
+#if DEBUG
+            switch (timing)
+            {
+                case PlayerLoopTiming.Initialization:
+                    Initialization();
+                    break;
+                case PlayerLoopTiming.LastInitialization:
+                    LastInitialization();
+                    break;
+                case PlayerLoopTiming.EarlyUpdate:
+                    EarlyUpdate();
+                    break;
+                case PlayerLoopTiming.LastEarlyUpdate:
+                    LastEarlyUpdate();
+                    break;
+                case PlayerLoopTiming.FixedUpdate:
+                    FixedUpdate();
+                    break;
+                case PlayerLoopTiming.LastFixedUpdate:
+                    LastFixedUpdate();
+                    break;
+                case PlayerLoopTiming.PreUpdate:
+                    PreUpdate();
+                    break;
+                case PlayerLoopTiming.LastPreUpdate:
+                    LastPreUpdate();
+                    break;
+                case PlayerLoopTiming.Update:
+                    Update();
+                    break;
+                case PlayerLoopTiming.LastUpdate:
+                    LastUpdate();
+                    break;
+                case PlayerLoopTiming.PreLateUpdate:
+                    PreLateUpdate();
+                    break;
+                case PlayerLoopTiming.LastPreLateUpdate:
+                    LastPreLateUpdate();
+                    break;
+                case PlayerLoopTiming.PostLateUpdate:
+                    PostLateUpdate();
+                    break;
+                case PlayerLoopTiming.LastPostLateUpdate:
+                    LastPostLateUpdate();
+                    break;
+#if UNITY_2020_2_OR_NEWER
+                case PlayerLoopTiming.TimeUpdate:
+                    TimeUpdate();
+                    break;
+                case PlayerLoopTiming.LastTimeUpdate:
+                    LastTimeUpdate();
+                    break;
+#endif
+                default:
+                    break;
+            }
+#else
+            RunCore();
+#endif
+        }
+
+        void Initialization() => RunCore();
+        void LastInitialization() => RunCore();
+        void EarlyUpdate() => RunCore();
+        void LastEarlyUpdate() => RunCore();
+        void FixedUpdate() => RunCore();
+        void LastFixedUpdate() => RunCore();
+        void PreUpdate() => RunCore();
+        void LastPreUpdate() => RunCore();
+        void Update() => RunCore();
+        void LastUpdate() => RunCore();
+        void PreLateUpdate() => RunCore();
+        void LastPreLateUpdate() => RunCore();
+        void PostLateUpdate() => RunCore();
+        void LastPostLateUpdate() => RunCore();
+#if UNITY_2020_2_OR_NEWER
+        void TimeUpdate() => RunCore();
+        void LastTimeUpdate() => RunCore();
+#endif
+
+        [System.Diagnostics.DebuggerHidden]
+        void RunCore()
+        {
+            {
+                bool lockTaken = false;
+                try
+                {
+                    gate.Enter(ref lockTaken);
+                    if (actionListCount == 0) return;
+                    dequing = true;
+                }
+                finally
+                {
+                    if (lockTaken) gate.Exit(false);
+                }
+            }
+
+            for (int i = 0; i < actionListCount; i++)
+            {
+
+                var action = actionList[i];
+                actionList[i] = null;
+                try
+                {
+                    action();
+                }
+                catch (Exception ex)
+                {
+                    UnityEngine.Debug.LogException(ex);
+                }
+            }
+
+            {
+                bool lockTaken = false;
+                try
+                {
+                    gate.Enter(ref lockTaken);
+                    dequing = false;
+
+                    var swapTempActionList = actionList;
+
+                    actionListCount = waitingListCount;
+                    actionList = waitingList;
+
+                    waitingListCount = 0;
+                    waitingList = swapTempActionList;
+                }
+                finally
+                {
+                    if (lockTaken) gate.Exit(false);
+                }
+            }
+        }
+    }
+}
+

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/ContinuationQueue.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/ContinuationQueue.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f66c32454e50f2546b17deadc80a4c77
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/DiagnosticsExtensions.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/DiagnosticsExtensions.cs
@@ -1,0 +1,249 @@
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Security;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace Cysharp.Threading.Tasks.Internal
+{
+    internal static class DiagnosticsExtensions
+    {
+        static bool displayFilenames = true;
+
+        static readonly Regex typeBeautifyRegex = new Regex("`.+$", RegexOptions.Compiled);
+
+        static readonly Dictionary<Type, string> builtInTypeNames = new Dictionary<Type, string>
+        {
+            { typeof(void), "void" },
+            { typeof(bool), "bool" },
+            { typeof(byte), "byte" },
+            { typeof(char), "char" },
+            { typeof(decimal), "decimal" },
+            { typeof(double), "double" },
+            { typeof(float), "float" },
+            { typeof(int), "int" },
+            { typeof(long), "long" },
+            { typeof(object), "object" },
+            { typeof(sbyte), "sbyte" },
+            { typeof(short), "short" },
+            { typeof(string), "string" },
+            { typeof(uint), "uint" },
+            { typeof(ulong), "ulong" },
+            { typeof(ushort), "ushort" },
+            { typeof(Task), "Task" },
+            { typeof(UniTask), "UniTask" },
+            { typeof(UniTaskVoid), "UniTaskVoid" }
+        };
+
+        public static string CleanupAsyncStackTrace(this StackTrace stackTrace)
+        {
+            if (stackTrace == null) return "";
+
+            var sb = new StringBuilder();
+            for (int i = 0; i < stackTrace.FrameCount; i++)
+            {
+                var sf = stackTrace.GetFrame(i);
+
+                var mb = sf.GetMethod();
+
+                if (IgnoreLine(mb)) continue;
+                if (IsAsync(mb))
+                {
+                    sb.Append("async ");
+                    TryResolveStateMachineMethod(ref mb, out var decType);
+                }
+
+                // return type
+                if (mb is MethodInfo mi)
+                {
+                    sb.Append(BeautifyType(mi.ReturnType, false));
+                    sb.Append(" ");
+                }
+
+                // method name
+                sb.Append(BeautifyType(mb.DeclaringType, false));
+                if (!mb.IsConstructor)
+                {
+                    sb.Append(".");
+                }
+                sb.Append(mb.Name);
+                if (mb.IsGenericMethod)
+                {
+                    sb.Append("<");
+                    foreach (var item in mb.GetGenericArguments())
+                    {
+                        sb.Append(BeautifyType(item, true));
+                    }
+                    sb.Append(">");
+                }
+
+                // parameter
+                sb.Append("(");
+                sb.Append(string.Join(", ", mb.GetParameters().Select(p => BeautifyType(p.ParameterType, true) + " " + p.Name)));
+                sb.Append(")");
+
+                // file name
+                if (displayFilenames && (sf.GetILOffset() != -1))
+                {
+                    String fileName = null;
+
+                    try
+                    {
+                        fileName = sf.GetFileName();
+                    }
+                    catch (NotSupportedException)
+                    {
+                        displayFilenames = false;
+                    }
+                    catch (SecurityException)
+                    {
+                        displayFilenames = false;
+                    }
+
+                    if (fileName != null)
+                    {
+                        sb.Append(' ');
+                        sb.AppendFormat(CultureInfo.InvariantCulture, "(at {0})", AppendHyperLink(fileName, sf.GetFileLineNumber().ToString()));
+                    }
+                }
+
+                sb.AppendLine();
+            }
+            return sb.ToString();
+        }
+
+
+        static bool IsAsync(MethodBase methodInfo)
+        {
+            var declareType = methodInfo.DeclaringType;
+            return typeof(IAsyncStateMachine).IsAssignableFrom(declareType);
+        }
+
+        // code from Ben.Demystifier/EnhancedStackTrace.Frame.cs
+        static bool TryResolveStateMachineMethod(ref MethodBase method, out Type declaringType)
+        {
+            declaringType = method.DeclaringType;
+
+            var parentType = declaringType.DeclaringType;
+            if (parentType == null)
+            {
+                return false;
+            }
+
+            var methods = parentType.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+            if (methods == null)
+            {
+                return false;
+            }
+
+            foreach (var candidateMethod in methods)
+            {
+                var attributes = candidateMethod.GetCustomAttributes<StateMachineAttribute>(false);
+                if (attributes == null)
+                {
+                    continue;
+                }
+
+                foreach (var asma in attributes)
+                {
+                    if (asma.StateMachineType == declaringType)
+                    {
+                        method = candidateMethod;
+                        declaringType = candidateMethod.DeclaringType;
+                        // Mark the iterator as changed; so it gets the + annotation of the original method
+                        // async statemachines resolve directly to their builder methods so aren't marked as changed
+                        return asma is IteratorStateMachineAttribute;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        static string BeautifyType(Type t, bool shortName)
+        {
+            if (builtInTypeNames.TryGetValue(t, out var builtin))
+            {
+                return builtin;
+            }
+            if (t.IsGenericParameter) return t.Name;
+            if (t.IsArray) return BeautifyType(t.GetElementType(), shortName) + "[]";
+            if (t.FullName?.StartsWith("System.ValueTuple") ?? false)
+            {
+                return "(" + string.Join(", ", t.GetGenericArguments().Select(x => BeautifyType(x, true))) + ")";
+            }
+            if (!t.IsGenericType) return shortName ? t.Name : t.FullName.Replace("Cysharp.Threading.Tasks.Triggers.", "").Replace("Cysharp.Threading.Tasks.Internal.", "").Replace("Cysharp.Threading.Tasks.", "") ?? t.Name;
+
+            var innerFormat = string.Join(", ", t.GetGenericArguments().Select(x => BeautifyType(x, true)));
+
+            var genericType = t.GetGenericTypeDefinition().FullName;
+            if (genericType == "System.Threading.Tasks.Task`1")
+            {
+                genericType = "Task";
+            }
+
+            return typeBeautifyRegex.Replace(genericType, "").Replace("Cysharp.Threading.Tasks.Triggers.", "").Replace("Cysharp.Threading.Tasks.Internal.", "").Replace("Cysharp.Threading.Tasks.", "") + "<" + innerFormat + ">";
+        }
+
+        static bool IgnoreLine(MethodBase methodInfo)
+        {
+            var declareType = methodInfo.DeclaringType.FullName;
+            if (declareType == "System.Threading.ExecutionContext")
+            {
+                return true;
+            }
+            else if (declareType.StartsWith("System.Runtime.CompilerServices"))
+            {
+                return true;
+            }
+            else if (declareType.StartsWith("Cysharp.Threading.Tasks.CompilerServices"))
+            {
+                return true;
+            }
+            else if (declareType == "System.Threading.Tasks.AwaitTaskContinuation")
+            {
+                return true;
+            }
+            else if (declareType.StartsWith("System.Threading.Tasks.Task"))
+            {
+                return true;
+            }
+            else if (declareType.StartsWith("Cysharp.Threading.Tasks.UniTaskCompletionSourceCore"))
+            {
+                return true;
+            }
+            else if (declareType.StartsWith("Cysharp.Threading.Tasks.AwaiterActions"))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        static string AppendHyperLink(string path, string line)
+        {
+            var fi = new FileInfo(path);
+            if (fi.Directory == null)
+            {
+                return fi.Name;
+            }
+            else
+            {
+                var fname = fi.FullName.Replace(Path.DirectorySeparatorChar, '/').Replace(PlayerLoopHelper.ApplicationDataPath, "");
+                var withAssetsPath = "Assets/" + fname;
+                return "<a href=\"" + withAssetsPath + "\" line=\"" + line + "\">" + withAssetsPath + ":" + line + "</a>";
+            }
+        }
+    }
+}
+

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/DiagnosticsExtensions.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/DiagnosticsExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f80fb1c9ed4c99447be1b0a47a8d980b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/Error.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/Error.cs
@@ -1,0 +1,79 @@
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Cysharp.Threading.Tasks.Internal
+{
+    internal static class Error
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ThrowArgumentNullException<T>(T value, string paramName)
+          where T : class
+        {
+            if (value == null) ThrowArgumentNullExceptionCore(paramName);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ThrowArgumentNullExceptionCore(string paramName)
+        {
+            throw new ArgumentNullException(paramName);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Exception ArgumentOutOfRange(string paramName)
+        {
+            return new ArgumentOutOfRangeException(paramName);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Exception NoElements()
+        {
+            return new InvalidOperationException("Source sequence doesn't contain any elements.");
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Exception MoreThanOneElement()
+        {
+            return new InvalidOperationException("Source sequence contains more than one element.");
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void ThrowArgumentException<T>(string message)
+        {
+            throw new ArgumentException(message);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void ThrowNotYetCompleted()
+        {
+            throw new InvalidOperationException("Not yet completed.");
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static T ThrowNotYetCompleted<T>()
+        {
+            throw new InvalidOperationException("Not yet completed.");
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ThrowWhenContinuationIsAlreadyRegistered<T>(T continuationField)
+          where T : class
+        {
+            if (continuationField != null) ThrowInvalidOperationExceptionCore("continuation is already registered.");
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ThrowInvalidOperationExceptionCore(string message)
+        {
+            throw new InvalidOperationException(message);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void ThrowOperationCanceledException()
+        {
+            throw new OperationCanceledException();
+        }
+    }
+}
+

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/Error.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/Error.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 5f39f495294d4604b8082202faf98554
+timeCreated: 1532361007
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/MinimumQueue.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/MinimumQueue.cs
@@ -1,0 +1,112 @@
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Cysharp.Threading.Tasks.Internal
+{
+    // optimized version of Standard Queue<T>.
+    internal class MinimumQueue<T>
+    {
+        const int MinimumGrow = 4;
+        const int GrowFactor = 200;
+
+        T[] array;
+        int head;
+        int tail;
+        int size;
+
+        public MinimumQueue(int capacity)
+        {
+            if (capacity < 0) throw new ArgumentOutOfRangeException("capacity");
+            array = new T[capacity];
+            head = tail = size = 0;
+        }
+
+        public int Count
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get { return size; }
+        }
+
+        public T Peek()
+        {
+            if (size == 0) ThrowForEmptyQueue();
+            return array[head];
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Enqueue(T item)
+        {
+            if (size == array.Length)
+            {
+                Grow();
+            }
+
+            array[tail] = item;
+            MoveNext(ref tail);
+            size++;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public T Dequeue()
+        {
+            if (size == 0) ThrowForEmptyQueue();
+
+            int head = this.head;
+            T[] array = this.array;
+            T removed = array[head];
+            array[head] = default(T);
+            MoveNext(ref this.head);
+            size--;
+            return removed;
+        }
+
+        void Grow()
+        {
+            int newcapacity = (int)((long)array.Length * (long)GrowFactor / 100);
+            if (newcapacity < array.Length + MinimumGrow)
+            {
+                newcapacity = array.Length + MinimumGrow;
+            }
+            SetCapacity(newcapacity);
+        }
+
+        void SetCapacity(int capacity)
+        {
+            T[] newarray = new T[capacity];
+            if (size > 0)
+            {
+                if (head < tail)
+                {
+                    Array.Copy(array, head, newarray, 0, size);
+                }
+                else
+                {
+                    Array.Copy(array, head, newarray, 0, array.Length - head);
+                    Array.Copy(array, 0, newarray, array.Length - head, tail);
+                }
+            }
+
+            array = newarray;
+            head = 0;
+            tail = (size == capacity) ? 0 : size;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        void MoveNext(ref int index)
+        {
+            int tmp = index + 1;
+            if (tmp == array.Length)
+            {
+                tmp = 0;
+            }
+            index = tmp;
+        }
+
+        void ThrowForEmptyQueue()
+        {
+            throw new InvalidOperationException("EmptyQueue");
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/MinimumQueue.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/MinimumQueue.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7d63add489ccc99498114d79702b904d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/PlayerLoopRunner.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/PlayerLoopRunner.cs
@@ -1,0 +1,260 @@
+﻿
+using System;
+using UnityEngine;
+
+namespace Cysharp.Threading.Tasks.Internal
+{
+    internal sealed class PlayerLoopRunner
+    {
+        const int InitialSize = 16;
+
+        readonly PlayerLoopTiming timing;
+        readonly object runningAndQueueLock = new object();
+        readonly object arrayLock = new object();
+        readonly Action<Exception> unhandledExceptionCallback;
+
+        int tail = 0;
+        bool running = false;
+        IPlayerLoopItem[] loopItems = new IPlayerLoopItem[InitialSize];
+        MinimumQueue<IPlayerLoopItem> waitQueue = new MinimumQueue<IPlayerLoopItem>(InitialSize);
+
+
+
+        public PlayerLoopRunner(PlayerLoopTiming timing)
+        {
+            this.unhandledExceptionCallback = ex => Debug.LogException(ex);
+            this.timing = timing;
+        }
+
+        public void AddAction(IPlayerLoopItem item)
+        {
+            lock (runningAndQueueLock)
+            {
+                if (running)
+                {
+                    waitQueue.Enqueue(item);
+                    return;
+                }
+            }
+
+            lock (arrayLock)
+            {
+                // Ensure Capacity
+                if (loopItems.Length == tail)
+                {
+                    Array.Resize(ref loopItems, checked(tail * 2));
+                }
+                loopItems[tail++] = item;
+            }
+        }
+
+        public int Clear()
+        {
+            lock (arrayLock)
+            {
+                var rest = 0;
+
+                for (var index = 0; index < loopItems.Length; index++)
+                {
+                    if (loopItems[index] != null)
+                    {
+                        rest++;
+                    }
+
+                    loopItems[index] = null;
+                }
+
+                tail = 0;
+                return rest;
+            }
+        }
+
+        // delegate entrypoint.
+        public void Run()
+        {
+            // for debugging, create named stacktrace.
+#if DEBUG
+            switch (timing)
+            {
+                case PlayerLoopTiming.Initialization:
+                    Initialization();
+                    break;
+                case PlayerLoopTiming.LastInitialization:
+                    LastInitialization();
+                    break;
+                case PlayerLoopTiming.EarlyUpdate:
+                    EarlyUpdate();
+                    break;
+                case PlayerLoopTiming.LastEarlyUpdate:
+                    LastEarlyUpdate();
+                    break;
+                case PlayerLoopTiming.FixedUpdate:
+                    FixedUpdate();
+                    break;
+                case PlayerLoopTiming.LastFixedUpdate:
+                    LastFixedUpdate();
+                    break;
+                case PlayerLoopTiming.PreUpdate:
+                    PreUpdate();
+                    break;
+                case PlayerLoopTiming.LastPreUpdate:
+                    LastPreUpdate();
+                    break;
+                case PlayerLoopTiming.Update:
+                    Update();
+                    break;
+                case PlayerLoopTiming.LastUpdate:
+                    LastUpdate();
+                    break;
+                case PlayerLoopTiming.PreLateUpdate:
+                    PreLateUpdate();
+                    break;
+                case PlayerLoopTiming.LastPreLateUpdate:
+                    LastPreLateUpdate();
+                    break;
+                case PlayerLoopTiming.PostLateUpdate:
+                    PostLateUpdate();
+                    break;
+                case PlayerLoopTiming.LastPostLateUpdate:
+                    LastPostLateUpdate();
+                    break;
+#if UNITY_2020_2_OR_NEWER
+                case PlayerLoopTiming.TimeUpdate:
+                    TimeUpdate();
+                    break;
+                case PlayerLoopTiming.LastTimeUpdate:
+                    LastTimeUpdate();
+                    break;
+#endif
+                default:
+                    break;
+            }
+#else
+            RunCore();
+#endif
+        }
+
+        void Initialization() => RunCore();
+        void LastInitialization() => RunCore();
+        void EarlyUpdate() => RunCore();
+        void LastEarlyUpdate() => RunCore();
+        void FixedUpdate() => RunCore();
+        void LastFixedUpdate() => RunCore();
+        void PreUpdate() => RunCore();
+        void LastPreUpdate() => RunCore();
+        void Update() => RunCore();
+        void LastUpdate() => RunCore();
+        void PreLateUpdate() => RunCore();
+        void LastPreLateUpdate() => RunCore();
+        void PostLateUpdate() => RunCore();
+        void LastPostLateUpdate() => RunCore();
+#if UNITY_2020_2_OR_NEWER
+        void TimeUpdate() => RunCore();
+        void LastTimeUpdate() => RunCore();
+#endif
+
+        [System.Diagnostics.DebuggerHidden]
+        void RunCore()
+        {
+            lock (runningAndQueueLock)
+            {
+                running = true;
+            }
+
+            lock (arrayLock)
+            {
+                var j = tail - 1;
+
+                for (int i = 0; i < loopItems.Length; i++)
+                {
+                    var action = loopItems[i];
+                    if (action != null)
+                    {
+                        try
+                        {
+                            if (!action.MoveNext())
+                            {
+                                loopItems[i] = null;
+                            }
+                            else
+                            {
+                                continue; // next i 
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            loopItems[i] = null;
+                            try
+                            {
+                                unhandledExceptionCallback(ex);
+                            }
+                            catch { }
+                        }
+                    }
+
+                    // find null, loop from tail
+                    while (i < j)
+                    {
+                        var fromTail = loopItems[j];
+                        if (fromTail != null)
+                        {
+                            try
+                            {
+                                if (!fromTail.MoveNext())
+                                {
+                                    loopItems[j] = null;
+                                    j--;
+                                    continue; // next j
+                                }
+                                else
+                                {
+                                    // swap
+                                    loopItems[i] = fromTail;
+                                    loopItems[j] = null;
+                                    j--;
+                                    goto NEXT_LOOP; // next i
+                                }
+                            }
+                            catch (Exception ex)
+                            {
+                                loopItems[j] = null;
+                                j--;
+                                try
+                                {
+                                    unhandledExceptionCallback(ex);
+                                }
+                                catch { }
+                                continue; // next j
+                            }
+                        }
+                        else
+                        {
+                            j--;
+                        }
+                    }
+
+                    tail = i; // loop end
+                    break; // LOOP END
+
+                    NEXT_LOOP:
+                    continue;
+                }
+
+
+                lock (runningAndQueueLock)
+                {
+                    running = false;
+                    while (waitQueue.Count != 0)
+                    {
+                        if (loopItems.Length == tail)
+                        {
+                            Array.Resize(ref loopItems, checked(tail * 2));
+                        }
+                        loopItems[tail++] = waitQueue.Dequeue();
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/PlayerLoopRunner.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/PlayerLoopRunner.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 340c6d420bb4f484aa8683415ea92571
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/PooledDelegate.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/PooledDelegate.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+
+namespace Cysharp.Threading.Tasks.Internal
+{
+    internal sealed class PooledDelegate<T> : ITaskPoolNode<PooledDelegate<T>>
+    {
+        static TaskPool<PooledDelegate<T>> pool;
+
+        PooledDelegate<T> nextNode;
+        public ref PooledDelegate<T> NextNode => ref nextNode;
+
+        static PooledDelegate()
+        {
+            TaskPool.RegisterSizeGetter(typeof(PooledDelegate<T>), () => pool.Size);
+        }
+
+        readonly Action<T> runDelegate;
+        Action continuation;
+
+        PooledDelegate()
+        {
+            runDelegate = Run;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Action<T> Create(Action continuation)
+        {
+            if (!pool.TryPop(out var item))
+            {
+                item = new PooledDelegate<T>();
+            }
+
+            item.continuation = continuation;
+            return item.runDelegate;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        void Run(T _)
+        {
+            var call = continuation;
+            continuation = null;
+            if (call != null)
+            {
+                pool.TryPush(this);
+                call.Invoke();
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/PooledDelegate.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/PooledDelegate.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8932579438742fa40b010edd412dbfba
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/RuntimeHelpersAbstraction.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/RuntimeHelpersAbstraction.cs
@@ -1,0 +1,64 @@
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System;
+#if UNITY_2018_3_OR_NEWER
+using UnityEngine;
+#endif
+
+namespace Cysharp.Threading.Tasks.Internal
+{
+    internal static class RuntimeHelpersAbstraction
+    {
+        // If we can use RuntimeHelpers.IsReferenceOrContainsReferences(.NET Core 2.0), use it.
+        public static bool IsWellKnownNoReferenceContainsType<T>()
+        {
+            return WellKnownNoReferenceContainsType<T>.IsWellKnownType;
+        }
+
+        static bool WellKnownNoReferenceContainsTypeInitialize(Type t)
+        {
+            // The primitive types are Boolean, Byte, SByte, Int16, UInt16, Int32, UInt32, Int64, UInt64, IntPtr, UIntPtr, Char, Double, and Single.
+            if (t.IsPrimitive) return true;
+
+            if (t.IsEnum) return true;
+            if (t == typeof(DateTime)) return true;
+            if (t == typeof(DateTimeOffset)) return true;
+            if (t == typeof(Guid)) return true;
+            if (t == typeof(decimal)) return true;
+
+            // unwrap nullable
+            if (t.IsGenericType && t.GetGenericTypeDefinition() == typeof(Nullable<>))
+            {
+                return WellKnownNoReferenceContainsTypeInitialize(t.GetGenericArguments()[0]);
+            }
+
+#if UNITY_2018_3_OR_NEWER
+
+            // or add other wellknown types(Vector, etc...) here
+            if (t == typeof(Vector2)) return true;
+            if (t == typeof(Vector3)) return true;
+            if (t == typeof(Vector4)) return true;
+            if (t == typeof(Color)) return true;
+            if (t == typeof(Rect)) return true;
+            if (t == typeof(Bounds)) return true;
+            if (t == typeof(Quaternion)) return true;
+            if (t == typeof(Vector2Int)) return true;
+            if (t == typeof(Vector3Int)) return true;
+
+#endif
+
+            return false;
+        }
+
+        static class WellKnownNoReferenceContainsType<T>
+        {
+            public static readonly bool IsWellKnownType;
+
+            static WellKnownNoReferenceContainsType()
+            {
+                IsWellKnownType = WellKnownNoReferenceContainsTypeInitialize(typeof(T));
+            }
+        }
+    }
+}
+

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/RuntimeHelpersAbstraction.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/RuntimeHelpersAbstraction.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 94975e4d4e0c0ea4ba787d3872ce9bb4
+timeCreated: 1532361007
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/StatePool.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/StatePool.cs
@@ -1,0 +1,153 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+
+namespace Cysharp.Threading.Tasks.Internal
+{
+    internal static class StateTuple
+    {
+        public static StateTuple<T1> Create<T1>(T1 item1)
+        {
+            return StatePool<T1>.Create(item1);
+        }
+
+        public static StateTuple<T1, T2> Create<T1, T2>(T1 item1, T2 item2)
+        {
+            return StatePool<T1, T2>.Create(item1, item2);
+        }
+
+        public static StateTuple<T1, T2, T3> Create<T1, T2, T3>(T1 item1, T2 item2, T3 item3)
+        {
+            return StatePool<T1, T2, T3>.Create(item1, item2, item3);
+        }
+    }
+
+    internal class StateTuple<T1> : IDisposable
+    {
+        public T1 Item1;
+
+        public void Deconstruct(out T1 item1)
+        {
+            item1 = this.Item1;
+        }
+
+        public void Dispose()
+        {
+            StatePool<T1>.Return(this);
+        }
+    }
+
+    internal static class StatePool<T1>
+    {
+        static readonly ConcurrentQueue<StateTuple<T1>> queue = new ConcurrentQueue<StateTuple<T1>>();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static StateTuple<T1> Create(T1 item1)
+        {
+            if (queue.TryDequeue(out var value))
+            {
+                value.Item1 = item1;
+                return value;
+            }
+
+            return new StateTuple<T1> { Item1 = item1 };
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Return(StateTuple<T1> tuple)
+        {
+            tuple.Item1 = default;
+            queue.Enqueue(tuple);
+        }
+    }
+
+    internal class StateTuple<T1, T2> : IDisposable
+    {
+        public T1 Item1;
+        public T2 Item2;
+
+        public void Deconstruct(out T1 item1, out T2 item2)
+        {
+            item1 = this.Item1;
+            item2 = this.Item2;
+        }
+
+        public void Dispose()
+        {
+            StatePool<T1, T2>.Return(this);
+        }
+    }
+
+    internal static class StatePool<T1, T2>
+    {
+        static readonly ConcurrentQueue<StateTuple<T1, T2>> queue = new ConcurrentQueue<StateTuple<T1, T2>>();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static StateTuple<T1, T2> Create(T1 item1, T2 item2)
+        {
+            if (queue.TryDequeue(out var value))
+            {
+                value.Item1 = item1;
+                value.Item2 = item2;
+                return value;
+            }
+
+            return new StateTuple<T1, T2> { Item1 = item1, Item2 = item2 };
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Return(StateTuple<T1, T2> tuple)
+        {
+            tuple.Item1 = default;
+            tuple.Item2 = default;
+            queue.Enqueue(tuple);
+        }
+    }
+
+    internal class StateTuple<T1, T2, T3> : IDisposable
+    {
+        public T1 Item1;
+        public T2 Item2;
+        public T3 Item3;
+
+        public void Deconstruct(out T1 item1, out T2 item2, out T3 item3)
+        {
+            item1 = this.Item1;
+            item2 = this.Item2;
+            item3 = this.Item3;
+        }
+
+        public void Dispose()
+        {
+            StatePool<T1, T2, T3>.Return(this);
+        }
+    }
+
+    internal static class StatePool<T1, T2, T3>
+    {
+        static readonly ConcurrentQueue<StateTuple<T1, T2, T3>> queue = new ConcurrentQueue<StateTuple<T1, T2, T3>>();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static StateTuple<T1, T2, T3> Create(T1 item1, T2 item2, T3 item3)
+        {
+            if (queue.TryDequeue(out var value))
+            {
+                value.Item1 = item1;
+                value.Item2 = item2;
+                value.Item3 = item3;
+                return value;
+            }
+
+            return new StateTuple<T1, T2, T3> { Item1 = item1, Item2 = item2, Item3 = item3 };
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Return(StateTuple<T1, T2, T3> tuple)
+        {
+            tuple.Item1 = default;
+            tuple.Item2 = default;
+            tuple.Item3 = default;
+            queue.Enqueue(tuple);
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/StatePool.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/StatePool.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 60cdf0bcaea36b444a7ae7263ae7598f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/TaskTracker.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/TaskTracker.cs
@@ -1,0 +1,178 @@
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+using System.Threading;
+using Cysharp.Threading.Tasks.Internal;
+
+namespace Cysharp.Threading.Tasks
+{
+    // public for add user custom.
+
+    public static class TaskTracker
+    {
+#if UNITY_EDITOR
+
+        static int trackingId = 0;
+
+        public const string EnableAutoReloadKey = "UniTaskTrackerWindow_EnableAutoReloadKey";
+        public const string EnableTrackingKey = "UniTaskTrackerWindow_EnableTrackingKey";
+        public const string EnableStackTraceKey = "UniTaskTrackerWindow_EnableStackTraceKey";
+
+        public static class EditorEnableState
+        {
+            static bool enableAutoReload;
+            public static bool EnableAutoReload
+            {
+                get { return enableAutoReload; }
+                set
+                {
+                    enableAutoReload = value;
+                    UnityEditor.EditorPrefs.SetBool(EnableAutoReloadKey, value);
+                }
+            }
+
+            static bool enableTracking;
+            public static bool EnableTracking
+            {
+                get { return enableTracking; }
+                set
+                {
+                    enableTracking = value;
+                    UnityEditor.EditorPrefs.SetBool(EnableTrackingKey, value);
+                }
+            }
+
+            static bool enableStackTrace;
+            public static bool EnableStackTrace
+            {
+                get { return enableStackTrace; }
+                set
+                {
+                    enableStackTrace = value;
+                    UnityEditor.EditorPrefs.SetBool(EnableStackTraceKey, value);
+                }
+            }
+        }
+
+#endif
+
+
+        static List<KeyValuePair<IUniTaskSource, (string formattedType, int trackingId, DateTime addTime, string stackTrace)>> listPool = new List<KeyValuePair<IUniTaskSource, (string formattedType, int trackingId, DateTime addTime, string stackTrace)>>();
+
+        static readonly WeakDictionary<IUniTaskSource, (string formattedType, int trackingId, DateTime addTime, string stackTrace)> tracking = new WeakDictionary<IUniTaskSource, (string formattedType, int trackingId, DateTime addTime, string stackTrace)>();
+
+        [Conditional("UNITY_EDITOR")]
+        public static void TrackActiveTask(IUniTaskSource task, int skipFrame)
+        {
+#if UNITY_EDITOR
+            dirty = true;
+            if (!EditorEnableState.EnableTracking) return;
+            var stackTrace = EditorEnableState.EnableStackTrace ? new StackTrace(skipFrame, true).CleanupAsyncStackTrace() : "";
+
+            string typeName;
+            if (EditorEnableState.EnableStackTrace)
+            {
+                var sb = new StringBuilder();
+                TypeBeautify(task.GetType(), sb);
+                typeName = sb.ToString();
+            }
+            else
+            {
+                typeName = task.GetType().Name;
+            }
+            tracking.TryAdd(task, (typeName, Interlocked.Increment(ref trackingId), DateTime.UtcNow, stackTrace));
+#endif
+        }
+
+        [Conditional("UNITY_EDITOR")]
+        public static void RemoveTracking(IUniTaskSource task)
+        {
+#if UNITY_EDITOR
+            dirty = true;
+            if (!EditorEnableState.EnableTracking) return;
+            var success = tracking.TryRemove(task);
+#endif
+        }
+
+        static bool dirty;
+
+        public static bool CheckAndResetDirty()
+        {
+            var current = dirty;
+            dirty = false;
+            return current;
+        }
+
+        /// <summary>(trackingId, awaiterType, awaiterStatus, createdTime, stackTrace)</summary>
+        public static void ForEachActiveTask(Action<int, string, UniTaskStatus, DateTime, string> action)
+        {
+            lock (listPool)
+            {
+                var count = tracking.ToList(ref listPool, clear: false);
+                try
+                {
+                    for (int i = 0; i < count; i++)
+                    {
+                        action(listPool[i].Value.trackingId, listPool[i].Value.formattedType, listPool[i].Key.UnsafeGetStatus(), listPool[i].Value.addTime, listPool[i].Value.stackTrace);
+                        listPool[i] = default;
+                    }
+                }
+                catch
+                {
+                    listPool.Clear();
+                    throw;
+                }
+            }
+        }
+
+        static void TypeBeautify(Type type, StringBuilder sb)
+        {
+            if (type.IsNested)
+            {
+                // TypeBeautify(type.DeclaringType, sb);
+                sb.Append(type.DeclaringType.Name.ToString());
+                sb.Append(".");
+            }
+
+            if (type.IsGenericType)
+            {
+                var genericsStart = type.Name.IndexOf("`");
+                if (genericsStart != -1)
+                {
+                    sb.Append(type.Name.Substring(0, genericsStart));
+                }
+                else
+                {
+                    sb.Append(type.Name);
+                }
+                sb.Append("<");
+                var first = true;
+                foreach (var item in type.GetGenericArguments())
+                {
+                    if (!first)
+                    {
+                        sb.Append(", ");
+                    }
+                    first = false;
+                    TypeBeautify(item, sb);
+                }
+                sb.Append(">");
+            }
+            else
+            {
+                sb.Append(type.Name);
+            }
+        }
+
+        //static string RemoveUniTaskNamespace(string str)
+        //{
+        //    return str.Replace("Cysharp.Threading.Tasks.CompilerServices", "")
+        //        .Replace("Cysharp.Threading.Tasks.Linq", "")
+        //        .Replace("Cysharp.Threading.Tasks", "");
+        //}
+    }
+}
+

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/TaskTracker.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/TaskTracker.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a203c73eb4ccdbb44bddfd82d38fdda9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/UnityEqualityComparer.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/UnityEqualityComparer.cs
@@ -1,0 +1,267 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Cysharp.Threading.Tasks.Internal
+{
+    internal static class UnityEqualityComparer
+    {
+        public static readonly IEqualityComparer<Vector2> Vector2 = new Vector2EqualityComparer();
+        public static readonly IEqualityComparer<Vector3> Vector3 = new Vector3EqualityComparer();
+        public static readonly IEqualityComparer<Vector4> Vector4 = new Vector4EqualityComparer();
+        public static readonly IEqualityComparer<Color> Color = new ColorEqualityComparer();
+        public static readonly IEqualityComparer<Color32> Color32 = new Color32EqualityComparer();
+        public static readonly IEqualityComparer<Rect> Rect = new RectEqualityComparer();
+        public static readonly IEqualityComparer<Bounds> Bounds = new BoundsEqualityComparer();
+        public static readonly IEqualityComparer<Quaternion> Quaternion = new QuaternionEqualityComparer();
+
+        static readonly RuntimeTypeHandle vector2Type = typeof(Vector2).TypeHandle;
+        static readonly RuntimeTypeHandle vector3Type = typeof(Vector3).TypeHandle;
+        static readonly RuntimeTypeHandle vector4Type = typeof(Vector4).TypeHandle;
+        static readonly RuntimeTypeHandle colorType = typeof(Color).TypeHandle;
+        static readonly RuntimeTypeHandle color32Type = typeof(Color32).TypeHandle;
+        static readonly RuntimeTypeHandle rectType = typeof(Rect).TypeHandle;
+        static readonly RuntimeTypeHandle boundsType = typeof(Bounds).TypeHandle;
+        static readonly RuntimeTypeHandle quaternionType = typeof(Quaternion).TypeHandle;
+
+#if UNITY_2017_2_OR_NEWER
+
+        public static readonly IEqualityComparer<Vector2Int> Vector2Int = new Vector2IntEqualityComparer();
+        public static readonly IEqualityComparer<Vector3Int> Vector3Int = new Vector3IntEqualityComparer();
+        public static readonly IEqualityComparer<RangeInt> RangeInt = new RangeIntEqualityComparer();
+        public static readonly IEqualityComparer<RectInt> RectInt = new RectIntEqualityComparer();
+        public static readonly IEqualityComparer<BoundsInt> BoundsInt = new BoundsIntEqualityComparer();
+
+        static readonly RuntimeTypeHandle vector2IntType = typeof(Vector2Int).TypeHandle;
+        static readonly RuntimeTypeHandle vector3IntType = typeof(Vector3Int).TypeHandle;
+        static readonly RuntimeTypeHandle rangeIntType = typeof(RangeInt).TypeHandle;
+        static readonly RuntimeTypeHandle rectIntType = typeof(RectInt).TypeHandle;
+        static readonly RuntimeTypeHandle boundsIntType = typeof(BoundsInt).TypeHandle;
+
+#endif
+
+        static class Cache<T>
+        {
+            public static readonly IEqualityComparer<T> Comparer;
+
+            static Cache()
+            {
+                var comparer = GetDefaultHelper(typeof(T));
+                if (comparer == null)
+                {
+                    Comparer = EqualityComparer<T>.Default;
+                }
+                else
+                {
+                    Comparer = (IEqualityComparer<T>)comparer;
+                }
+            }
+        }
+
+        public static IEqualityComparer<T> GetDefault<T>()
+        {
+            return Cache<T>.Comparer;
+        }
+
+        static object GetDefaultHelper(Type type)
+        {
+            var t = type.TypeHandle;
+
+            if (t.Equals(vector2Type)) return (object)UnityEqualityComparer.Vector2;
+            if (t.Equals(vector3Type)) return (object)UnityEqualityComparer.Vector3;
+            if (t.Equals(vector4Type)) return (object)UnityEqualityComparer.Vector4;
+            if (t.Equals(colorType)) return (object)UnityEqualityComparer.Color;
+            if (t.Equals(color32Type)) return (object)UnityEqualityComparer.Color32;
+            if (t.Equals(rectType)) return (object)UnityEqualityComparer.Rect;
+            if (t.Equals(boundsType)) return (object)UnityEqualityComparer.Bounds;
+            if (t.Equals(quaternionType)) return (object)UnityEqualityComparer.Quaternion;
+
+#if UNITY_2017_2_OR_NEWER
+
+            if (t.Equals(vector2IntType)) return (object)UnityEqualityComparer.Vector2Int;
+            if (t.Equals(vector3IntType)) return (object)UnityEqualityComparer.Vector3Int;
+            if (t.Equals(rangeIntType)) return (object)UnityEqualityComparer.RangeInt;
+            if (t.Equals(rectIntType)) return (object)UnityEqualityComparer.RectInt;
+            if (t.Equals(boundsIntType)) return (object)UnityEqualityComparer.BoundsInt;
+#endif
+
+            return null;
+        }
+
+        sealed class Vector2EqualityComparer : IEqualityComparer<Vector2>
+        {
+            public bool Equals(Vector2 self, Vector2 vector)
+            {
+                return self.x.Equals(vector.x) && self.y.Equals(vector.y);
+            }
+
+            public int GetHashCode(Vector2 obj)
+            {
+                return obj.x.GetHashCode() ^ obj.y.GetHashCode() << 2;
+            }
+        }
+
+        sealed class Vector3EqualityComparer : IEqualityComparer<Vector3>
+        {
+            public bool Equals(Vector3 self, Vector3 vector)
+            {
+                return self.x.Equals(vector.x) && self.y.Equals(vector.y) && self.z.Equals(vector.z);
+            }
+
+            public int GetHashCode(Vector3 obj)
+            {
+                return obj.x.GetHashCode() ^ obj.y.GetHashCode() << 2 ^ obj.z.GetHashCode() >> 2;
+            }
+        }
+
+        sealed class Vector4EqualityComparer : IEqualityComparer<Vector4>
+        {
+            public bool Equals(Vector4 self, Vector4 vector)
+            {
+                return self.x.Equals(vector.x) && self.y.Equals(vector.y) && self.z.Equals(vector.z) && self.w.Equals(vector.w);
+            }
+
+            public int GetHashCode(Vector4 obj)
+            {
+                return obj.x.GetHashCode() ^ obj.y.GetHashCode() << 2 ^ obj.z.GetHashCode() >> 2 ^ obj.w.GetHashCode() >> 1;
+            }
+        }
+
+        sealed class ColorEqualityComparer : IEqualityComparer<Color>
+        {
+            public bool Equals(Color self, Color other)
+            {
+                return self.r.Equals(other.r) && self.g.Equals(other.g) && self.b.Equals(other.b) && self.a.Equals(other.a);
+            }
+
+            public int GetHashCode(Color obj)
+            {
+                return obj.r.GetHashCode() ^ obj.g.GetHashCode() << 2 ^ obj.b.GetHashCode() >> 2 ^ obj.a.GetHashCode() >> 1;
+            }
+        }
+
+        sealed class RectEqualityComparer : IEqualityComparer<Rect>
+        {
+            public bool Equals(Rect self, Rect other)
+            {
+                return self.x.Equals(other.x) && self.width.Equals(other.width) && self.y.Equals(other.y) && self.height.Equals(other.height);
+            }
+
+            public int GetHashCode(Rect obj)
+            {
+                return obj.x.GetHashCode() ^ obj.width.GetHashCode() << 2 ^ obj.y.GetHashCode() >> 2 ^ obj.height.GetHashCode() >> 1;
+            }
+        }
+
+        sealed class BoundsEqualityComparer : IEqualityComparer<Bounds>
+        {
+            public bool Equals(Bounds self, Bounds vector)
+            {
+                return self.center.Equals(vector.center) && self.extents.Equals(vector.extents);
+            }
+
+            public int GetHashCode(Bounds obj)
+            {
+                return obj.center.GetHashCode() ^ obj.extents.GetHashCode() << 2;
+            }
+        }
+
+        sealed class QuaternionEqualityComparer : IEqualityComparer<Quaternion>
+        {
+            public bool Equals(Quaternion self, Quaternion vector)
+            {
+                return self.x.Equals(vector.x) && self.y.Equals(vector.y) && self.z.Equals(vector.z) && self.w.Equals(vector.w);
+            }
+
+            public int GetHashCode(Quaternion obj)
+            {
+                return obj.x.GetHashCode() ^ obj.y.GetHashCode() << 2 ^ obj.z.GetHashCode() >> 2 ^ obj.w.GetHashCode() >> 1;
+            }
+        }
+
+        sealed class Color32EqualityComparer : IEqualityComparer<Color32>
+        {
+            public bool Equals(Color32 self, Color32 vector)
+            {
+                return self.a.Equals(vector.a) && self.r.Equals(vector.r) && self.g.Equals(vector.g) && self.b.Equals(vector.b);
+            }
+
+            public int GetHashCode(Color32 obj)
+            {
+                return obj.a.GetHashCode() ^ obj.r.GetHashCode() << 2 ^ obj.g.GetHashCode() >> 2 ^ obj.b.GetHashCode() >> 1;
+            }
+        }
+
+#if UNITY_2017_2_OR_NEWER
+
+        sealed class Vector2IntEqualityComparer : IEqualityComparer<Vector2Int>
+        {
+            public bool Equals(Vector2Int self, Vector2Int vector)
+            {
+                return self.x.Equals(vector.x) && self.y.Equals(vector.y);
+            }
+
+            public int GetHashCode(Vector2Int obj)
+            {
+                return obj.x.GetHashCode() ^ obj.y.GetHashCode() << 2;
+            }
+        }
+
+        sealed class Vector3IntEqualityComparer : IEqualityComparer<Vector3Int>
+        {
+            public static readonly Vector3IntEqualityComparer Default = new Vector3IntEqualityComparer();
+
+            public bool Equals(Vector3Int self, Vector3Int vector)
+            {
+                return self.x.Equals(vector.x) && self.y.Equals(vector.y) && self.z.Equals(vector.z);
+            }
+
+            public int GetHashCode(Vector3Int obj)
+            {
+                return obj.x.GetHashCode() ^ obj.y.GetHashCode() << 2 ^ obj.z.GetHashCode() >> 2;
+            }
+        }
+
+        sealed class RangeIntEqualityComparer : IEqualityComparer<RangeInt>
+        {
+            public bool Equals(RangeInt self, RangeInt vector)
+            {
+                return self.start.Equals(vector.start) && self.length.Equals(vector.length);
+            }
+
+            public int GetHashCode(RangeInt obj)
+            {
+                return obj.start.GetHashCode() ^ obj.length.GetHashCode() << 2;
+            }
+        }
+
+        sealed class RectIntEqualityComparer : IEqualityComparer<RectInt>
+        {
+            public bool Equals(RectInt self, RectInt other)
+            {
+                return self.x.Equals(other.x) && self.width.Equals(other.width) && self.y.Equals(other.y) && self.height.Equals(other.height);
+            }
+
+            public int GetHashCode(RectInt obj)
+            {
+                return obj.x.GetHashCode() ^ obj.width.GetHashCode() << 2 ^ obj.y.GetHashCode() >> 2 ^ obj.height.GetHashCode() >> 1;
+            }
+        }
+
+        sealed class BoundsIntEqualityComparer : IEqualityComparer<BoundsInt>
+        {
+            public bool Equals(BoundsInt self, BoundsInt vector)
+            {
+                return Vector3IntEqualityComparer.Default.Equals(self.position, vector.position)
+                    && Vector3IntEqualityComparer.Default.Equals(self.size, vector.size);
+            }
+
+            public int GetHashCode(BoundsInt obj)
+            {
+                return Vector3IntEqualityComparer.Default.GetHashCode(obj.position) ^ Vector3IntEqualityComparer.Default.GetHashCode(obj.size) << 2;
+            }
+        }
+
+#endif
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/UnityEqualityComparer.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/UnityEqualityComparer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ebaaf14253c9cfb47b23283218ff9b67
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/UnityWebRequestExtensions.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/UnityWebRequestExtensions.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine.Networking;
+
+namespace Cysharp.Threading.Tasks.Internal
+{
+#if ENABLE_UNITYWEBREQUEST && (!UNITY_2019_1_OR_NEWER || UNITASK_WEBREQUEST_SUPPORT)
+    
+    internal static class UnityWebRequestResultExtensions
+    {
+        public static bool IsError(this UnityWebRequest unityWebRequest)
+        {
+#if UNITY_2020_2_OR_NEWER
+            var result = unityWebRequest.result;
+            return (result == UnityWebRequest.Result.ConnectionError)
+                || (result == UnityWebRequest.Result.DataProcessingError)
+                || (result == UnityWebRequest.Result.ProtocolError);
+#else
+            return unityWebRequest.isHttpError || unityWebRequest.isNetworkError;
+#endif
+        }
+    }
+
+#endif
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/UnityWebRequestExtensions.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/UnityWebRequestExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 111ba0e639de1d7428af6c823ead4918
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/ValueStopwatch.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/ValueStopwatch.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Diagnostics;
+
+namespace Cysharp.Threading.Tasks.Internal
+{
+    internal readonly struct ValueStopwatch
+    {
+        static readonly double TimestampToTicks = TimeSpan.TicksPerSecond / (double)Stopwatch.Frequency;
+
+        readonly long startTimestamp;
+
+        public static ValueStopwatch StartNew() => new ValueStopwatch(Stopwatch.GetTimestamp());
+
+        ValueStopwatch(long startTimestamp)
+        {
+            this.startTimestamp = startTimestamp;
+        }
+
+        public TimeSpan Elapsed => TimeSpan.FromTicks(this.ElapsedTicks);
+
+        public bool IsInvalid => startTimestamp == 0;
+
+        public long ElapsedTicks
+        {
+            get
+            {
+                if (startTimestamp == 0)
+                {
+                    throw new InvalidOperationException("Detected invalid initialization(use 'default'), only to create from StartNew().");
+                }
+
+                var delta = Stopwatch.GetTimestamp() - startTimestamp;
+                return (long)(delta * TimestampToTicks);
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/ValueStopwatch.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/ValueStopwatch.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f16fb466974ad034c8732c79c7fd67ea
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/WeakDictionary.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/WeakDictionary.cs
@@ -1,0 +1,334 @@
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Internal
+{
+    // Add, Remove, Enumerate with sweep. All operations are thread safe(in spinlock).
+    internal class WeakDictionary<TKey, TValue>
+        where TKey : class
+    {
+        Entry[] buckets;
+        int size;
+        SpinLock gate; // mutable struct(not readonly)
+
+        readonly float loadFactor;
+        readonly IEqualityComparer<TKey> keyEqualityComparer;
+
+        public WeakDictionary(int capacity = 4, float loadFactor = 0.75f, IEqualityComparer<TKey> keyComparer = null)
+        {
+            var tableSize = CalculateCapacity(capacity, loadFactor);
+            this.buckets = new Entry[tableSize];
+            this.loadFactor = loadFactor;
+            this.gate = new SpinLock(false);
+            this.keyEqualityComparer = keyComparer ?? EqualityComparer<TKey>.Default;
+        }
+
+        public bool TryAdd(TKey key, TValue value)
+        {
+            bool lockTaken = false;
+            try
+            {
+                gate.Enter(ref lockTaken);
+                return TryAddInternal(key, value);
+            }
+            finally
+            {
+                if (lockTaken) gate.Exit(false);
+            }
+        }
+
+        public bool TryGetValue(TKey key, out TValue value)
+        {
+            bool lockTaken = false;
+            try
+            {
+                gate.Enter(ref lockTaken);
+                if (TryGetEntry(key, out _, out var entry))
+                {
+                    value = entry.Value;
+                    return true;
+                }
+
+                value = default(TValue);
+                return false;
+            }
+            finally
+            {
+                if (lockTaken) gate.Exit(false);
+            }
+        }
+
+        public bool TryRemove(TKey key)
+        {
+            bool lockTaken = false;
+            try
+            {
+                gate.Enter(ref lockTaken);
+                if (TryGetEntry(key, out var hashIndex, out var entry))
+                {
+                    Remove(hashIndex, entry);
+                    return true;
+                }
+
+                return false;
+            }
+            finally
+            {
+                if (lockTaken) gate.Exit(false);
+            }
+        }
+
+        bool TryAddInternal(TKey key, TValue value)
+        {
+            var nextCapacity = CalculateCapacity(size + 1, loadFactor);
+
+            TRY_ADD_AGAIN:
+            if (buckets.Length < nextCapacity)
+            {
+                // rehash
+                var nextBucket = new Entry[nextCapacity];
+                for (int i = 0; i < buckets.Length; i++)
+                {
+                    var e = buckets[i];
+                    while (e != null)
+                    {
+                        AddToBuckets(nextBucket, key, e.Value, e.Hash);
+                        e = e.Next;
+                    }
+                }
+
+                buckets = nextBucket;
+                goto TRY_ADD_AGAIN;
+            }
+            else
+            {
+                // add entry
+                var successAdd = AddToBuckets(buckets, key, value, keyEqualityComparer.GetHashCode(key));
+                if (successAdd) size++;
+                return successAdd;
+            }
+        }
+
+        bool AddToBuckets(Entry[] targetBuckets, TKey newKey, TValue value, int keyHash)
+        {
+            var h = keyHash;
+            var hashIndex = h & (targetBuckets.Length - 1);
+
+            TRY_ADD_AGAIN:
+            if (targetBuckets[hashIndex] == null)
+            {
+                targetBuckets[hashIndex] = new Entry
+                {
+                    Key = new WeakReference<TKey>(newKey, false),
+                    Value = value,
+                    Hash = h
+                };
+
+                return true;
+            }
+            else
+            {
+                // add to last.
+                var entry = targetBuckets[hashIndex];
+                while (entry != null)
+                {
+                    if (entry.Key.TryGetTarget(out var target))
+                    {
+                        if (keyEqualityComparer.Equals(newKey, target))
+                        {
+                            return false; // duplicate
+                        }
+                    }
+                    else
+                    {
+                        Remove(hashIndex, entry);
+                        if (targetBuckets[hashIndex] == null) goto TRY_ADD_AGAIN; // add new entry
+                    }
+
+                    if (entry.Next != null)
+                    {
+                        entry = entry.Next;
+                    }
+                    else
+                    {
+                        // found last
+                        entry.Next = new Entry
+                        {
+                            Key = new WeakReference<TKey>(newKey, false),
+                            Value = value,
+                            Hash = h
+                        };
+                        entry.Next.Prev = entry;
+                    }
+                }
+
+                return false;
+            }
+        }
+
+        bool TryGetEntry(TKey key, out int hashIndex, out Entry entry)
+        {
+            var table = buckets;
+            var hash = keyEqualityComparer.GetHashCode(key);
+            hashIndex = hash & table.Length - 1;
+            entry = table[hashIndex];
+
+            while (entry != null)
+            {
+                if (entry.Key.TryGetTarget(out var target))
+                {
+                    if (keyEqualityComparer.Equals(key, target))
+                    {
+                        return true;
+                    }
+                }
+                else
+                {
+                    // sweap
+                    Remove(hashIndex, entry);
+                }
+
+                entry = entry.Next;
+            }
+
+            return false;
+        }
+
+        void Remove(int hashIndex, Entry entry)
+        {
+            if (entry.Prev == null && entry.Next == null)
+            {
+                buckets[hashIndex] = null;
+            }
+            else
+            {
+                if (entry.Prev == null)
+                {
+                    buckets[hashIndex] = entry.Next;
+                }
+                if (entry.Prev != null)
+                {
+                    entry.Prev.Next = entry.Next;
+                }
+                if (entry.Next != null)
+                {
+                    entry.Next.Prev = entry.Prev;
+                }
+            }
+            size--;
+        }
+
+        public List<KeyValuePair<TKey, TValue>> ToList()
+        {
+            var list = new List<KeyValuePair<TKey, TValue>>(size);
+            ToList(ref list, false);
+            return list;
+        }
+
+        // avoid allocate everytime.
+        public int ToList(ref List<KeyValuePair<TKey, TValue>> list, bool clear = true)
+        {
+            if (clear)
+            {
+                list.Clear();
+            }
+
+            var listIndex = 0;
+
+            bool lockTaken = false;
+            try
+            {
+                for (int i = 0; i < buckets.Length; i++)
+                {
+                    var entry = buckets[i];
+                    while (entry != null)
+                    {
+                        if (entry.Key.TryGetTarget(out var target))
+                        {
+                            var item = new KeyValuePair<TKey, TValue>(target, entry.Value);
+                            if (listIndex < list.Count)
+                            {
+                                list[listIndex++] = item;
+                            }
+                            else
+                            {
+                                list.Add(item);
+                                listIndex++;
+                            }
+                        }
+                        else
+                        {
+                            // sweap
+                            Remove(i, entry);
+                        }
+
+                        entry = entry.Next;
+                    }
+                }
+            }
+            finally
+            {
+                if (lockTaken) gate.Exit(false);
+            }
+
+            return listIndex;
+        }
+
+        static int CalculateCapacity(int collectionSize, float loadFactor)
+        {
+            var size = (int)(((float)collectionSize) / loadFactor);
+
+            size--;
+            size |= size >> 1;
+            size |= size >> 2;
+            size |= size >> 4;
+            size |= size >> 8;
+            size |= size >> 16;
+            size += 1;
+
+            if (size < 8)
+            {
+                size = 8;
+            }
+            return size;
+        }
+
+        class Entry
+        {
+            public WeakReference<TKey> Key;
+            public TValue Value;
+            public int Hash;
+            public Entry Prev;
+            public Entry Next;
+
+            // debug only
+            public override string ToString()
+            {
+                if (Key.TryGetTarget(out var target))
+                {
+                    return target + "(" + Count() + ")";
+                }
+                else
+                {
+                    return "(Dead)";
+                }
+            }
+
+            int Count()
+            {
+                var count = 1;
+                var n = this;
+                while (n.Next != null)
+                {
+                    count++;
+                    n = n.Next;
+                }
+                return count;
+            }
+        }
+    }
+}
+

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/WeakDictionary.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Internal/WeakDictionary.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6c78563864409714593226af59bcb6f3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a598fc850bb4dfa4f8b98e5656b8f1be
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Aggregate.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Aggregate.cs
@@ -1,0 +1,318 @@
+﻿using Cysharp.Threading.Tasks.Internal;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static UniTask<TSource> AggregateAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, TSource, TSource> accumulator, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(accumulator, nameof(accumulator));
+
+            return Aggregate.AggregateAsync(source, accumulator, cancellationToken);
+        }
+
+        public static UniTask<TAccumulate> AggregateAsync<TSource, TAccumulate>(this IUniTaskAsyncEnumerable<TSource> source, TAccumulate seed, Func<TAccumulate, TSource, TAccumulate> accumulator, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(accumulator, nameof(accumulator));
+
+            return Aggregate.AggregateAsync(source, seed, accumulator, cancellationToken);
+        }
+
+        public static UniTask<TResult> AggregateAsync<TSource, TAccumulate, TResult>(this IUniTaskAsyncEnumerable<TSource> source, TAccumulate seed, Func<TAccumulate, TSource, TAccumulate> accumulator, Func<TAccumulate, TResult> resultSelector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(accumulator, nameof(accumulator));
+            Error.ThrowArgumentNullException(accumulator, nameof(resultSelector));
+
+            return Aggregate.AggregateAsync(source, seed, accumulator, resultSelector, cancellationToken);
+        }
+
+        public static UniTask<TSource> AggregateAwaitAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, TSource, UniTask<TSource>> accumulator, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(accumulator, nameof(accumulator));
+
+            return Aggregate.AggregateAwaitAsync(source, accumulator, cancellationToken);
+        }
+
+        public static UniTask<TAccumulate> AggregateAwaitAsync<TSource, TAccumulate>(this IUniTaskAsyncEnumerable<TSource> source, TAccumulate seed, Func<TAccumulate, TSource, UniTask<TAccumulate>> accumulator, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(accumulator, nameof(accumulator));
+
+            return Aggregate.AggregateAwaitAsync(source, seed, accumulator, cancellationToken);
+        }
+
+        public static UniTask<TResult> AggregateAwaitAsync<TSource, TAccumulate, TResult>(this IUniTaskAsyncEnumerable<TSource> source, TAccumulate seed, Func<TAccumulate, TSource, UniTask<TAccumulate>> accumulator, Func<TAccumulate, UniTask<TResult>> resultSelector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(accumulator, nameof(accumulator));
+            Error.ThrowArgumentNullException(accumulator, nameof(resultSelector));
+
+            return Aggregate.AggregateAwaitAsync(source, seed, accumulator, resultSelector, cancellationToken);
+        }
+
+        public static UniTask<TSource> AggregateAwaitWithCancellationAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, TSource, CancellationToken, UniTask<TSource>> accumulator, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(accumulator, nameof(accumulator));
+
+            return Aggregate.AggregateAwaitWithCancellationAsync(source, accumulator, cancellationToken);
+        }
+
+        public static UniTask<TAccumulate> AggregateAwaitWithCancellationAsync<TSource, TAccumulate>(this IUniTaskAsyncEnumerable<TSource> source, TAccumulate seed, Func<TAccumulate, TSource, CancellationToken, UniTask<TAccumulate>> accumulator, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(accumulator, nameof(accumulator));
+
+            return Aggregate.AggregateAwaitWithCancellationAsync(source, seed, accumulator, cancellationToken);
+        }
+
+        public static UniTask<TResult> AggregateAwaitWithCancellationAsync<TSource, TAccumulate, TResult>(this IUniTaskAsyncEnumerable<TSource> source, TAccumulate seed, Func<TAccumulate, TSource, CancellationToken, UniTask<TAccumulate>> accumulator, Func<TAccumulate, CancellationToken, UniTask<TResult>> resultSelector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(accumulator, nameof(accumulator));
+            Error.ThrowArgumentNullException(accumulator, nameof(resultSelector));
+
+            return Aggregate.AggregateAwaitWithCancellationAsync(source, seed, accumulator, resultSelector, cancellationToken);
+        }
+    }
+
+    internal static class Aggregate
+    {
+        internal static async UniTask<TSource> AggregateAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, TSource, TSource> accumulator, CancellationToken cancellationToken)
+        {
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                TSource value;
+                if (await e.MoveNextAsync())
+                {
+                    value = e.Current;
+                }
+                else
+                {
+                    throw Error.NoElements();
+                }
+
+                while (await e.MoveNextAsync())
+                {
+                    value = accumulator(value, e.Current);
+                }
+                return value;
+
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+        }
+
+        internal static async UniTask<TAccumulate> AggregateAsync<TSource, TAccumulate>(IUniTaskAsyncEnumerable<TSource> source, TAccumulate seed, Func<TAccumulate, TSource, TAccumulate> accumulator, CancellationToken cancellationToken)
+        {
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                TAccumulate value = seed;
+                while (await e.MoveNextAsync())
+                {
+                    value = accumulator(value, e.Current);
+                }
+                return value;
+
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+        }
+
+        internal static async UniTask<TResult> AggregateAsync<TSource, TAccumulate, TResult>(IUniTaskAsyncEnumerable<TSource> source, TAccumulate seed, Func<TAccumulate, TSource, TAccumulate> accumulator, Func<TAccumulate, TResult> resultSelector, CancellationToken cancellationToken)
+        {
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                TAccumulate value = seed;
+                while (await e.MoveNextAsync())
+                {
+                    value = accumulator(value, e.Current);
+                }
+                return resultSelector(value);
+
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+        }
+
+        // with async
+
+        internal static async UniTask<TSource> AggregateAwaitAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, TSource, UniTask<TSource>> accumulator, CancellationToken cancellationToken)
+        {
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                TSource value;
+                if (await e.MoveNextAsync())
+                {
+                    value = e.Current;
+                }
+                else
+                {
+                    throw Error.NoElements();
+                }
+
+                while (await e.MoveNextAsync())
+                {
+                    value = await accumulator(value, e.Current);
+                }
+                return value;
+
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+        }
+
+        internal static async UniTask<TAccumulate> AggregateAwaitAsync<TSource, TAccumulate>(IUniTaskAsyncEnumerable<TSource> source, TAccumulate seed, Func<TAccumulate, TSource, UniTask<TAccumulate>> accumulator, CancellationToken cancellationToken)
+        {
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                TAccumulate value = seed;
+                while (await e.MoveNextAsync())
+                {
+                    value = await accumulator(value, e.Current);
+                }
+                return value;
+
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+        }
+
+        internal static async UniTask<TResult> AggregateAwaitAsync<TSource, TAccumulate, TResult>(IUniTaskAsyncEnumerable<TSource> source, TAccumulate seed, Func<TAccumulate, TSource, UniTask<TAccumulate>> accumulator, Func<TAccumulate, UniTask<TResult>> resultSelector, CancellationToken cancellationToken)
+        {
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                TAccumulate value = seed;
+                while (await e.MoveNextAsync())
+                {
+                    value = await accumulator(value, e.Current);
+                }
+                return await resultSelector(value);
+
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+        }
+
+
+        // with cancellation
+
+        internal static async UniTask<TSource> AggregateAwaitWithCancellationAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, TSource, CancellationToken, UniTask<TSource>> accumulator, CancellationToken cancellationToken)
+        {
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                TSource value;
+                if (await e.MoveNextAsync())
+                {
+                    value = e.Current;
+                }
+                else
+                {
+                    throw Error.NoElements();
+                }
+
+                while (await e.MoveNextAsync())
+                {
+                    value = await accumulator(value, e.Current, cancellationToken);
+                }
+                return value;
+
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+        }
+
+        internal static async UniTask<TAccumulate> AggregateAwaitWithCancellationAsync<TSource, TAccumulate>(IUniTaskAsyncEnumerable<TSource> source, TAccumulate seed, Func<TAccumulate, TSource, CancellationToken, UniTask<TAccumulate>> accumulator, CancellationToken cancellationToken)
+        {
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                TAccumulate value = seed;
+                while (await e.MoveNextAsync())
+                {
+                    value = await accumulator(value, e.Current, cancellationToken);
+                }
+                return value;
+
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+        }
+
+        internal static async UniTask<TResult> AggregateAwaitWithCancellationAsync<TSource, TAccumulate, TResult>(IUniTaskAsyncEnumerable<TSource> source, TAccumulate seed, Func<TAccumulate, TSource, CancellationToken, UniTask<TAccumulate>> accumulator, Func<TAccumulate, CancellationToken, UniTask<TResult>> resultSelector, CancellationToken cancellationToken)
+        {
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                TAccumulate value = seed;
+                while (await e.MoveNextAsync())
+                {
+                    value = await accumulator(value, e.Current, cancellationToken);
+                }
+                return await resultSelector(value, cancellationToken);
+
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Aggregate.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Aggregate.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5dc68c05a4228c643937f6ebd185bcca
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/All.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/All.cs
@@ -1,0 +1,108 @@
+﻿using Cysharp.Threading.Tasks.Internal;
+using System;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static UniTask<Boolean> AllAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Boolean> predicate, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(predicate, nameof(predicate));
+
+            return All.AllAsync(source, predicate, cancellationToken);
+        }
+
+        public static UniTask<Boolean> AllAwaitAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Boolean>> predicate, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(predicate, nameof(predicate));
+
+            return All.AllAwaitAsync(source, predicate, cancellationToken);
+        }
+
+        public static UniTask<Boolean> AllAwaitWithCancellationAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Boolean>> predicate, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(predicate, nameof(predicate));
+
+            return All.AllAwaitWithCancellationAsync(source, predicate, cancellationToken);
+        }
+    }
+
+    internal static class All
+    {
+        internal static async UniTask<bool> AllAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Boolean> predicate, CancellationToken cancellationToken)
+        {
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    if (!predicate(e.Current))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+        }
+
+        internal static async UniTask<bool> AllAwaitAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Boolean>> predicate, CancellationToken cancellationToken)
+        {
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    if (!await predicate(e.Current))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+        }
+
+        internal static async UniTask<bool> AllAwaitWithCancellationAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Boolean>> predicate, CancellationToken cancellationToken)
+        {
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    if (!await predicate(e.Current, cancellationToken))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/All.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/All.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7271437e0033af2448b600ee248924dd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Any.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Any.cs
@@ -1,0 +1,136 @@
+﻿using Cysharp.Threading.Tasks.Internal;
+using System;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static UniTask<Boolean> AnyAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return Any.AnyAsync(source, cancellationToken);
+        }
+
+        public static UniTask<Boolean> AnyAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Boolean> predicate, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(predicate, nameof(predicate));
+
+            return Any.AnyAsync(source, predicate, cancellationToken);
+        }
+
+        public static UniTask<Boolean> AnyAwaitAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Boolean>> predicate, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(predicate, nameof(predicate));
+
+            return Any.AnyAwaitAsync(source, predicate, cancellationToken);
+        }
+
+        public static UniTask<Boolean> AnyAwaitWithCancellationAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Boolean>> predicate, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(predicate, nameof(predicate));
+
+            return Any.AnyAwaitWithCancellationAsync(source, predicate, cancellationToken);
+        }
+    }
+
+    internal static class Any
+    {
+        internal static async UniTask<bool> AnyAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, CancellationToken cancellationToken)
+        {
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                if (await e.MoveNextAsync())
+                {
+                    return true;
+                }
+
+                return false;
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+        }
+
+        internal static async UniTask<bool> AnyAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Boolean> predicate, CancellationToken cancellationToken)
+        {
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    if (predicate(e.Current))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+        }
+
+        internal static async UniTask<bool> AnyAwaitAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Boolean>> predicate, CancellationToken cancellationToken)
+        {
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    if (await predicate(e.Current))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+        }
+
+        internal static async UniTask<bool> AnyAwaitWithCancellationAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Boolean>> predicate, CancellationToken cancellationToken)
+        {
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    if (await predicate(e.Current, cancellationToken))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Any.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Any.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e2b2e65745263994fbe34f3e0ec8eb12
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/AppendPrepend.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/AppendPrepend.cs
@@ -1,0 +1,151 @@
+﻿using Cysharp.Threading.Tasks.Internal;
+using System;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static IUniTaskAsyncEnumerable<TSource> Append<TSource>(this IUniTaskAsyncEnumerable<TSource> source, TSource element)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return new AppendPrepend<TSource>(source, element, true);
+        }
+
+        public static IUniTaskAsyncEnumerable<TSource> Prepend<TSource>(this IUniTaskAsyncEnumerable<TSource> source, TSource element)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return new AppendPrepend<TSource>(source, element, false);
+        }
+    }
+
+    internal sealed class AppendPrepend<TSource> : IUniTaskAsyncEnumerable<TSource>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+        readonly TSource element;
+        readonly bool append; // or prepend
+
+        public AppendPrepend(IUniTaskAsyncEnumerable<TSource> source, TSource element, bool append)
+        {
+            this.source = source;
+            this.element = element;
+            this.append = append;
+        }
+
+        public IUniTaskAsyncEnumerator<TSource> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _AppendPrepend(source, element, append, cancellationToken);
+        }
+
+        sealed class _AppendPrepend : MoveNextSource, IUniTaskAsyncEnumerator<TSource>
+        {
+            enum State : byte
+            {
+                None,
+                RequirePrepend,
+                RequireAppend,
+                Completed
+            }
+
+            static readonly Action<object> MoveNextCoreDelegate = MoveNextCore;
+
+            readonly IUniTaskAsyncEnumerable<TSource> source;
+            readonly TSource element;
+            CancellationToken cancellationToken;
+
+            State state;
+            IUniTaskAsyncEnumerator<TSource> enumerator;
+            UniTask<bool>.Awaiter awaiter;
+
+            public _AppendPrepend(IUniTaskAsyncEnumerable<TSource> source, TSource element, bool append, CancellationToken cancellationToken)
+            {
+                this.source = source;
+                this.element = element;
+                this.state = append ? State.RequireAppend : State.RequirePrepend;
+                this.cancellationToken = cancellationToken;
+
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public TSource Current { get; private set; }
+
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                completionSource.Reset();
+
+                if (enumerator == null)
+                {
+                    if (state == State.RequirePrepend)
+                    {
+                        Current = element;
+                        state = State.None;
+                        return CompletedTasks.True;
+                    }
+
+                    enumerator = source.GetAsyncEnumerator(cancellationToken);
+                }
+
+                if (state == State.Completed)
+                {
+                    return CompletedTasks.False;
+                }
+
+                awaiter = enumerator.MoveNextAsync().GetAwaiter();
+
+                if (awaiter.IsCompleted)
+                {
+                    MoveNextCoreDelegate(this);
+                }
+                else
+                {
+                    awaiter.SourceOnCompleted(MoveNextCoreDelegate, this);
+                }
+
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            static void MoveNextCore(object state)
+            {
+                var self = (_AppendPrepend)state;
+
+                if (self.TryGetResult(self.awaiter, out var result))
+                {
+                    if (result)
+                    {
+                        self.Current = self.enumerator.Current;
+                        self.completionSource.TrySetResult(true);
+                    }
+                    else
+                    {
+                        if (self.state == State.RequireAppend)
+                        {
+                            self.state = State.Completed;
+                            self.Current = self.element;
+                            self.completionSource.TrySetResult(true);
+                        }
+                        else
+                        {
+                            self.state = State.Completed;
+                            self.completionSource.TrySetResult(false);
+                        }
+                    }
+                }
+            }
+
+            public UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                if (enumerator != null)
+                {
+                    return enumerator.DisposeAsync();
+                }
+                return default;
+            }
+        }
+    }
+
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/AppendPrepend.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/AppendPrepend.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3268ec424b8055f45aa2a26d17c80468
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/AsUniTaskAsyncEnumerable.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/AsUniTaskAsyncEnumerable.cs
@@ -1,0 +1,10 @@
+﻿namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static IUniTaskAsyncEnumerable<TSource> AsUniTaskAsyncEnumerable<TSource>(this IUniTaskAsyncEnumerable<TSource> source)
+        {
+            return source;
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/AsUniTaskAsyncEnumerable.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/AsUniTaskAsyncEnumerable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 69866e262589ea643bbc62a1d696077a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/AsyncEnumeratorBase.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/AsyncEnumeratorBase.cs
@@ -1,0 +1,356 @@
+﻿using System;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    // note: refactor all inherit class and should remove this.
+    // see Select and Where.
+    internal abstract class AsyncEnumeratorBase<TSource, TResult> : MoveNextSource, IUniTaskAsyncEnumerator<TResult>
+    {
+        static readonly Action<object> moveNextCallbackDelegate = MoveNextCallBack;
+
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+        protected CancellationToken cancellationToken;
+
+        IUniTaskAsyncEnumerator<TSource> enumerator;
+        UniTask<bool>.Awaiter sourceMoveNext;
+
+        public AsyncEnumeratorBase(IUniTaskAsyncEnumerable<TSource> source, CancellationToken cancellationToken)
+        {
+            this.source = source;
+            this.cancellationToken = cancellationToken;
+            TaskTracker.TrackActiveTask(this, 4);
+        }
+
+        // abstract
+
+        /// <summary>
+        /// If return value is false, continue source.MoveNext.
+        /// </summary>
+        protected abstract bool TryMoveNextCore(bool sourceHasCurrent, out bool result);
+
+        // Util
+        protected TSource SourceCurrent => enumerator.Current;
+
+        // IUniTaskAsyncEnumerator<T>
+
+        public TResult Current { get; protected set; }
+
+        public UniTask<bool> MoveNextAsync()
+        {
+            if (enumerator == null)
+            {
+                enumerator = source.GetAsyncEnumerator(cancellationToken);
+            }
+
+            completionSource.Reset();
+            if (!OnFirstIteration())
+            {
+                SourceMoveNext();
+            }
+            return new UniTask<bool>(this, completionSource.Version);
+        }
+
+        protected virtual bool OnFirstIteration()
+        {
+            return false;
+        }
+
+        protected void SourceMoveNext()
+        {
+            CONTINUE:
+            sourceMoveNext = enumerator.MoveNextAsync().GetAwaiter();
+            if (sourceMoveNext.IsCompleted)
+            {
+                bool result = false;
+                try
+                {
+                    if (!TryMoveNextCore(sourceMoveNext.GetResult(), out result))
+                    {
+                        goto CONTINUE;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    completionSource.TrySetException(ex);
+                    return;
+                }
+
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    completionSource.TrySetCanceled(cancellationToken);
+                }
+                else
+                {
+                    completionSource.TrySetResult(result);
+                }
+            }
+            else
+            {
+                sourceMoveNext.SourceOnCompleted(moveNextCallbackDelegate, this);
+            }
+        }
+
+        static void MoveNextCallBack(object state)
+        {
+            var self = (AsyncEnumeratorBase<TSource, TResult>)state;
+            bool result;
+            try
+            {
+                if (!self.TryMoveNextCore(self.sourceMoveNext.GetResult(), out result))
+                {
+                    self.SourceMoveNext();
+                    return;
+                }
+            }
+            catch (Exception ex)
+            {
+                self.completionSource.TrySetException(ex);
+                return;
+            }
+
+            if (self.cancellationToken.IsCancellationRequested)
+            {
+                self.completionSource.TrySetCanceled(self.cancellationToken);
+            }
+            else
+            {
+                self.completionSource.TrySetResult(result);
+            }
+        }
+
+        // if require additional resource to dispose, override and call base.DisposeAsync.
+        public virtual UniTask DisposeAsync()
+        {
+            TaskTracker.RemoveTracking(this);
+            if (enumerator != null)
+            {
+                return enumerator.DisposeAsync();
+            }
+            return default;
+        }
+    }
+
+    internal abstract class AsyncEnumeratorAwaitSelectorBase<TSource, TResult, TAwait> : MoveNextSource, IUniTaskAsyncEnumerator<TResult>
+    {
+        static readonly Action<object> moveNextCallbackDelegate = MoveNextCallBack;
+        static readonly Action<object> setCurrentCallbackDelegate = SetCurrentCallBack;
+
+
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+        protected CancellationToken cancellationToken;
+
+        IUniTaskAsyncEnumerator<TSource> enumerator;
+        UniTask<bool>.Awaiter sourceMoveNext;
+
+        UniTask<TAwait>.Awaiter resultAwaiter;
+
+        public AsyncEnumeratorAwaitSelectorBase(IUniTaskAsyncEnumerable<TSource> source, CancellationToken cancellationToken)
+        {
+            this.source = source;
+            this.cancellationToken = cancellationToken;
+            TaskTracker.TrackActiveTask(this, 4);
+        }
+
+        // abstract
+
+        protected abstract UniTask<TAwait> TransformAsync(TSource sourceCurrent);
+        protected abstract bool TrySetCurrentCore(TAwait awaitResult, out bool terminateIteration);
+
+        // Util
+        protected TSource SourceCurrent { get; private set; }
+
+        protected (bool waitCallback, bool requireNextIteration) ActionCompleted(bool trySetCurrentResult, out bool moveNextResult)
+        {
+            if (trySetCurrentResult)
+            {
+                moveNextResult = true;
+                return (false, false);
+            }
+            else
+            {
+                moveNextResult = default;
+                return (false, true);
+            }
+        }
+        protected (bool waitCallback, bool requireNextIteration) WaitAwaitCallback(out bool moveNextResult) { moveNextResult = default; return (true, false); }
+        protected (bool waitCallback, bool requireNextIteration) IterateFinished(out bool moveNextResult) { moveNextResult = false; return (false, false); }
+
+        // IUniTaskAsyncEnumerator<T>
+
+        public TResult Current { get; protected set; }
+
+        public UniTask<bool> MoveNextAsync()
+        {
+            if (enumerator == null)
+            {
+                enumerator = source.GetAsyncEnumerator(cancellationToken);
+            }
+
+            completionSource.Reset();
+            SourceMoveNext();
+            return new UniTask<bool>(this, completionSource.Version);
+        }
+
+        protected void SourceMoveNext()
+        {
+            CONTINUE:
+            sourceMoveNext = enumerator.MoveNextAsync().GetAwaiter();
+            if (sourceMoveNext.IsCompleted)
+            {
+                bool result = false;
+                try
+                {
+                    (bool waitCallback, bool requireNextIteration) = TryMoveNextCore(sourceMoveNext.GetResult(), out result);
+
+                    if (waitCallback)
+                    {
+                        return;
+                    }
+
+                    if (requireNextIteration)
+                    {
+                        goto CONTINUE;
+                    }
+                    else
+                    {
+                        completionSource.TrySetResult(result);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    completionSource.TrySetException(ex);
+                    return;
+                }
+            }
+            else
+            {
+                sourceMoveNext.SourceOnCompleted(moveNextCallbackDelegate, this);
+            }
+        }
+
+        (bool waitCallback, bool requireNextIteration) TryMoveNextCore(bool sourceHasCurrent, out bool result)
+        {
+            if (sourceHasCurrent)
+            {
+                SourceCurrent = enumerator.Current;
+                var task = TransformAsync(SourceCurrent);
+                if (UnwarapTask(task, out var taskResult))
+                {
+                    var currentResult = TrySetCurrentCore(taskResult, out var terminateIteration);
+                    if (terminateIteration)
+                    {
+                        return IterateFinished(out result);
+                    }
+
+                    return ActionCompleted(currentResult, out result);
+                }
+                else
+                {
+                    return WaitAwaitCallback(out result);
+                }
+            }
+
+            return IterateFinished(out result);
+        }
+
+        protected bool UnwarapTask(UniTask<TAwait> taskResult, out TAwait result)
+        {
+            resultAwaiter = taskResult.GetAwaiter();
+
+            if (resultAwaiter.IsCompleted)
+            {
+                result = resultAwaiter.GetResult();
+                return true;
+            }
+            else
+            {
+                resultAwaiter.SourceOnCompleted(setCurrentCallbackDelegate, this);
+                result = default;
+                return false;
+            }
+        }
+
+        static void MoveNextCallBack(object state)
+        {
+            var self = (AsyncEnumeratorAwaitSelectorBase<TSource, TResult, TAwait>)state;
+            bool result = false;
+            try
+            {
+                (bool waitCallback, bool requireNextIteration) = self.TryMoveNextCore(self.sourceMoveNext.GetResult(), out result);
+
+                if (waitCallback)
+                {
+                    return;
+                }
+
+                if (requireNextIteration)
+                {
+                    self.SourceMoveNext();
+                    return;
+                }
+                else
+                {
+                    self.completionSource.TrySetResult(result);
+                }
+            }
+            catch (Exception ex)
+            {
+                self.completionSource.TrySetException(ex);
+                return;
+            }
+        }
+
+        static void SetCurrentCallBack(object state)
+        {
+            var self = (AsyncEnumeratorAwaitSelectorBase<TSource, TResult, TAwait>)state;
+
+            bool doneSetCurrent;
+            bool terminateIteration;
+            try
+            {
+                var result = self.resultAwaiter.GetResult();
+                doneSetCurrent = self.TrySetCurrentCore(result, out terminateIteration);
+            }
+            catch (Exception ex)
+            {
+                self.completionSource.TrySetException(ex);
+                return;
+            }
+
+            if (self.cancellationToken.IsCancellationRequested)
+            {
+                self.completionSource.TrySetCanceled(self.cancellationToken);
+            }
+            else
+            {
+                if (doneSetCurrent)
+                {
+                    self.completionSource.TrySetResult(true);
+                }
+                else
+                {
+                    if (terminateIteration)
+                    {
+                        self.completionSource.TrySetResult(false);
+                    }
+                    else
+                    {
+                        self.SourceMoveNext();
+                    }
+                }
+            }
+        }
+
+        // if require additional resource to dispose, override and call base.DisposeAsync.
+        public virtual UniTask DisposeAsync()
+        {
+            TaskTracker.RemoveTracking(this);
+            if (enumerator != null)
+            {
+                return enumerator.DisposeAsync();
+            }
+            return default;
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/AsyncEnumeratorBase.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/AsyncEnumeratorBase.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 01ba1d3b17e13fb4c95740131c7e6e19
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Average.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Average.cs
@@ -1,0 +1,1524 @@
+﻿using System;
+using System.Threading;
+using Cysharp.Threading.Tasks.Internal;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static UniTask<double> AverageAsync(this IUniTaskAsyncEnumerable<Int32> source, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return Average.AverageAsync(source, cancellationToken);
+        }
+
+        public static UniTask<double> AverageAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Int32> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Average.AverageAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<double> AverageAwaitAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Int32>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Average.AverageAwaitAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<double> AverageAwaitWithCancellationAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Int32>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Average.AverageAwaitWithCancellationAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<double> AverageAsync(this IUniTaskAsyncEnumerable<Int64> source, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return Average.AverageAsync(source, cancellationToken);
+        }
+
+        public static UniTask<double> AverageAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Int64> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Average.AverageAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<double> AverageAwaitAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Int64>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Average.AverageAwaitAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<double> AverageAwaitWithCancellationAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Int64>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Average.AverageAwaitWithCancellationAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<float> AverageAsync(this IUniTaskAsyncEnumerable<Single> source, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return Average.AverageAsync(source, cancellationToken);
+        }
+
+        public static UniTask<float> AverageAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Single> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Average.AverageAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<float> AverageAwaitAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Single>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Average.AverageAwaitAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<float> AverageAwaitWithCancellationAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Single>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Average.AverageAwaitWithCancellationAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<double> AverageAsync(this IUniTaskAsyncEnumerable<Double> source, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return Average.AverageAsync(source, cancellationToken);
+        }
+
+        public static UniTask<double> AverageAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Double> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Average.AverageAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<double> AverageAwaitAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Double>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Average.AverageAwaitAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<double> AverageAwaitWithCancellationAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Double>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Average.AverageAwaitWithCancellationAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<decimal> AverageAsync(this IUniTaskAsyncEnumerable<Decimal> source, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return Average.AverageAsync(source, cancellationToken);
+        }
+
+        public static UniTask<decimal> AverageAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Decimal> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Average.AverageAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<decimal> AverageAwaitAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Decimal>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Average.AverageAwaitAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<decimal> AverageAwaitWithCancellationAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Decimal>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Average.AverageAwaitWithCancellationAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<double?> AverageAsync(this IUniTaskAsyncEnumerable<Int32?> source, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return Average.AverageAsync(source, cancellationToken);
+        }
+
+        public static UniTask<double?> AverageAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Int32?> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Average.AverageAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<double?> AverageAwaitAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Int32?>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Average.AverageAwaitAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<double?> AverageAwaitWithCancellationAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Int32?>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Average.AverageAwaitWithCancellationAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<double?> AverageAsync(this IUniTaskAsyncEnumerable<Int64?> source, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return Average.AverageAsync(source, cancellationToken);
+        }
+
+        public static UniTask<double?> AverageAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Int64?> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Average.AverageAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<double?> AverageAwaitAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Int64?>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Average.AverageAwaitAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<double?> AverageAwaitWithCancellationAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Int64?>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Average.AverageAwaitWithCancellationAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<float?> AverageAsync(this IUniTaskAsyncEnumerable<Single?> source, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return Average.AverageAsync(source, cancellationToken);
+        }
+
+        public static UniTask<float?> AverageAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Single?> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Average.AverageAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<float?> AverageAwaitAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Single?>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Average.AverageAwaitAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<float?> AverageAwaitWithCancellationAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Single?>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Average.AverageAwaitWithCancellationAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<double?> AverageAsync(this IUniTaskAsyncEnumerable<Double?> source, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return Average.AverageAsync(source, cancellationToken);
+        }
+
+        public static UniTask<double?> AverageAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Double?> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Average.AverageAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<double?> AverageAwaitAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Double?>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Average.AverageAwaitAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<double?> AverageAwaitWithCancellationAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Double?>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Average.AverageAwaitWithCancellationAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<decimal?> AverageAsync(this IUniTaskAsyncEnumerable<Decimal?> source, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return Average.AverageAsync(source, cancellationToken);
+        }
+
+        public static UniTask<decimal?> AverageAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Decimal?> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Average.AverageAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<decimal?> AverageAwaitAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Decimal?>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Average.AverageAwaitAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<decimal?> AverageAwaitWithCancellationAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Decimal?>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Average.AverageAwaitWithCancellationAsync(source, selector, cancellationToken);
+        }
+
+    }
+
+    internal static class Average
+    {
+        public static async UniTask<double> AverageAsync(IUniTaskAsyncEnumerable<Int32> source, CancellationToken cancellationToken)
+        {
+            long count = 0;
+            Int32 sum = 0;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    checked
+                    {
+                        sum += e.Current;
+                        count++;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return (double)sum / count;
+        }
+
+        public static async UniTask<double> AverageAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Int32> selector, CancellationToken cancellationToken)
+        {
+            long count = 0;
+            Int32 sum = 0;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    checked
+                    {
+                        sum += selector(e.Current);
+                        count++;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return (double)sum / count;
+        }
+
+        public static async UniTask<double> AverageAwaitAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Int32>> selector, CancellationToken cancellationToken)
+        {
+            long count = 0;
+            Int32 sum = 0;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    checked
+                    {
+                        sum += await selector(e.Current);
+                        count++;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return (double)sum / count;
+        }
+
+        public static async UniTask<double> AverageAwaitWithCancellationAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Int32>> selector, CancellationToken cancellationToken)
+        {
+            long count = 0;
+            Int32 sum = 0;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    checked
+                    {
+                        sum += await selector(e.Current, cancellationToken);
+                        count++;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return (double)sum / count;
+        }
+
+        public static async UniTask<double> AverageAsync(IUniTaskAsyncEnumerable<Int64> source, CancellationToken cancellationToken)
+        {
+            long count = 0;
+            Int64 sum = 0;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    checked
+                    {
+                        sum += e.Current;
+                        count++;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return (double)sum / count;
+        }
+
+        public static async UniTask<double> AverageAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Int64> selector, CancellationToken cancellationToken)
+        {
+            long count = 0;
+            Int64 sum = 0;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    checked
+                    {
+                        sum += selector(e.Current);
+                        count++;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return (double)sum / count;
+        }
+
+        public static async UniTask<double> AverageAwaitAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Int64>> selector, CancellationToken cancellationToken)
+        {
+            long count = 0;
+            Int64 sum = 0;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    checked
+                    {
+                        sum += await selector(e.Current);
+                        count++;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return (double)sum / count;
+        }
+
+        public static async UniTask<double> AverageAwaitWithCancellationAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Int64>> selector, CancellationToken cancellationToken)
+        {
+            long count = 0;
+            Int64 sum = 0;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    checked
+                    {
+                        sum += await selector(e.Current, cancellationToken);
+                        count++;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return (double)sum / count;
+        }
+
+        public static async UniTask<float> AverageAsync(IUniTaskAsyncEnumerable<Single> source, CancellationToken cancellationToken)
+        {
+            long count = 0;
+            Single sum = 0;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    checked
+                    {
+                        sum += e.Current;
+                        count++;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return (float)(sum / count);
+        }
+
+        public static async UniTask<float> AverageAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Single> selector, CancellationToken cancellationToken)
+        {
+            long count = 0;
+            Single sum = 0;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    checked
+                    {
+                        sum += selector(e.Current);
+                        count++;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return (float)(sum / count);
+        }
+
+        public static async UniTask<float> AverageAwaitAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Single>> selector, CancellationToken cancellationToken)
+        {
+            long count = 0;
+            Single sum = 0;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    checked
+                    {
+                        sum += await selector(e.Current);
+                        count++;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return (float)(sum / count);
+        }
+
+        public static async UniTask<float> AverageAwaitWithCancellationAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Single>> selector, CancellationToken cancellationToken)
+        {
+            long count = 0;
+            Single sum = 0;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    checked
+                    {
+                        sum += await selector(e.Current, cancellationToken);
+                        count++;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return (float)(sum / count);
+        }
+
+        public static async UniTask<double> AverageAsync(IUniTaskAsyncEnumerable<Double> source, CancellationToken cancellationToken)
+        {
+            long count = 0;
+            Double sum = 0;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    checked
+                    {
+                        sum += e.Current;
+                        count++;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return sum / count;
+        }
+
+        public static async UniTask<double> AverageAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Double> selector, CancellationToken cancellationToken)
+        {
+            long count = 0;
+            Double sum = 0;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    checked
+                    {
+                        sum += selector(e.Current);
+                        count++;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return sum / count;
+        }
+
+        public static async UniTask<double> AverageAwaitAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Double>> selector, CancellationToken cancellationToken)
+        {
+            long count = 0;
+            Double sum = 0;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    checked
+                    {
+                        sum += await selector(e.Current);
+                        count++;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return sum / count;
+        }
+
+        public static async UniTask<double> AverageAwaitWithCancellationAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Double>> selector, CancellationToken cancellationToken)
+        {
+            long count = 0;
+            Double sum = 0;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    checked
+                    {
+                        sum += await selector(e.Current, cancellationToken);
+                        count++;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return sum / count;
+        }
+
+        public static async UniTask<decimal> AverageAsync(IUniTaskAsyncEnumerable<Decimal> source, CancellationToken cancellationToken)
+        {
+            long count = 0;
+            Decimal sum = 0;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    checked
+                    {
+                        sum += e.Current;
+                        count++;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return sum / count;
+        }
+
+        public static async UniTask<decimal> AverageAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Decimal> selector, CancellationToken cancellationToken)
+        {
+            long count = 0;
+            Decimal sum = 0;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    checked
+                    {
+                        sum += selector(e.Current);
+                        count++;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return sum / count;
+        }
+
+        public static async UniTask<decimal> AverageAwaitAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Decimal>> selector, CancellationToken cancellationToken)
+        {
+            long count = 0;
+            Decimal sum = 0;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    checked
+                    {
+                        sum += await selector(e.Current);
+                        count++;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return sum / count;
+        }
+
+        public static async UniTask<decimal> AverageAwaitWithCancellationAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Decimal>> selector, CancellationToken cancellationToken)
+        {
+            long count = 0;
+            Decimal sum = 0;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    checked
+                    {
+                        sum += await selector(e.Current, cancellationToken);
+                        count++;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return sum / count;
+        }
+
+        public static async UniTask<double?> AverageAsync(IUniTaskAsyncEnumerable<Int32?> source, CancellationToken cancellationToken)
+        {
+            long count = 0;
+            Int32? sum = 0;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    var v = e.Current;
+                    if (v.HasValue)
+                    {
+                        checked    
+                        {
+                            sum += v.Value;
+                            count++;
+                        }
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return (double)sum / count;
+        }
+
+        public static async UniTask<double?> AverageAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Int32?> selector, CancellationToken cancellationToken)
+        {
+            long count = 0;
+            Int32? sum = 0;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    var v = selector(e.Current);
+                    if (v.HasValue)
+                    {
+                        checked    
+                        {
+                            sum += v.Value;
+                            count++;
+                        }
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return (double)sum / count;
+        }
+
+        public static async UniTask<double?> AverageAwaitAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Int32?>> selector, CancellationToken cancellationToken)
+        {
+            long count = 0;
+            Int32? sum = 0;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    var v = await selector(e.Current);
+                    if (v.HasValue)
+                    {
+                        checked    
+                        {
+                            sum += v.Value;
+                            count++;
+                        }
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return (double)sum / count;
+        }
+
+        public static async UniTask<double?> AverageAwaitWithCancellationAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Int32?>> selector, CancellationToken cancellationToken)
+        {
+            long count = 0;
+            Int32? sum = 0;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    var v = await selector(e.Current, cancellationToken);
+                    if (v.HasValue)
+                    {
+                        checked    
+                        {
+                            sum += v.Value;
+                            count++;
+                        }
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return (double)sum / count;
+        }
+
+        public static async UniTask<double?> AverageAsync(IUniTaskAsyncEnumerable<Int64?> source, CancellationToken cancellationToken)
+        {
+            long count = 0;
+            Int64? sum = 0;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    var v = e.Current;
+                    if (v.HasValue)
+                    {
+                        checked    
+                        {
+                            sum += v.Value;
+                            count++;
+                        }
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return (double)sum / count;
+        }
+
+        public static async UniTask<double?> AverageAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Int64?> selector, CancellationToken cancellationToken)
+        {
+            long count = 0;
+            Int64? sum = 0;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    var v = selector(e.Current);
+                    if (v.HasValue)
+                    {
+                        checked    
+                        {
+                            sum += v.Value;
+                            count++;
+                        }
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return (double)sum / count;
+        }
+
+        public static async UniTask<double?> AverageAwaitAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Int64?>> selector, CancellationToken cancellationToken)
+        {
+            long count = 0;
+            Int64? sum = 0;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    var v = await selector(e.Current);
+                    if (v.HasValue)
+                    {
+                        checked    
+                        {
+                            sum += v.Value;
+                            count++;
+                        }
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return (double)sum / count;
+        }
+
+        public static async UniTask<double?> AverageAwaitWithCancellationAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Int64?>> selector, CancellationToken cancellationToken)
+        {
+            long count = 0;
+            Int64? sum = 0;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    var v = await selector(e.Current, cancellationToken);
+                    if (v.HasValue)
+                    {
+                        checked    
+                        {
+                            sum += v.Value;
+                            count++;
+                        }
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return (double)sum / count;
+        }
+
+        public static async UniTask<float?> AverageAsync(IUniTaskAsyncEnumerable<Single?> source, CancellationToken cancellationToken)
+        {
+            long count = 0;
+            Single? sum = 0;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    var v = e.Current;
+                    if (v.HasValue)
+                    {
+                        checked    
+                        {
+                            sum += v.Value;
+                            count++;
+                        }
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return (float)(sum / count);
+        }
+
+        public static async UniTask<float?> AverageAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Single?> selector, CancellationToken cancellationToken)
+        {
+            long count = 0;
+            Single? sum = 0;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    var v = selector(e.Current);
+                    if (v.HasValue)
+                    {
+                        checked    
+                        {
+                            sum += v.Value;
+                            count++;
+                        }
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return (float)(sum / count);
+        }
+
+        public static async UniTask<float?> AverageAwaitAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Single?>> selector, CancellationToken cancellationToken)
+        {
+            long count = 0;
+            Single? sum = 0;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    var v = await selector(e.Current);
+                    if (v.HasValue)
+                    {
+                        checked    
+                        {
+                            sum += v.Value;
+                            count++;
+                        }
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return (float)(sum / count);
+        }
+
+        public static async UniTask<float?> AverageAwaitWithCancellationAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Single?>> selector, CancellationToken cancellationToken)
+        {
+            long count = 0;
+            Single? sum = 0;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    var v = await selector(e.Current, cancellationToken);
+                    if (v.HasValue)
+                    {
+                        checked    
+                        {
+                            sum += v.Value;
+                            count++;
+                        }
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return (float)(sum / count);
+        }
+
+        public static async UniTask<double?> AverageAsync(IUniTaskAsyncEnumerable<Double?> source, CancellationToken cancellationToken)
+        {
+            long count = 0;
+            Double? sum = 0;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    var v = e.Current;
+                    if (v.HasValue)
+                    {
+                        checked    
+                        {
+                            sum += v.Value;
+                            count++;
+                        }
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return sum / count;
+        }
+
+        public static async UniTask<double?> AverageAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Double?> selector, CancellationToken cancellationToken)
+        {
+            long count = 0;
+            Double? sum = 0;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    var v = selector(e.Current);
+                    if (v.HasValue)
+                    {
+                        checked    
+                        {
+                            sum += v.Value;
+                            count++;
+                        }
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return sum / count;
+        }
+
+        public static async UniTask<double?> AverageAwaitAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Double?>> selector, CancellationToken cancellationToken)
+        {
+            long count = 0;
+            Double? sum = 0;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    var v = await selector(e.Current);
+                    if (v.HasValue)
+                    {
+                        checked    
+                        {
+                            sum += v.Value;
+                            count++;
+                        }
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return sum / count;
+        }
+
+        public static async UniTask<double?> AverageAwaitWithCancellationAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Double?>> selector, CancellationToken cancellationToken)
+        {
+            long count = 0;
+            Double? sum = 0;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    var v = await selector(e.Current, cancellationToken);
+                    if (v.HasValue)
+                    {
+                        checked    
+                        {
+                            sum += v.Value;
+                            count++;
+                        }
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return sum / count;
+        }
+
+        public static async UniTask<decimal?> AverageAsync(IUniTaskAsyncEnumerable<Decimal?> source, CancellationToken cancellationToken)
+        {
+            long count = 0;
+            Decimal? sum = 0;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    var v = e.Current;
+                    if (v.HasValue)
+                    {
+                        checked    
+                        {
+                            sum += v.Value;
+                            count++;
+                        }
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return sum / count;
+        }
+
+        public static async UniTask<decimal?> AverageAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Decimal?> selector, CancellationToken cancellationToken)
+        {
+            long count = 0;
+            Decimal? sum = 0;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    var v = selector(e.Current);
+                    if (v.HasValue)
+                    {
+                        checked    
+                        {
+                            sum += v.Value;
+                            count++;
+                        }
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return sum / count;
+        }
+
+        public static async UniTask<decimal?> AverageAwaitAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Decimal?>> selector, CancellationToken cancellationToken)
+        {
+            long count = 0;
+            Decimal? sum = 0;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    var v = await selector(e.Current);
+                    if (v.HasValue)
+                    {
+                        checked    
+                        {
+                            sum += v.Value;
+                            count++;
+                        }
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return sum / count;
+        }
+
+        public static async UniTask<decimal?> AverageAwaitWithCancellationAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Decimal?>> selector, CancellationToken cancellationToken)
+        {
+            long count = 0;
+            Decimal? sum = 0;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    var v = await selector(e.Current, cancellationToken);
+                    if (v.HasValue)
+                    {
+                        checked    
+                        {
+                            sum += v.Value;
+                            count++;
+                        }
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return sum / count;
+        }
+
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Average.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Average.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 58499f95012fb3c47bb7bcbc5862e562
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Buffer.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Buffer.cs
@@ -1,0 +1,345 @@
+﻿using Cysharp.Threading.Tasks.Internal;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static IUniTaskAsyncEnumerable<IList<TSource>> Buffer<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Int32 count)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            if (count <= 0) throw Error.ArgumentOutOfRange(nameof(count));
+
+            return new Buffer<TSource>(source, count);
+        }
+
+        public static IUniTaskAsyncEnumerable<IList<TSource>> Buffer<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Int32 count, Int32 skip)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            if (count <= 0) throw Error.ArgumentOutOfRange(nameof(count));
+            if (skip <= 0) throw Error.ArgumentOutOfRange(nameof(skip));
+
+            return new BufferSkip<TSource>(source, count, skip);
+        }
+    }
+
+    internal sealed class Buffer<TSource> : IUniTaskAsyncEnumerable<IList<TSource>>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+        readonly int count;
+
+        public Buffer(IUniTaskAsyncEnumerable<TSource> source, int count)
+        {
+            this.source = source;
+            this.count = count;
+        }
+
+        public IUniTaskAsyncEnumerator<IList<TSource>> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _Buffer(source, count, cancellationToken);
+        }
+
+        sealed class _Buffer : MoveNextSource, IUniTaskAsyncEnumerator<IList<TSource>>
+        {
+            static readonly Action<object> MoveNextCoreDelegate = MoveNextCore;
+
+            readonly IUniTaskAsyncEnumerable<TSource> source;
+            readonly int count;
+            CancellationToken cancellationToken;
+
+            IUniTaskAsyncEnumerator<TSource> enumerator;
+            UniTask<bool>.Awaiter awaiter;
+            bool continueNext;
+
+            bool completed;
+            List<TSource> buffer;
+
+            public _Buffer(IUniTaskAsyncEnumerable<TSource> source, int count, CancellationToken cancellationToken)
+            {
+                this.source = source;
+                this.count = count;
+                this.cancellationToken = cancellationToken;
+
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public IList<TSource> Current { get; private set; }
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (enumerator == null)
+                {
+                    enumerator = source.GetAsyncEnumerator(cancellationToken);
+                    buffer = new List<TSource>(count);
+                }
+
+                completionSource.Reset();
+                SourceMoveNext();
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            void SourceMoveNext()
+            {
+                if (completed)
+                {
+                    if (buffer != null && buffer.Count > 0)
+                    {
+                        var ret = buffer;
+                        buffer = null;
+                        Current = ret;
+                        completionSource.TrySetResult(true);
+                        return;
+                    }
+                    else
+                    {
+                        completionSource.TrySetResult(false);
+                        return;
+                    }
+                }
+
+                try
+                {
+
+                    LOOP:
+                    awaiter = enumerator.MoveNextAsync().GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        continueNext = true;
+                        MoveNextCore(this);
+                        if (continueNext)
+                        {
+                            continueNext = false;
+                            goto LOOP; // avoid recursive
+                        }
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(MoveNextCoreDelegate, this);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    completionSource.TrySetException(ex);
+                }
+            }
+
+
+            static void MoveNextCore(object state)
+            {
+                var self = (_Buffer)state;
+
+                if (self.TryGetResult(self.awaiter, out var result))
+                {
+                    if (result)
+                    {
+                        self.buffer.Add(self.enumerator.Current);
+
+                        if (self.buffer.Count == self.count)
+                        {
+                            self.Current = self.buffer;
+                            self.buffer = new List<TSource>(self.count);
+                            self.continueNext = false;
+                            self.completionSource.TrySetResult(true);
+                            return;
+                        }
+                        else
+                        {
+                            if (!self.continueNext)
+                            {
+                                self.SourceMoveNext();
+                            }
+                        }
+                    }
+                    else
+                    {
+                        self.continueNext = false;
+                        self.completed = true;
+                        self.SourceMoveNext();
+                    }
+                }
+                else
+                {
+                    self.continueNext = false;
+                }
+            }
+
+            public UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                if (enumerator != null)
+                {
+                    return enumerator.DisposeAsync();
+                }
+                return default;
+            }
+        }
+    }
+
+    internal sealed class BufferSkip<TSource> : IUniTaskAsyncEnumerable<IList<TSource>>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+        readonly int count;
+        readonly int skip;
+
+        public BufferSkip(IUniTaskAsyncEnumerable<TSource> source, int count, int skip)
+        {
+            this.source = source;
+            this.count = count;
+            this.skip = skip;
+        }
+
+        public IUniTaskAsyncEnumerator<IList<TSource>> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _BufferSkip(source, count, skip, cancellationToken);
+        }
+
+        sealed class _BufferSkip : MoveNextSource, IUniTaskAsyncEnumerator<IList<TSource>>
+        {
+            static readonly Action<object> MoveNextCoreDelegate = MoveNextCore;
+
+            readonly IUniTaskAsyncEnumerable<TSource> source;
+            readonly int count;
+            readonly int skip;
+            CancellationToken cancellationToken;
+
+            IUniTaskAsyncEnumerator<TSource> enumerator;
+            UniTask<bool>.Awaiter awaiter;
+            bool continueNext;
+
+            bool completed;
+            Queue<List<TSource>> buffers;
+            int index = 0;
+
+            public _BufferSkip(IUniTaskAsyncEnumerable<TSource> source, int count, int skip, CancellationToken cancellationToken)
+            {
+                this.source = source;
+                this.count = count;
+                this.skip = skip;
+                this.cancellationToken = cancellationToken;
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public IList<TSource> Current { get; private set; }
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (enumerator == null)
+                {
+                    enumerator = source.GetAsyncEnumerator(cancellationToken);
+                    buffers = new Queue<List<TSource>>();
+                }
+
+                completionSource.Reset();
+                SourceMoveNext();
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            void SourceMoveNext()
+            {
+                if (completed)
+                {
+                    if (buffers.Count > 0)
+                    {
+                        Current = buffers.Dequeue();
+                        completionSource.TrySetResult(true);
+                        return;
+                    }
+                    else
+                    {
+                        completionSource.TrySetResult(false);
+                        return;
+                    }
+                }
+
+                try
+                {
+
+                    LOOP:
+                    awaiter = enumerator.MoveNextAsync().GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        continueNext = true;
+                        MoveNextCore(this);
+                        if (continueNext)
+                        {
+                            continueNext = false;
+                            goto LOOP; // avoid recursive
+                        }
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(MoveNextCoreDelegate, this);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    completionSource.TrySetException(ex);
+                }
+            }
+
+
+            static void MoveNextCore(object state)
+            {
+                var self = (_BufferSkip)state;
+
+                if (self.TryGetResult(self.awaiter, out var result))
+                {
+                    if (result)
+                    {
+                        if (self.index++ % self.skip == 0)
+                        {
+                            self.buffers.Enqueue(new List<TSource>(self.count));
+                        }
+
+                        var item = self.enumerator.Current;
+                        foreach (var buffer in self.buffers)
+                        {
+                            buffer.Add(item);
+                        }
+
+                        if (self.buffers.Count > 0 && self.buffers.Peek().Count == self.count)
+                        {
+                            self.Current = self.buffers.Dequeue();
+                            self.continueNext = false;
+                            self.completionSource.TrySetResult(true);
+                            return;
+                        }
+                        else
+                        {
+                            if (!self.continueNext)
+                            {
+                                self.SourceMoveNext();
+                            }
+                        }
+                    }
+                    else
+                    {
+                        self.continueNext = false;
+                        self.completed = true;
+                        self.SourceMoveNext();
+                    }
+                }
+                else
+                {
+                    self.continueNext = false;
+                }
+            }
+
+            public UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                if (enumerator != null)
+                {
+                    return enumerator.DisposeAsync();
+                }
+                return default;
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Buffer.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Buffer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 951310243334a3148a7872977cb31c5c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Cast.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Cast.cs
@@ -1,0 +1,53 @@
+﻿using Cysharp.Threading.Tasks.Internal;
+using System;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static IUniTaskAsyncEnumerable<TResult> Cast<TResult>(this IUniTaskAsyncEnumerable<Object> source)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return new Cast<TResult>(source);
+        }
+    }
+
+    internal sealed class Cast<TResult> : IUniTaskAsyncEnumerable<TResult>
+    {
+        readonly IUniTaskAsyncEnumerable<object> source;
+
+        public Cast(IUniTaskAsyncEnumerable<object> source)
+        {
+            this.source = source;
+        }
+
+        public IUniTaskAsyncEnumerator<TResult> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _Cast(source, cancellationToken);
+        }
+
+        class _Cast : AsyncEnumeratorBase<object, TResult>
+        {
+            public _Cast(IUniTaskAsyncEnumerable<object> source, CancellationToken cancellationToken)
+
+                : base(source, cancellationToken)
+            {
+            }
+
+            protected override bool TryMoveNextCore(bool sourceHasCurrent, out bool result)
+            {
+                if (sourceHasCurrent)
+                {
+                    Current = (TResult)SourceCurrent;
+                    result = true;
+                    return true;
+                }
+
+                result = false;
+                return true;
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Cast.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Cast.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: edebeae8b61352b428abe9ce8f3fc71a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/CombineLatest.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/CombineLatest.cs
@@ -1,0 +1,11372 @@
+﻿using Cysharp.Threading.Tasks.Internal;
+using System;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static IUniTaskAsyncEnumerable<TResult> CombineLatest<T1, T2, TResult>(this IUniTaskAsyncEnumerable<T1> source1, IUniTaskAsyncEnumerable<T2> source2, Func<T1, T2, TResult> resultSelector)
+        {
+            Error.ThrowArgumentNullException(source1, nameof(source1));
+            Error.ThrowArgumentNullException(source2, nameof(source2));
+            Error.ThrowArgumentNullException(resultSelector, nameof(resultSelector));
+
+            return new CombineLatest<T1, T2, TResult>(source1, source2, resultSelector);
+        }
+
+        public static IUniTaskAsyncEnumerable<TResult> CombineLatest<T1, T2, T3, TResult>(this IUniTaskAsyncEnumerable<T1> source1, IUniTaskAsyncEnumerable<T2> source2, IUniTaskAsyncEnumerable<T3> source3, Func<T1, T2, T3, TResult> resultSelector)
+        {
+            Error.ThrowArgumentNullException(source1, nameof(source1));
+            Error.ThrowArgumentNullException(source2, nameof(source2));
+            Error.ThrowArgumentNullException(source3, nameof(source3));
+            Error.ThrowArgumentNullException(resultSelector, nameof(resultSelector));
+
+            return new CombineLatest<T1, T2, T3, TResult>(source1, source2, source3, resultSelector);
+        }
+
+        public static IUniTaskAsyncEnumerable<TResult> CombineLatest<T1, T2, T3, T4, TResult>(this IUniTaskAsyncEnumerable<T1> source1, IUniTaskAsyncEnumerable<T2> source2, IUniTaskAsyncEnumerable<T3> source3, IUniTaskAsyncEnumerable<T4> source4, Func<T1, T2, T3, T4, TResult> resultSelector)
+        {
+            Error.ThrowArgumentNullException(source1, nameof(source1));
+            Error.ThrowArgumentNullException(source2, nameof(source2));
+            Error.ThrowArgumentNullException(source3, nameof(source3));
+            Error.ThrowArgumentNullException(source4, nameof(source4));
+            Error.ThrowArgumentNullException(resultSelector, nameof(resultSelector));
+
+            return new CombineLatest<T1, T2, T3, T4, TResult>(source1, source2, source3, source4, resultSelector);
+        }
+
+        public static IUniTaskAsyncEnumerable<TResult> CombineLatest<T1, T2, T3, T4, T5, TResult>(this IUniTaskAsyncEnumerable<T1> source1, IUniTaskAsyncEnumerable<T2> source2, IUniTaskAsyncEnumerable<T3> source3, IUniTaskAsyncEnumerable<T4> source4, IUniTaskAsyncEnumerable<T5> source5, Func<T1, T2, T3, T4, T5, TResult> resultSelector)
+        {
+            Error.ThrowArgumentNullException(source1, nameof(source1));
+            Error.ThrowArgumentNullException(source2, nameof(source2));
+            Error.ThrowArgumentNullException(source3, nameof(source3));
+            Error.ThrowArgumentNullException(source4, nameof(source4));
+            Error.ThrowArgumentNullException(source5, nameof(source5));
+            Error.ThrowArgumentNullException(resultSelector, nameof(resultSelector));
+
+            return new CombineLatest<T1, T2, T3, T4, T5, TResult>(source1, source2, source3, source4, source5, resultSelector);
+        }
+
+        public static IUniTaskAsyncEnumerable<TResult> CombineLatest<T1, T2, T3, T4, T5, T6, TResult>(this IUniTaskAsyncEnumerable<T1> source1, IUniTaskAsyncEnumerable<T2> source2, IUniTaskAsyncEnumerable<T3> source3, IUniTaskAsyncEnumerable<T4> source4, IUniTaskAsyncEnumerable<T5> source5, IUniTaskAsyncEnumerable<T6> source6, Func<T1, T2, T3, T4, T5, T6, TResult> resultSelector)
+        {
+            Error.ThrowArgumentNullException(source1, nameof(source1));
+            Error.ThrowArgumentNullException(source2, nameof(source2));
+            Error.ThrowArgumentNullException(source3, nameof(source3));
+            Error.ThrowArgumentNullException(source4, nameof(source4));
+            Error.ThrowArgumentNullException(source5, nameof(source5));
+            Error.ThrowArgumentNullException(source6, nameof(source6));
+            Error.ThrowArgumentNullException(resultSelector, nameof(resultSelector));
+
+            return new CombineLatest<T1, T2, T3, T4, T5, T6, TResult>(source1, source2, source3, source4, source5, source6, resultSelector);
+        }
+
+        public static IUniTaskAsyncEnumerable<TResult> CombineLatest<T1, T2, T3, T4, T5, T6, T7, TResult>(this IUniTaskAsyncEnumerable<T1> source1, IUniTaskAsyncEnumerable<T2> source2, IUniTaskAsyncEnumerable<T3> source3, IUniTaskAsyncEnumerable<T4> source4, IUniTaskAsyncEnumerable<T5> source5, IUniTaskAsyncEnumerable<T6> source6, IUniTaskAsyncEnumerable<T7> source7, Func<T1, T2, T3, T4, T5, T6, T7, TResult> resultSelector)
+        {
+            Error.ThrowArgumentNullException(source1, nameof(source1));
+            Error.ThrowArgumentNullException(source2, nameof(source2));
+            Error.ThrowArgumentNullException(source3, nameof(source3));
+            Error.ThrowArgumentNullException(source4, nameof(source4));
+            Error.ThrowArgumentNullException(source5, nameof(source5));
+            Error.ThrowArgumentNullException(source6, nameof(source6));
+            Error.ThrowArgumentNullException(source7, nameof(source7));
+            Error.ThrowArgumentNullException(resultSelector, nameof(resultSelector));
+
+            return new CombineLatest<T1, T2, T3, T4, T5, T6, T7, TResult>(source1, source2, source3, source4, source5, source6, source7, resultSelector);
+        }
+
+        public static IUniTaskAsyncEnumerable<TResult> CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(this IUniTaskAsyncEnumerable<T1> source1, IUniTaskAsyncEnumerable<T2> source2, IUniTaskAsyncEnumerable<T3> source3, IUniTaskAsyncEnumerable<T4> source4, IUniTaskAsyncEnumerable<T5> source5, IUniTaskAsyncEnumerable<T6> source6, IUniTaskAsyncEnumerable<T7> source7, IUniTaskAsyncEnumerable<T8> source8, Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> resultSelector)
+        {
+            Error.ThrowArgumentNullException(source1, nameof(source1));
+            Error.ThrowArgumentNullException(source2, nameof(source2));
+            Error.ThrowArgumentNullException(source3, nameof(source3));
+            Error.ThrowArgumentNullException(source4, nameof(source4));
+            Error.ThrowArgumentNullException(source5, nameof(source5));
+            Error.ThrowArgumentNullException(source6, nameof(source6));
+            Error.ThrowArgumentNullException(source7, nameof(source7));
+            Error.ThrowArgumentNullException(source8, nameof(source8));
+            Error.ThrowArgumentNullException(resultSelector, nameof(resultSelector));
+
+            return new CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(source1, source2, source3, source4, source5, source6, source7, source8, resultSelector);
+        }
+
+        public static IUniTaskAsyncEnumerable<TResult> CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(this IUniTaskAsyncEnumerable<T1> source1, IUniTaskAsyncEnumerable<T2> source2, IUniTaskAsyncEnumerable<T3> source3, IUniTaskAsyncEnumerable<T4> source4, IUniTaskAsyncEnumerable<T5> source5, IUniTaskAsyncEnumerable<T6> source6, IUniTaskAsyncEnumerable<T7> source7, IUniTaskAsyncEnumerable<T8> source8, IUniTaskAsyncEnumerable<T9> source9, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> resultSelector)
+        {
+            Error.ThrowArgumentNullException(source1, nameof(source1));
+            Error.ThrowArgumentNullException(source2, nameof(source2));
+            Error.ThrowArgumentNullException(source3, nameof(source3));
+            Error.ThrowArgumentNullException(source4, nameof(source4));
+            Error.ThrowArgumentNullException(source5, nameof(source5));
+            Error.ThrowArgumentNullException(source6, nameof(source6));
+            Error.ThrowArgumentNullException(source7, nameof(source7));
+            Error.ThrowArgumentNullException(source8, nameof(source8));
+            Error.ThrowArgumentNullException(source9, nameof(source9));
+            Error.ThrowArgumentNullException(resultSelector, nameof(resultSelector));
+
+            return new CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(source1, source2, source3, source4, source5, source6, source7, source8, source9, resultSelector);
+        }
+
+        public static IUniTaskAsyncEnumerable<TResult> CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(this IUniTaskAsyncEnumerable<T1> source1, IUniTaskAsyncEnumerable<T2> source2, IUniTaskAsyncEnumerable<T3> source3, IUniTaskAsyncEnumerable<T4> source4, IUniTaskAsyncEnumerable<T5> source5, IUniTaskAsyncEnumerable<T6> source6, IUniTaskAsyncEnumerable<T7> source7, IUniTaskAsyncEnumerable<T8> source8, IUniTaskAsyncEnumerable<T9> source9, IUniTaskAsyncEnumerable<T10> source10, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> resultSelector)
+        {
+            Error.ThrowArgumentNullException(source1, nameof(source1));
+            Error.ThrowArgumentNullException(source2, nameof(source2));
+            Error.ThrowArgumentNullException(source3, nameof(source3));
+            Error.ThrowArgumentNullException(source4, nameof(source4));
+            Error.ThrowArgumentNullException(source5, nameof(source5));
+            Error.ThrowArgumentNullException(source6, nameof(source6));
+            Error.ThrowArgumentNullException(source7, nameof(source7));
+            Error.ThrowArgumentNullException(source8, nameof(source8));
+            Error.ThrowArgumentNullException(source9, nameof(source9));
+            Error.ThrowArgumentNullException(source10, nameof(source10));
+            Error.ThrowArgumentNullException(resultSelector, nameof(resultSelector));
+
+            return new CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(source1, source2, source3, source4, source5, source6, source7, source8, source9, source10, resultSelector);
+        }
+
+        public static IUniTaskAsyncEnumerable<TResult> CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>(this IUniTaskAsyncEnumerable<T1> source1, IUniTaskAsyncEnumerable<T2> source2, IUniTaskAsyncEnumerable<T3> source3, IUniTaskAsyncEnumerable<T4> source4, IUniTaskAsyncEnumerable<T5> source5, IUniTaskAsyncEnumerable<T6> source6, IUniTaskAsyncEnumerable<T7> source7, IUniTaskAsyncEnumerable<T8> source8, IUniTaskAsyncEnumerable<T9> source9, IUniTaskAsyncEnumerable<T10> source10, IUniTaskAsyncEnumerable<T11> source11, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> resultSelector)
+        {
+            Error.ThrowArgumentNullException(source1, nameof(source1));
+            Error.ThrowArgumentNullException(source2, nameof(source2));
+            Error.ThrowArgumentNullException(source3, nameof(source3));
+            Error.ThrowArgumentNullException(source4, nameof(source4));
+            Error.ThrowArgumentNullException(source5, nameof(source5));
+            Error.ThrowArgumentNullException(source6, nameof(source6));
+            Error.ThrowArgumentNullException(source7, nameof(source7));
+            Error.ThrowArgumentNullException(source8, nameof(source8));
+            Error.ThrowArgumentNullException(source9, nameof(source9));
+            Error.ThrowArgumentNullException(source10, nameof(source10));
+            Error.ThrowArgumentNullException(source11, nameof(source11));
+            Error.ThrowArgumentNullException(resultSelector, nameof(resultSelector));
+
+            return new CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>(source1, source2, source3, source4, source5, source6, source7, source8, source9, source10, source11, resultSelector);
+        }
+
+        public static IUniTaskAsyncEnumerable<TResult> CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>(this IUniTaskAsyncEnumerable<T1> source1, IUniTaskAsyncEnumerable<T2> source2, IUniTaskAsyncEnumerable<T3> source3, IUniTaskAsyncEnumerable<T4> source4, IUniTaskAsyncEnumerable<T5> source5, IUniTaskAsyncEnumerable<T6> source6, IUniTaskAsyncEnumerable<T7> source7, IUniTaskAsyncEnumerable<T8> source8, IUniTaskAsyncEnumerable<T9> source9, IUniTaskAsyncEnumerable<T10> source10, IUniTaskAsyncEnumerable<T11> source11, IUniTaskAsyncEnumerable<T12> source12, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> resultSelector)
+        {
+            Error.ThrowArgumentNullException(source1, nameof(source1));
+            Error.ThrowArgumentNullException(source2, nameof(source2));
+            Error.ThrowArgumentNullException(source3, nameof(source3));
+            Error.ThrowArgumentNullException(source4, nameof(source4));
+            Error.ThrowArgumentNullException(source5, nameof(source5));
+            Error.ThrowArgumentNullException(source6, nameof(source6));
+            Error.ThrowArgumentNullException(source7, nameof(source7));
+            Error.ThrowArgumentNullException(source8, nameof(source8));
+            Error.ThrowArgumentNullException(source9, nameof(source9));
+            Error.ThrowArgumentNullException(source10, nameof(source10));
+            Error.ThrowArgumentNullException(source11, nameof(source11));
+            Error.ThrowArgumentNullException(source12, nameof(source12));
+            Error.ThrowArgumentNullException(resultSelector, nameof(resultSelector));
+
+            return new CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>(source1, source2, source3, source4, source5, source6, source7, source8, source9, source10, source11, source12, resultSelector);
+        }
+
+        public static IUniTaskAsyncEnumerable<TResult> CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>(this IUniTaskAsyncEnumerable<T1> source1, IUniTaskAsyncEnumerable<T2> source2, IUniTaskAsyncEnumerable<T3> source3, IUniTaskAsyncEnumerable<T4> source4, IUniTaskAsyncEnumerable<T5> source5, IUniTaskAsyncEnumerable<T6> source6, IUniTaskAsyncEnumerable<T7> source7, IUniTaskAsyncEnumerable<T8> source8, IUniTaskAsyncEnumerable<T9> source9, IUniTaskAsyncEnumerable<T10> source10, IUniTaskAsyncEnumerable<T11> source11, IUniTaskAsyncEnumerable<T12> source12, IUniTaskAsyncEnumerable<T13> source13, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> resultSelector)
+        {
+            Error.ThrowArgumentNullException(source1, nameof(source1));
+            Error.ThrowArgumentNullException(source2, nameof(source2));
+            Error.ThrowArgumentNullException(source3, nameof(source3));
+            Error.ThrowArgumentNullException(source4, nameof(source4));
+            Error.ThrowArgumentNullException(source5, nameof(source5));
+            Error.ThrowArgumentNullException(source6, nameof(source6));
+            Error.ThrowArgumentNullException(source7, nameof(source7));
+            Error.ThrowArgumentNullException(source8, nameof(source8));
+            Error.ThrowArgumentNullException(source9, nameof(source9));
+            Error.ThrowArgumentNullException(source10, nameof(source10));
+            Error.ThrowArgumentNullException(source11, nameof(source11));
+            Error.ThrowArgumentNullException(source12, nameof(source12));
+            Error.ThrowArgumentNullException(source13, nameof(source13));
+            Error.ThrowArgumentNullException(resultSelector, nameof(resultSelector));
+
+            return new CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>(source1, source2, source3, source4, source5, source6, source7, source8, source9, source10, source11, source12, source13, resultSelector);
+        }
+
+        public static IUniTaskAsyncEnumerable<TResult> CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>(this IUniTaskAsyncEnumerable<T1> source1, IUniTaskAsyncEnumerable<T2> source2, IUniTaskAsyncEnumerable<T3> source3, IUniTaskAsyncEnumerable<T4> source4, IUniTaskAsyncEnumerable<T5> source5, IUniTaskAsyncEnumerable<T6> source6, IUniTaskAsyncEnumerable<T7> source7, IUniTaskAsyncEnumerable<T8> source8, IUniTaskAsyncEnumerable<T9> source9, IUniTaskAsyncEnumerable<T10> source10, IUniTaskAsyncEnumerable<T11> source11, IUniTaskAsyncEnumerable<T12> source12, IUniTaskAsyncEnumerable<T13> source13, IUniTaskAsyncEnumerable<T14> source14, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> resultSelector)
+        {
+            Error.ThrowArgumentNullException(source1, nameof(source1));
+            Error.ThrowArgumentNullException(source2, nameof(source2));
+            Error.ThrowArgumentNullException(source3, nameof(source3));
+            Error.ThrowArgumentNullException(source4, nameof(source4));
+            Error.ThrowArgumentNullException(source5, nameof(source5));
+            Error.ThrowArgumentNullException(source6, nameof(source6));
+            Error.ThrowArgumentNullException(source7, nameof(source7));
+            Error.ThrowArgumentNullException(source8, nameof(source8));
+            Error.ThrowArgumentNullException(source9, nameof(source9));
+            Error.ThrowArgumentNullException(source10, nameof(source10));
+            Error.ThrowArgumentNullException(source11, nameof(source11));
+            Error.ThrowArgumentNullException(source12, nameof(source12));
+            Error.ThrowArgumentNullException(source13, nameof(source13));
+            Error.ThrowArgumentNullException(source14, nameof(source14));
+            Error.ThrowArgumentNullException(resultSelector, nameof(resultSelector));
+
+            return new CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>(source1, source2, source3, source4, source5, source6, source7, source8, source9, source10, source11, source12, source13, source14, resultSelector);
+        }
+
+        public static IUniTaskAsyncEnumerable<TResult> CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>(this IUniTaskAsyncEnumerable<T1> source1, IUniTaskAsyncEnumerable<T2> source2, IUniTaskAsyncEnumerable<T3> source3, IUniTaskAsyncEnumerable<T4> source4, IUniTaskAsyncEnumerable<T5> source5, IUniTaskAsyncEnumerable<T6> source6, IUniTaskAsyncEnumerable<T7> source7, IUniTaskAsyncEnumerable<T8> source8, IUniTaskAsyncEnumerable<T9> source9, IUniTaskAsyncEnumerable<T10> source10, IUniTaskAsyncEnumerable<T11> source11, IUniTaskAsyncEnumerable<T12> source12, IUniTaskAsyncEnumerable<T13> source13, IUniTaskAsyncEnumerable<T14> source14, IUniTaskAsyncEnumerable<T15> source15, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> resultSelector)
+        {
+            Error.ThrowArgumentNullException(source1, nameof(source1));
+            Error.ThrowArgumentNullException(source2, nameof(source2));
+            Error.ThrowArgumentNullException(source3, nameof(source3));
+            Error.ThrowArgumentNullException(source4, nameof(source4));
+            Error.ThrowArgumentNullException(source5, nameof(source5));
+            Error.ThrowArgumentNullException(source6, nameof(source6));
+            Error.ThrowArgumentNullException(source7, nameof(source7));
+            Error.ThrowArgumentNullException(source8, nameof(source8));
+            Error.ThrowArgumentNullException(source9, nameof(source9));
+            Error.ThrowArgumentNullException(source10, nameof(source10));
+            Error.ThrowArgumentNullException(source11, nameof(source11));
+            Error.ThrowArgumentNullException(source12, nameof(source12));
+            Error.ThrowArgumentNullException(source13, nameof(source13));
+            Error.ThrowArgumentNullException(source14, nameof(source14));
+            Error.ThrowArgumentNullException(source15, nameof(source15));
+            Error.ThrowArgumentNullException(resultSelector, nameof(resultSelector));
+
+            return new CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>(source1, source2, source3, source4, source5, source6, source7, source8, source9, source10, source11, source12, source13, source14, source15, resultSelector);
+        }
+
+    }
+
+    internal class CombineLatest<T1, T2, TResult> : IUniTaskAsyncEnumerable<TResult>
+    {
+        readonly IUniTaskAsyncEnumerable<T1> source1;
+        readonly IUniTaskAsyncEnumerable<T2> source2;
+        
+        readonly Func<T1, T2, TResult> resultSelector;
+
+        public CombineLatest(IUniTaskAsyncEnumerable<T1> source1, IUniTaskAsyncEnumerable<T2> source2, Func<T1, T2, TResult> resultSelector)
+        {
+            this.source1 = source1;
+            this.source2 = source2;
+        
+            this.resultSelector = resultSelector;
+        }
+
+        public IUniTaskAsyncEnumerator<TResult> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _CombineLatest(source1, source2, resultSelector, cancellationToken);
+        }
+
+        class _CombineLatest : MoveNextSource, IUniTaskAsyncEnumerator<TResult>
+        {
+            static readonly Action<object> Completed1Delegate = Completed1;
+            static readonly Action<object> Completed2Delegate = Completed2;
+            const int CompleteCount = 2;
+
+            readonly IUniTaskAsyncEnumerable<T1> source1;
+            readonly IUniTaskAsyncEnumerable<T2> source2;
+       
+            readonly Func<T1, T2, TResult> resultSelector;
+            CancellationToken cancellationToken;
+
+            IUniTaskAsyncEnumerator<T1> enumerator1;
+            UniTask<bool>.Awaiter awaiter1;
+            bool hasCurrent1;
+            bool running1;
+            T1 current1;
+
+            IUniTaskAsyncEnumerator<T2> enumerator2;
+            UniTask<bool>.Awaiter awaiter2;
+            bool hasCurrent2;
+            bool running2;
+            T2 current2;
+
+            int completedCount;
+            bool syncRunning;
+            TResult result;
+
+            public _CombineLatest(IUniTaskAsyncEnumerable<T1> source1, IUniTaskAsyncEnumerable<T2> source2, Func<T1, T2, TResult> resultSelector, CancellationToken cancellationToken)
+            {
+                this.source1 = source1;
+                this.source2 = source2;
+                
+                this.resultSelector = resultSelector;
+                this.cancellationToken = cancellationToken;
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public TResult Current => result;
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (completedCount == CompleteCount) return CompletedTasks.False;
+
+                if (enumerator1 == null)
+                {
+                    enumerator1 = source1.GetAsyncEnumerator(cancellationToken);
+                    enumerator2 = source2.GetAsyncEnumerator(cancellationToken);
+                }
+
+                completionSource.Reset();
+
+                AGAIN:
+                syncRunning = true;
+                if (!running1)
+                {
+                    running1 = true;
+                    awaiter1 = enumerator1.MoveNextAsync().GetAwaiter();
+                    if (awaiter1.IsCompleted)
+                    {
+                        Completed1(this);
+                    }
+                    else
+                    {
+                        awaiter1.SourceOnCompleted(Completed1Delegate, this);
+                    }
+                }
+                if (!running2)
+                {
+                    running2 = true;
+                    awaiter2 = enumerator2.MoveNextAsync().GetAwaiter();
+                    if (awaiter2.IsCompleted)
+                    {
+                        Completed2(this);
+                    }
+                    else
+                    {
+                        awaiter2.SourceOnCompleted(Completed2Delegate, this);
+                    }
+                }
+
+                if (!running1 || !running2)
+                {
+                    goto AGAIN;
+                }
+                syncRunning = false;
+
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            static void Completed1(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running1 = false;
+
+                try
+                {
+                    if (self.awaiter1.GetResult())
+                    {
+                        self.hasCurrent1 = true;
+                        self.current1 = self.enumerator1.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running1 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running1 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running1 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter1 = self.enumerator1.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter1.SourceOnCompleted(Completed1Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed2(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running2 = false;
+
+                try
+                {
+                    if (self.awaiter2.GetResult())
+                    {
+                        self.hasCurrent2 = true;
+                        self.current2 = self.enumerator2.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running2 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running2 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running2 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter2 = self.enumerator2.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter2.SourceOnCompleted(Completed2Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            bool TrySetResult()
+            {
+                if (hasCurrent1 && hasCurrent2)
+                {
+                    result = resultSelector(current1, current2);
+                    completionSource.TrySetResult(true);
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
+            public async UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                if (enumerator1 != null)
+                {
+                    await enumerator1.DisposeAsync();
+                }
+                if (enumerator2 != null)
+                {
+                    await enumerator2.DisposeAsync();
+                }
+            }
+        }
+    }
+
+    internal class CombineLatest<T1, T2, T3, TResult> : IUniTaskAsyncEnumerable<TResult>
+    {
+        readonly IUniTaskAsyncEnumerable<T1> source1;
+        readonly IUniTaskAsyncEnumerable<T2> source2;
+        readonly IUniTaskAsyncEnumerable<T3> source3;
+        
+        readonly Func<T1, T2, T3, TResult> resultSelector;
+
+        public CombineLatest(IUniTaskAsyncEnumerable<T1> source1, IUniTaskAsyncEnumerable<T2> source2, IUniTaskAsyncEnumerable<T3> source3, Func<T1, T2, T3, TResult> resultSelector)
+        {
+            this.source1 = source1;
+            this.source2 = source2;
+            this.source3 = source3;
+        
+            this.resultSelector = resultSelector;
+        }
+
+        public IUniTaskAsyncEnumerator<TResult> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _CombineLatest(source1, source2, source3, resultSelector, cancellationToken);
+        }
+
+        class _CombineLatest : MoveNextSource, IUniTaskAsyncEnumerator<TResult>
+        {
+            static readonly Action<object> Completed1Delegate = Completed1;
+            static readonly Action<object> Completed2Delegate = Completed2;
+            static readonly Action<object> Completed3Delegate = Completed3;
+            const int CompleteCount = 3;
+
+            readonly IUniTaskAsyncEnumerable<T1> source1;
+            readonly IUniTaskAsyncEnumerable<T2> source2;
+            readonly IUniTaskAsyncEnumerable<T3> source3;
+       
+            readonly Func<T1, T2, T3, TResult> resultSelector;
+            CancellationToken cancellationToken;
+
+            IUniTaskAsyncEnumerator<T1> enumerator1;
+            UniTask<bool>.Awaiter awaiter1;
+            bool hasCurrent1;
+            bool running1;
+            T1 current1;
+
+            IUniTaskAsyncEnumerator<T2> enumerator2;
+            UniTask<bool>.Awaiter awaiter2;
+            bool hasCurrent2;
+            bool running2;
+            T2 current2;
+
+            IUniTaskAsyncEnumerator<T3> enumerator3;
+            UniTask<bool>.Awaiter awaiter3;
+            bool hasCurrent3;
+            bool running3;
+            T3 current3;
+
+            int completedCount;
+            bool syncRunning;
+            TResult result;
+
+            public _CombineLatest(IUniTaskAsyncEnumerable<T1> source1, IUniTaskAsyncEnumerable<T2> source2, IUniTaskAsyncEnumerable<T3> source3, Func<T1, T2, T3, TResult> resultSelector, CancellationToken cancellationToken)
+            {
+                this.source1 = source1;
+                this.source2 = source2;
+                this.source3 = source3;
+                
+                this.resultSelector = resultSelector;
+                this.cancellationToken = cancellationToken;
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public TResult Current => result;
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (completedCount == CompleteCount) return CompletedTasks.False;
+
+                if (enumerator1 == null)
+                {
+                    enumerator1 = source1.GetAsyncEnumerator(cancellationToken);
+                    enumerator2 = source2.GetAsyncEnumerator(cancellationToken);
+                    enumerator3 = source3.GetAsyncEnumerator(cancellationToken);
+                }
+
+                completionSource.Reset();
+
+                AGAIN:
+                syncRunning = true;
+                if (!running1)
+                {
+                    running1 = true;
+                    awaiter1 = enumerator1.MoveNextAsync().GetAwaiter();
+                    if (awaiter1.IsCompleted)
+                    {
+                        Completed1(this);
+                    }
+                    else
+                    {
+                        awaiter1.SourceOnCompleted(Completed1Delegate, this);
+                    }
+                }
+                if (!running2)
+                {
+                    running2 = true;
+                    awaiter2 = enumerator2.MoveNextAsync().GetAwaiter();
+                    if (awaiter2.IsCompleted)
+                    {
+                        Completed2(this);
+                    }
+                    else
+                    {
+                        awaiter2.SourceOnCompleted(Completed2Delegate, this);
+                    }
+                }
+                if (!running3)
+                {
+                    running3 = true;
+                    awaiter3 = enumerator3.MoveNextAsync().GetAwaiter();
+                    if (awaiter3.IsCompleted)
+                    {
+                        Completed3(this);
+                    }
+                    else
+                    {
+                        awaiter3.SourceOnCompleted(Completed3Delegate, this);
+                    }
+                }
+
+                if (!running1 || !running2 || !running3)
+                {
+                    goto AGAIN;
+                }
+                syncRunning = false;
+
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            static void Completed1(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running1 = false;
+
+                try
+                {
+                    if (self.awaiter1.GetResult())
+                    {
+                        self.hasCurrent1 = true;
+                        self.current1 = self.enumerator1.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running1 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running1 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running1 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter1 = self.enumerator1.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter1.SourceOnCompleted(Completed1Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed2(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running2 = false;
+
+                try
+                {
+                    if (self.awaiter2.GetResult())
+                    {
+                        self.hasCurrent2 = true;
+                        self.current2 = self.enumerator2.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running2 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running2 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running2 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter2 = self.enumerator2.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter2.SourceOnCompleted(Completed2Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed3(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running3 = false;
+
+                try
+                {
+                    if (self.awaiter3.GetResult())
+                    {
+                        self.hasCurrent3 = true;
+                        self.current3 = self.enumerator3.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running3 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running3 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running3 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter3 = self.enumerator3.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter3.SourceOnCompleted(Completed3Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            bool TrySetResult()
+            {
+                if (hasCurrent1 && hasCurrent2 && hasCurrent3)
+                {
+                    result = resultSelector(current1, current2, current3);
+                    completionSource.TrySetResult(true);
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
+            public async UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                if (enumerator1 != null)
+                {
+                    await enumerator1.DisposeAsync();
+                }
+                if (enumerator2 != null)
+                {
+                    await enumerator2.DisposeAsync();
+                }
+                if (enumerator3 != null)
+                {
+                    await enumerator3.DisposeAsync();
+                }
+            }
+        }
+    }
+
+    internal class CombineLatest<T1, T2, T3, T4, TResult> : IUniTaskAsyncEnumerable<TResult>
+    {
+        readonly IUniTaskAsyncEnumerable<T1> source1;
+        readonly IUniTaskAsyncEnumerable<T2> source2;
+        readonly IUniTaskAsyncEnumerable<T3> source3;
+        readonly IUniTaskAsyncEnumerable<T4> source4;
+        
+        readonly Func<T1, T2, T3, T4, TResult> resultSelector;
+
+        public CombineLatest(IUniTaskAsyncEnumerable<T1> source1, IUniTaskAsyncEnumerable<T2> source2, IUniTaskAsyncEnumerable<T3> source3, IUniTaskAsyncEnumerable<T4> source4, Func<T1, T2, T3, T4, TResult> resultSelector)
+        {
+            this.source1 = source1;
+            this.source2 = source2;
+            this.source3 = source3;
+            this.source4 = source4;
+        
+            this.resultSelector = resultSelector;
+        }
+
+        public IUniTaskAsyncEnumerator<TResult> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _CombineLatest(source1, source2, source3, source4, resultSelector, cancellationToken);
+        }
+
+        class _CombineLatest : MoveNextSource, IUniTaskAsyncEnumerator<TResult>
+        {
+            static readonly Action<object> Completed1Delegate = Completed1;
+            static readonly Action<object> Completed2Delegate = Completed2;
+            static readonly Action<object> Completed3Delegate = Completed3;
+            static readonly Action<object> Completed4Delegate = Completed4;
+            const int CompleteCount = 4;
+
+            readonly IUniTaskAsyncEnumerable<T1> source1;
+            readonly IUniTaskAsyncEnumerable<T2> source2;
+            readonly IUniTaskAsyncEnumerable<T3> source3;
+            readonly IUniTaskAsyncEnumerable<T4> source4;
+       
+            readonly Func<T1, T2, T3, T4, TResult> resultSelector;
+            CancellationToken cancellationToken;
+
+            IUniTaskAsyncEnumerator<T1> enumerator1;
+            UniTask<bool>.Awaiter awaiter1;
+            bool hasCurrent1;
+            bool running1;
+            T1 current1;
+
+            IUniTaskAsyncEnumerator<T2> enumerator2;
+            UniTask<bool>.Awaiter awaiter2;
+            bool hasCurrent2;
+            bool running2;
+            T2 current2;
+
+            IUniTaskAsyncEnumerator<T3> enumerator3;
+            UniTask<bool>.Awaiter awaiter3;
+            bool hasCurrent3;
+            bool running3;
+            T3 current3;
+
+            IUniTaskAsyncEnumerator<T4> enumerator4;
+            UniTask<bool>.Awaiter awaiter4;
+            bool hasCurrent4;
+            bool running4;
+            T4 current4;
+
+            int completedCount;
+            bool syncRunning;
+            TResult result;
+
+            public _CombineLatest(IUniTaskAsyncEnumerable<T1> source1, IUniTaskAsyncEnumerable<T2> source2, IUniTaskAsyncEnumerable<T3> source3, IUniTaskAsyncEnumerable<T4> source4, Func<T1, T2, T3, T4, TResult> resultSelector, CancellationToken cancellationToken)
+            {
+                this.source1 = source1;
+                this.source2 = source2;
+                this.source3 = source3;
+                this.source4 = source4;
+                
+                this.resultSelector = resultSelector;
+                this.cancellationToken = cancellationToken;
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public TResult Current => result;
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (completedCount == CompleteCount) return CompletedTasks.False;
+
+                if (enumerator1 == null)
+                {
+                    enumerator1 = source1.GetAsyncEnumerator(cancellationToken);
+                    enumerator2 = source2.GetAsyncEnumerator(cancellationToken);
+                    enumerator3 = source3.GetAsyncEnumerator(cancellationToken);
+                    enumerator4 = source4.GetAsyncEnumerator(cancellationToken);
+                }
+
+                completionSource.Reset();
+
+                AGAIN:
+                syncRunning = true;
+                if (!running1)
+                {
+                    running1 = true;
+                    awaiter1 = enumerator1.MoveNextAsync().GetAwaiter();
+                    if (awaiter1.IsCompleted)
+                    {
+                        Completed1(this);
+                    }
+                    else
+                    {
+                        awaiter1.SourceOnCompleted(Completed1Delegate, this);
+                    }
+                }
+                if (!running2)
+                {
+                    running2 = true;
+                    awaiter2 = enumerator2.MoveNextAsync().GetAwaiter();
+                    if (awaiter2.IsCompleted)
+                    {
+                        Completed2(this);
+                    }
+                    else
+                    {
+                        awaiter2.SourceOnCompleted(Completed2Delegate, this);
+                    }
+                }
+                if (!running3)
+                {
+                    running3 = true;
+                    awaiter3 = enumerator3.MoveNextAsync().GetAwaiter();
+                    if (awaiter3.IsCompleted)
+                    {
+                        Completed3(this);
+                    }
+                    else
+                    {
+                        awaiter3.SourceOnCompleted(Completed3Delegate, this);
+                    }
+                }
+                if (!running4)
+                {
+                    running4 = true;
+                    awaiter4 = enumerator4.MoveNextAsync().GetAwaiter();
+                    if (awaiter4.IsCompleted)
+                    {
+                        Completed4(this);
+                    }
+                    else
+                    {
+                        awaiter4.SourceOnCompleted(Completed4Delegate, this);
+                    }
+                }
+
+                if (!running1 || !running2 || !running3 || !running4)
+                {
+                    goto AGAIN;
+                }
+                syncRunning = false;
+
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            static void Completed1(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running1 = false;
+
+                try
+                {
+                    if (self.awaiter1.GetResult())
+                    {
+                        self.hasCurrent1 = true;
+                        self.current1 = self.enumerator1.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running1 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running1 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running1 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter1 = self.enumerator1.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter1.SourceOnCompleted(Completed1Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed2(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running2 = false;
+
+                try
+                {
+                    if (self.awaiter2.GetResult())
+                    {
+                        self.hasCurrent2 = true;
+                        self.current2 = self.enumerator2.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running2 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running2 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running2 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter2 = self.enumerator2.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter2.SourceOnCompleted(Completed2Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed3(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running3 = false;
+
+                try
+                {
+                    if (self.awaiter3.GetResult())
+                    {
+                        self.hasCurrent3 = true;
+                        self.current3 = self.enumerator3.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running3 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running3 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running3 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter3 = self.enumerator3.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter3.SourceOnCompleted(Completed3Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed4(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running4 = false;
+
+                try
+                {
+                    if (self.awaiter4.GetResult())
+                    {
+                        self.hasCurrent4 = true;
+                        self.current4 = self.enumerator4.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running4 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running4 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running4 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter4 = self.enumerator4.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter4.SourceOnCompleted(Completed4Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            bool TrySetResult()
+            {
+                if (hasCurrent1 && hasCurrent2 && hasCurrent3 && hasCurrent4)
+                {
+                    result = resultSelector(current1, current2, current3, current4);
+                    completionSource.TrySetResult(true);
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
+            public async UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                if (enumerator1 != null)
+                {
+                    await enumerator1.DisposeAsync();
+                }
+                if (enumerator2 != null)
+                {
+                    await enumerator2.DisposeAsync();
+                }
+                if (enumerator3 != null)
+                {
+                    await enumerator3.DisposeAsync();
+                }
+                if (enumerator4 != null)
+                {
+                    await enumerator4.DisposeAsync();
+                }
+            }
+        }
+    }
+
+    internal class CombineLatest<T1, T2, T3, T4, T5, TResult> : IUniTaskAsyncEnumerable<TResult>
+    {
+        readonly IUniTaskAsyncEnumerable<T1> source1;
+        readonly IUniTaskAsyncEnumerable<T2> source2;
+        readonly IUniTaskAsyncEnumerable<T3> source3;
+        readonly IUniTaskAsyncEnumerable<T4> source4;
+        readonly IUniTaskAsyncEnumerable<T5> source5;
+        
+        readonly Func<T1, T2, T3, T4, T5, TResult> resultSelector;
+
+        public CombineLatest(IUniTaskAsyncEnumerable<T1> source1, IUniTaskAsyncEnumerable<T2> source2, IUniTaskAsyncEnumerable<T3> source3, IUniTaskAsyncEnumerable<T4> source4, IUniTaskAsyncEnumerable<T5> source5, Func<T1, T2, T3, T4, T5, TResult> resultSelector)
+        {
+            this.source1 = source1;
+            this.source2 = source2;
+            this.source3 = source3;
+            this.source4 = source4;
+            this.source5 = source5;
+        
+            this.resultSelector = resultSelector;
+        }
+
+        public IUniTaskAsyncEnumerator<TResult> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _CombineLatest(source1, source2, source3, source4, source5, resultSelector, cancellationToken);
+        }
+
+        class _CombineLatest : MoveNextSource, IUniTaskAsyncEnumerator<TResult>
+        {
+            static readonly Action<object> Completed1Delegate = Completed1;
+            static readonly Action<object> Completed2Delegate = Completed2;
+            static readonly Action<object> Completed3Delegate = Completed3;
+            static readonly Action<object> Completed4Delegate = Completed4;
+            static readonly Action<object> Completed5Delegate = Completed5;
+            const int CompleteCount = 5;
+
+            readonly IUniTaskAsyncEnumerable<T1> source1;
+            readonly IUniTaskAsyncEnumerable<T2> source2;
+            readonly IUniTaskAsyncEnumerable<T3> source3;
+            readonly IUniTaskAsyncEnumerable<T4> source4;
+            readonly IUniTaskAsyncEnumerable<T5> source5;
+       
+            readonly Func<T1, T2, T3, T4, T5, TResult> resultSelector;
+            CancellationToken cancellationToken;
+
+            IUniTaskAsyncEnumerator<T1> enumerator1;
+            UniTask<bool>.Awaiter awaiter1;
+            bool hasCurrent1;
+            bool running1;
+            T1 current1;
+
+            IUniTaskAsyncEnumerator<T2> enumerator2;
+            UniTask<bool>.Awaiter awaiter2;
+            bool hasCurrent2;
+            bool running2;
+            T2 current2;
+
+            IUniTaskAsyncEnumerator<T3> enumerator3;
+            UniTask<bool>.Awaiter awaiter3;
+            bool hasCurrent3;
+            bool running3;
+            T3 current3;
+
+            IUniTaskAsyncEnumerator<T4> enumerator4;
+            UniTask<bool>.Awaiter awaiter4;
+            bool hasCurrent4;
+            bool running4;
+            T4 current4;
+
+            IUniTaskAsyncEnumerator<T5> enumerator5;
+            UniTask<bool>.Awaiter awaiter5;
+            bool hasCurrent5;
+            bool running5;
+            T5 current5;
+
+            int completedCount;
+            bool syncRunning;
+            TResult result;
+
+            public _CombineLatest(IUniTaskAsyncEnumerable<T1> source1, IUniTaskAsyncEnumerable<T2> source2, IUniTaskAsyncEnumerable<T3> source3, IUniTaskAsyncEnumerable<T4> source4, IUniTaskAsyncEnumerable<T5> source5, Func<T1, T2, T3, T4, T5, TResult> resultSelector, CancellationToken cancellationToken)
+            {
+                this.source1 = source1;
+                this.source2 = source2;
+                this.source3 = source3;
+                this.source4 = source4;
+                this.source5 = source5;
+                
+                this.resultSelector = resultSelector;
+                this.cancellationToken = cancellationToken;
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public TResult Current => result;
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (completedCount == CompleteCount) return CompletedTasks.False;
+
+                if (enumerator1 == null)
+                {
+                    enumerator1 = source1.GetAsyncEnumerator(cancellationToken);
+                    enumerator2 = source2.GetAsyncEnumerator(cancellationToken);
+                    enumerator3 = source3.GetAsyncEnumerator(cancellationToken);
+                    enumerator4 = source4.GetAsyncEnumerator(cancellationToken);
+                    enumerator5 = source5.GetAsyncEnumerator(cancellationToken);
+                }
+
+                completionSource.Reset();
+
+                AGAIN:
+                syncRunning = true;
+                if (!running1)
+                {
+                    running1 = true;
+                    awaiter1 = enumerator1.MoveNextAsync().GetAwaiter();
+                    if (awaiter1.IsCompleted)
+                    {
+                        Completed1(this);
+                    }
+                    else
+                    {
+                        awaiter1.SourceOnCompleted(Completed1Delegate, this);
+                    }
+                }
+                if (!running2)
+                {
+                    running2 = true;
+                    awaiter2 = enumerator2.MoveNextAsync().GetAwaiter();
+                    if (awaiter2.IsCompleted)
+                    {
+                        Completed2(this);
+                    }
+                    else
+                    {
+                        awaiter2.SourceOnCompleted(Completed2Delegate, this);
+                    }
+                }
+                if (!running3)
+                {
+                    running3 = true;
+                    awaiter3 = enumerator3.MoveNextAsync().GetAwaiter();
+                    if (awaiter3.IsCompleted)
+                    {
+                        Completed3(this);
+                    }
+                    else
+                    {
+                        awaiter3.SourceOnCompleted(Completed3Delegate, this);
+                    }
+                }
+                if (!running4)
+                {
+                    running4 = true;
+                    awaiter4 = enumerator4.MoveNextAsync().GetAwaiter();
+                    if (awaiter4.IsCompleted)
+                    {
+                        Completed4(this);
+                    }
+                    else
+                    {
+                        awaiter4.SourceOnCompleted(Completed4Delegate, this);
+                    }
+                }
+                if (!running5)
+                {
+                    running5 = true;
+                    awaiter5 = enumerator5.MoveNextAsync().GetAwaiter();
+                    if (awaiter5.IsCompleted)
+                    {
+                        Completed5(this);
+                    }
+                    else
+                    {
+                        awaiter5.SourceOnCompleted(Completed5Delegate, this);
+                    }
+                }
+
+                if (!running1 || !running2 || !running3 || !running4 || !running5)
+                {
+                    goto AGAIN;
+                }
+                syncRunning = false;
+
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            static void Completed1(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running1 = false;
+
+                try
+                {
+                    if (self.awaiter1.GetResult())
+                    {
+                        self.hasCurrent1 = true;
+                        self.current1 = self.enumerator1.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running1 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running1 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running1 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter1 = self.enumerator1.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter1.SourceOnCompleted(Completed1Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed2(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running2 = false;
+
+                try
+                {
+                    if (self.awaiter2.GetResult())
+                    {
+                        self.hasCurrent2 = true;
+                        self.current2 = self.enumerator2.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running2 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running2 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running2 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter2 = self.enumerator2.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter2.SourceOnCompleted(Completed2Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed3(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running3 = false;
+
+                try
+                {
+                    if (self.awaiter3.GetResult())
+                    {
+                        self.hasCurrent3 = true;
+                        self.current3 = self.enumerator3.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running3 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running3 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running3 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter3 = self.enumerator3.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter3.SourceOnCompleted(Completed3Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed4(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running4 = false;
+
+                try
+                {
+                    if (self.awaiter4.GetResult())
+                    {
+                        self.hasCurrent4 = true;
+                        self.current4 = self.enumerator4.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running4 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running4 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running4 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter4 = self.enumerator4.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter4.SourceOnCompleted(Completed4Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed5(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running5 = false;
+
+                try
+                {
+                    if (self.awaiter5.GetResult())
+                    {
+                        self.hasCurrent5 = true;
+                        self.current5 = self.enumerator5.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running5 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running5 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running5 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter5 = self.enumerator5.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter5.SourceOnCompleted(Completed5Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            bool TrySetResult()
+            {
+                if (hasCurrent1 && hasCurrent2 && hasCurrent3 && hasCurrent4 && hasCurrent5)
+                {
+                    result = resultSelector(current1, current2, current3, current4, current5);
+                    completionSource.TrySetResult(true);
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
+            public async UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                if (enumerator1 != null)
+                {
+                    await enumerator1.DisposeAsync();
+                }
+                if (enumerator2 != null)
+                {
+                    await enumerator2.DisposeAsync();
+                }
+                if (enumerator3 != null)
+                {
+                    await enumerator3.DisposeAsync();
+                }
+                if (enumerator4 != null)
+                {
+                    await enumerator4.DisposeAsync();
+                }
+                if (enumerator5 != null)
+                {
+                    await enumerator5.DisposeAsync();
+                }
+            }
+        }
+    }
+
+    internal class CombineLatest<T1, T2, T3, T4, T5, T6, TResult> : IUniTaskAsyncEnumerable<TResult>
+    {
+        readonly IUniTaskAsyncEnumerable<T1> source1;
+        readonly IUniTaskAsyncEnumerable<T2> source2;
+        readonly IUniTaskAsyncEnumerable<T3> source3;
+        readonly IUniTaskAsyncEnumerable<T4> source4;
+        readonly IUniTaskAsyncEnumerable<T5> source5;
+        readonly IUniTaskAsyncEnumerable<T6> source6;
+        
+        readonly Func<T1, T2, T3, T4, T5, T6, TResult> resultSelector;
+
+        public CombineLatest(IUniTaskAsyncEnumerable<T1> source1, IUniTaskAsyncEnumerable<T2> source2, IUniTaskAsyncEnumerable<T3> source3, IUniTaskAsyncEnumerable<T4> source4, IUniTaskAsyncEnumerable<T5> source5, IUniTaskAsyncEnumerable<T6> source6, Func<T1, T2, T3, T4, T5, T6, TResult> resultSelector)
+        {
+            this.source1 = source1;
+            this.source2 = source2;
+            this.source3 = source3;
+            this.source4 = source4;
+            this.source5 = source5;
+            this.source6 = source6;
+        
+            this.resultSelector = resultSelector;
+        }
+
+        public IUniTaskAsyncEnumerator<TResult> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _CombineLatest(source1, source2, source3, source4, source5, source6, resultSelector, cancellationToken);
+        }
+
+        class _CombineLatest : MoveNextSource, IUniTaskAsyncEnumerator<TResult>
+        {
+            static readonly Action<object> Completed1Delegate = Completed1;
+            static readonly Action<object> Completed2Delegate = Completed2;
+            static readonly Action<object> Completed3Delegate = Completed3;
+            static readonly Action<object> Completed4Delegate = Completed4;
+            static readonly Action<object> Completed5Delegate = Completed5;
+            static readonly Action<object> Completed6Delegate = Completed6;
+            const int CompleteCount = 6;
+
+            readonly IUniTaskAsyncEnumerable<T1> source1;
+            readonly IUniTaskAsyncEnumerable<T2> source2;
+            readonly IUniTaskAsyncEnumerable<T3> source3;
+            readonly IUniTaskAsyncEnumerable<T4> source4;
+            readonly IUniTaskAsyncEnumerable<T5> source5;
+            readonly IUniTaskAsyncEnumerable<T6> source6;
+       
+            readonly Func<T1, T2, T3, T4, T5, T6, TResult> resultSelector;
+            CancellationToken cancellationToken;
+
+            IUniTaskAsyncEnumerator<T1> enumerator1;
+            UniTask<bool>.Awaiter awaiter1;
+            bool hasCurrent1;
+            bool running1;
+            T1 current1;
+
+            IUniTaskAsyncEnumerator<T2> enumerator2;
+            UniTask<bool>.Awaiter awaiter2;
+            bool hasCurrent2;
+            bool running2;
+            T2 current2;
+
+            IUniTaskAsyncEnumerator<T3> enumerator3;
+            UniTask<bool>.Awaiter awaiter3;
+            bool hasCurrent3;
+            bool running3;
+            T3 current3;
+
+            IUniTaskAsyncEnumerator<T4> enumerator4;
+            UniTask<bool>.Awaiter awaiter4;
+            bool hasCurrent4;
+            bool running4;
+            T4 current4;
+
+            IUniTaskAsyncEnumerator<T5> enumerator5;
+            UniTask<bool>.Awaiter awaiter5;
+            bool hasCurrent5;
+            bool running5;
+            T5 current5;
+
+            IUniTaskAsyncEnumerator<T6> enumerator6;
+            UniTask<bool>.Awaiter awaiter6;
+            bool hasCurrent6;
+            bool running6;
+            T6 current6;
+
+            int completedCount;
+            bool syncRunning;
+            TResult result;
+
+            public _CombineLatest(IUniTaskAsyncEnumerable<T1> source1, IUniTaskAsyncEnumerable<T2> source2, IUniTaskAsyncEnumerable<T3> source3, IUniTaskAsyncEnumerable<T4> source4, IUniTaskAsyncEnumerable<T5> source5, IUniTaskAsyncEnumerable<T6> source6, Func<T1, T2, T3, T4, T5, T6, TResult> resultSelector, CancellationToken cancellationToken)
+            {
+                this.source1 = source1;
+                this.source2 = source2;
+                this.source3 = source3;
+                this.source4 = source4;
+                this.source5 = source5;
+                this.source6 = source6;
+                
+                this.resultSelector = resultSelector;
+                this.cancellationToken = cancellationToken;
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public TResult Current => result;
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (completedCount == CompleteCount) return CompletedTasks.False;
+
+                if (enumerator1 == null)
+                {
+                    enumerator1 = source1.GetAsyncEnumerator(cancellationToken);
+                    enumerator2 = source2.GetAsyncEnumerator(cancellationToken);
+                    enumerator3 = source3.GetAsyncEnumerator(cancellationToken);
+                    enumerator4 = source4.GetAsyncEnumerator(cancellationToken);
+                    enumerator5 = source5.GetAsyncEnumerator(cancellationToken);
+                    enumerator6 = source6.GetAsyncEnumerator(cancellationToken);
+                }
+
+                completionSource.Reset();
+
+                AGAIN:
+                syncRunning = true;
+                if (!running1)
+                {
+                    running1 = true;
+                    awaiter1 = enumerator1.MoveNextAsync().GetAwaiter();
+                    if (awaiter1.IsCompleted)
+                    {
+                        Completed1(this);
+                    }
+                    else
+                    {
+                        awaiter1.SourceOnCompleted(Completed1Delegate, this);
+                    }
+                }
+                if (!running2)
+                {
+                    running2 = true;
+                    awaiter2 = enumerator2.MoveNextAsync().GetAwaiter();
+                    if (awaiter2.IsCompleted)
+                    {
+                        Completed2(this);
+                    }
+                    else
+                    {
+                        awaiter2.SourceOnCompleted(Completed2Delegate, this);
+                    }
+                }
+                if (!running3)
+                {
+                    running3 = true;
+                    awaiter3 = enumerator3.MoveNextAsync().GetAwaiter();
+                    if (awaiter3.IsCompleted)
+                    {
+                        Completed3(this);
+                    }
+                    else
+                    {
+                        awaiter3.SourceOnCompleted(Completed3Delegate, this);
+                    }
+                }
+                if (!running4)
+                {
+                    running4 = true;
+                    awaiter4 = enumerator4.MoveNextAsync().GetAwaiter();
+                    if (awaiter4.IsCompleted)
+                    {
+                        Completed4(this);
+                    }
+                    else
+                    {
+                        awaiter4.SourceOnCompleted(Completed4Delegate, this);
+                    }
+                }
+                if (!running5)
+                {
+                    running5 = true;
+                    awaiter5 = enumerator5.MoveNextAsync().GetAwaiter();
+                    if (awaiter5.IsCompleted)
+                    {
+                        Completed5(this);
+                    }
+                    else
+                    {
+                        awaiter5.SourceOnCompleted(Completed5Delegate, this);
+                    }
+                }
+                if (!running6)
+                {
+                    running6 = true;
+                    awaiter6 = enumerator6.MoveNextAsync().GetAwaiter();
+                    if (awaiter6.IsCompleted)
+                    {
+                        Completed6(this);
+                    }
+                    else
+                    {
+                        awaiter6.SourceOnCompleted(Completed6Delegate, this);
+                    }
+                }
+
+                if (!running1 || !running2 || !running3 || !running4 || !running5 || !running6)
+                {
+                    goto AGAIN;
+                }
+                syncRunning = false;
+
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            static void Completed1(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running1 = false;
+
+                try
+                {
+                    if (self.awaiter1.GetResult())
+                    {
+                        self.hasCurrent1 = true;
+                        self.current1 = self.enumerator1.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running1 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running1 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running1 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter1 = self.enumerator1.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter1.SourceOnCompleted(Completed1Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed2(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running2 = false;
+
+                try
+                {
+                    if (self.awaiter2.GetResult())
+                    {
+                        self.hasCurrent2 = true;
+                        self.current2 = self.enumerator2.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running2 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running2 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running2 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter2 = self.enumerator2.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter2.SourceOnCompleted(Completed2Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed3(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running3 = false;
+
+                try
+                {
+                    if (self.awaiter3.GetResult())
+                    {
+                        self.hasCurrent3 = true;
+                        self.current3 = self.enumerator3.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running3 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running3 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running3 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter3 = self.enumerator3.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter3.SourceOnCompleted(Completed3Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed4(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running4 = false;
+
+                try
+                {
+                    if (self.awaiter4.GetResult())
+                    {
+                        self.hasCurrent4 = true;
+                        self.current4 = self.enumerator4.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running4 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running4 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running4 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter4 = self.enumerator4.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter4.SourceOnCompleted(Completed4Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed5(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running5 = false;
+
+                try
+                {
+                    if (self.awaiter5.GetResult())
+                    {
+                        self.hasCurrent5 = true;
+                        self.current5 = self.enumerator5.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running5 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running5 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running5 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter5 = self.enumerator5.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter5.SourceOnCompleted(Completed5Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed6(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running6 = false;
+
+                try
+                {
+                    if (self.awaiter6.GetResult())
+                    {
+                        self.hasCurrent6 = true;
+                        self.current6 = self.enumerator6.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running6 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running6 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running6 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter6 = self.enumerator6.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter6.SourceOnCompleted(Completed6Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            bool TrySetResult()
+            {
+                if (hasCurrent1 && hasCurrent2 && hasCurrent3 && hasCurrent4 && hasCurrent5 && hasCurrent6)
+                {
+                    result = resultSelector(current1, current2, current3, current4, current5, current6);
+                    completionSource.TrySetResult(true);
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
+            public async UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                if (enumerator1 != null)
+                {
+                    await enumerator1.DisposeAsync();
+                }
+                if (enumerator2 != null)
+                {
+                    await enumerator2.DisposeAsync();
+                }
+                if (enumerator3 != null)
+                {
+                    await enumerator3.DisposeAsync();
+                }
+                if (enumerator4 != null)
+                {
+                    await enumerator4.DisposeAsync();
+                }
+                if (enumerator5 != null)
+                {
+                    await enumerator5.DisposeAsync();
+                }
+                if (enumerator6 != null)
+                {
+                    await enumerator6.DisposeAsync();
+                }
+            }
+        }
+    }
+
+    internal class CombineLatest<T1, T2, T3, T4, T5, T6, T7, TResult> : IUniTaskAsyncEnumerable<TResult>
+    {
+        readonly IUniTaskAsyncEnumerable<T1> source1;
+        readonly IUniTaskAsyncEnumerable<T2> source2;
+        readonly IUniTaskAsyncEnumerable<T3> source3;
+        readonly IUniTaskAsyncEnumerable<T4> source4;
+        readonly IUniTaskAsyncEnumerable<T5> source5;
+        readonly IUniTaskAsyncEnumerable<T6> source6;
+        readonly IUniTaskAsyncEnumerable<T7> source7;
+        
+        readonly Func<T1, T2, T3, T4, T5, T6, T7, TResult> resultSelector;
+
+        public CombineLatest(IUniTaskAsyncEnumerable<T1> source1, IUniTaskAsyncEnumerable<T2> source2, IUniTaskAsyncEnumerable<T3> source3, IUniTaskAsyncEnumerable<T4> source4, IUniTaskAsyncEnumerable<T5> source5, IUniTaskAsyncEnumerable<T6> source6, IUniTaskAsyncEnumerable<T7> source7, Func<T1, T2, T3, T4, T5, T6, T7, TResult> resultSelector)
+        {
+            this.source1 = source1;
+            this.source2 = source2;
+            this.source3 = source3;
+            this.source4 = source4;
+            this.source5 = source5;
+            this.source6 = source6;
+            this.source7 = source7;
+        
+            this.resultSelector = resultSelector;
+        }
+
+        public IUniTaskAsyncEnumerator<TResult> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _CombineLatest(source1, source2, source3, source4, source5, source6, source7, resultSelector, cancellationToken);
+        }
+
+        class _CombineLatest : MoveNextSource, IUniTaskAsyncEnumerator<TResult>
+        {
+            static readonly Action<object> Completed1Delegate = Completed1;
+            static readonly Action<object> Completed2Delegate = Completed2;
+            static readonly Action<object> Completed3Delegate = Completed3;
+            static readonly Action<object> Completed4Delegate = Completed4;
+            static readonly Action<object> Completed5Delegate = Completed5;
+            static readonly Action<object> Completed6Delegate = Completed6;
+            static readonly Action<object> Completed7Delegate = Completed7;
+            const int CompleteCount = 7;
+
+            readonly IUniTaskAsyncEnumerable<T1> source1;
+            readonly IUniTaskAsyncEnumerable<T2> source2;
+            readonly IUniTaskAsyncEnumerable<T3> source3;
+            readonly IUniTaskAsyncEnumerable<T4> source4;
+            readonly IUniTaskAsyncEnumerable<T5> source5;
+            readonly IUniTaskAsyncEnumerable<T6> source6;
+            readonly IUniTaskAsyncEnumerable<T7> source7;
+       
+            readonly Func<T1, T2, T3, T4, T5, T6, T7, TResult> resultSelector;
+            CancellationToken cancellationToken;
+
+            IUniTaskAsyncEnumerator<T1> enumerator1;
+            UniTask<bool>.Awaiter awaiter1;
+            bool hasCurrent1;
+            bool running1;
+            T1 current1;
+
+            IUniTaskAsyncEnumerator<T2> enumerator2;
+            UniTask<bool>.Awaiter awaiter2;
+            bool hasCurrent2;
+            bool running2;
+            T2 current2;
+
+            IUniTaskAsyncEnumerator<T3> enumerator3;
+            UniTask<bool>.Awaiter awaiter3;
+            bool hasCurrent3;
+            bool running3;
+            T3 current3;
+
+            IUniTaskAsyncEnumerator<T4> enumerator4;
+            UniTask<bool>.Awaiter awaiter4;
+            bool hasCurrent4;
+            bool running4;
+            T4 current4;
+
+            IUniTaskAsyncEnumerator<T5> enumerator5;
+            UniTask<bool>.Awaiter awaiter5;
+            bool hasCurrent5;
+            bool running5;
+            T5 current5;
+
+            IUniTaskAsyncEnumerator<T6> enumerator6;
+            UniTask<bool>.Awaiter awaiter6;
+            bool hasCurrent6;
+            bool running6;
+            T6 current6;
+
+            IUniTaskAsyncEnumerator<T7> enumerator7;
+            UniTask<bool>.Awaiter awaiter7;
+            bool hasCurrent7;
+            bool running7;
+            T7 current7;
+
+            int completedCount;
+            bool syncRunning;
+            TResult result;
+
+            public _CombineLatest(IUniTaskAsyncEnumerable<T1> source1, IUniTaskAsyncEnumerable<T2> source2, IUniTaskAsyncEnumerable<T3> source3, IUniTaskAsyncEnumerable<T4> source4, IUniTaskAsyncEnumerable<T5> source5, IUniTaskAsyncEnumerable<T6> source6, IUniTaskAsyncEnumerable<T7> source7, Func<T1, T2, T3, T4, T5, T6, T7, TResult> resultSelector, CancellationToken cancellationToken)
+            {
+                this.source1 = source1;
+                this.source2 = source2;
+                this.source3 = source3;
+                this.source4 = source4;
+                this.source5 = source5;
+                this.source6 = source6;
+                this.source7 = source7;
+                
+                this.resultSelector = resultSelector;
+                this.cancellationToken = cancellationToken;
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public TResult Current => result;
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (completedCount == CompleteCount) return CompletedTasks.False;
+
+                if (enumerator1 == null)
+                {
+                    enumerator1 = source1.GetAsyncEnumerator(cancellationToken);
+                    enumerator2 = source2.GetAsyncEnumerator(cancellationToken);
+                    enumerator3 = source3.GetAsyncEnumerator(cancellationToken);
+                    enumerator4 = source4.GetAsyncEnumerator(cancellationToken);
+                    enumerator5 = source5.GetAsyncEnumerator(cancellationToken);
+                    enumerator6 = source6.GetAsyncEnumerator(cancellationToken);
+                    enumerator7 = source7.GetAsyncEnumerator(cancellationToken);
+                }
+
+                completionSource.Reset();
+
+                AGAIN:
+                syncRunning = true;
+                if (!running1)
+                {
+                    running1 = true;
+                    awaiter1 = enumerator1.MoveNextAsync().GetAwaiter();
+                    if (awaiter1.IsCompleted)
+                    {
+                        Completed1(this);
+                    }
+                    else
+                    {
+                        awaiter1.SourceOnCompleted(Completed1Delegate, this);
+                    }
+                }
+                if (!running2)
+                {
+                    running2 = true;
+                    awaiter2 = enumerator2.MoveNextAsync().GetAwaiter();
+                    if (awaiter2.IsCompleted)
+                    {
+                        Completed2(this);
+                    }
+                    else
+                    {
+                        awaiter2.SourceOnCompleted(Completed2Delegate, this);
+                    }
+                }
+                if (!running3)
+                {
+                    running3 = true;
+                    awaiter3 = enumerator3.MoveNextAsync().GetAwaiter();
+                    if (awaiter3.IsCompleted)
+                    {
+                        Completed3(this);
+                    }
+                    else
+                    {
+                        awaiter3.SourceOnCompleted(Completed3Delegate, this);
+                    }
+                }
+                if (!running4)
+                {
+                    running4 = true;
+                    awaiter4 = enumerator4.MoveNextAsync().GetAwaiter();
+                    if (awaiter4.IsCompleted)
+                    {
+                        Completed4(this);
+                    }
+                    else
+                    {
+                        awaiter4.SourceOnCompleted(Completed4Delegate, this);
+                    }
+                }
+                if (!running5)
+                {
+                    running5 = true;
+                    awaiter5 = enumerator5.MoveNextAsync().GetAwaiter();
+                    if (awaiter5.IsCompleted)
+                    {
+                        Completed5(this);
+                    }
+                    else
+                    {
+                        awaiter5.SourceOnCompleted(Completed5Delegate, this);
+                    }
+                }
+                if (!running6)
+                {
+                    running6 = true;
+                    awaiter6 = enumerator6.MoveNextAsync().GetAwaiter();
+                    if (awaiter6.IsCompleted)
+                    {
+                        Completed6(this);
+                    }
+                    else
+                    {
+                        awaiter6.SourceOnCompleted(Completed6Delegate, this);
+                    }
+                }
+                if (!running7)
+                {
+                    running7 = true;
+                    awaiter7 = enumerator7.MoveNextAsync().GetAwaiter();
+                    if (awaiter7.IsCompleted)
+                    {
+                        Completed7(this);
+                    }
+                    else
+                    {
+                        awaiter7.SourceOnCompleted(Completed7Delegate, this);
+                    }
+                }
+
+                if (!running1 || !running2 || !running3 || !running4 || !running5 || !running6 || !running7)
+                {
+                    goto AGAIN;
+                }
+                syncRunning = false;
+
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            static void Completed1(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running1 = false;
+
+                try
+                {
+                    if (self.awaiter1.GetResult())
+                    {
+                        self.hasCurrent1 = true;
+                        self.current1 = self.enumerator1.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running1 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running1 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running1 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter1 = self.enumerator1.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter1.SourceOnCompleted(Completed1Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed2(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running2 = false;
+
+                try
+                {
+                    if (self.awaiter2.GetResult())
+                    {
+                        self.hasCurrent2 = true;
+                        self.current2 = self.enumerator2.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running2 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running2 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running2 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter2 = self.enumerator2.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter2.SourceOnCompleted(Completed2Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed3(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running3 = false;
+
+                try
+                {
+                    if (self.awaiter3.GetResult())
+                    {
+                        self.hasCurrent3 = true;
+                        self.current3 = self.enumerator3.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running3 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running3 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running3 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter3 = self.enumerator3.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter3.SourceOnCompleted(Completed3Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed4(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running4 = false;
+
+                try
+                {
+                    if (self.awaiter4.GetResult())
+                    {
+                        self.hasCurrent4 = true;
+                        self.current4 = self.enumerator4.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running4 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running4 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running4 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter4 = self.enumerator4.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter4.SourceOnCompleted(Completed4Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed5(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running5 = false;
+
+                try
+                {
+                    if (self.awaiter5.GetResult())
+                    {
+                        self.hasCurrent5 = true;
+                        self.current5 = self.enumerator5.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running5 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running5 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running5 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter5 = self.enumerator5.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter5.SourceOnCompleted(Completed5Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed6(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running6 = false;
+
+                try
+                {
+                    if (self.awaiter6.GetResult())
+                    {
+                        self.hasCurrent6 = true;
+                        self.current6 = self.enumerator6.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running6 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running6 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running6 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter6 = self.enumerator6.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter6.SourceOnCompleted(Completed6Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed7(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running7 = false;
+
+                try
+                {
+                    if (self.awaiter7.GetResult())
+                    {
+                        self.hasCurrent7 = true;
+                        self.current7 = self.enumerator7.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running7 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running7 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running7 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter7 = self.enumerator7.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter7.SourceOnCompleted(Completed7Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            bool TrySetResult()
+            {
+                if (hasCurrent1 && hasCurrent2 && hasCurrent3 && hasCurrent4 && hasCurrent5 && hasCurrent6 && hasCurrent7)
+                {
+                    result = resultSelector(current1, current2, current3, current4, current5, current6, current7);
+                    completionSource.TrySetResult(true);
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
+            public async UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                if (enumerator1 != null)
+                {
+                    await enumerator1.DisposeAsync();
+                }
+                if (enumerator2 != null)
+                {
+                    await enumerator2.DisposeAsync();
+                }
+                if (enumerator3 != null)
+                {
+                    await enumerator3.DisposeAsync();
+                }
+                if (enumerator4 != null)
+                {
+                    await enumerator4.DisposeAsync();
+                }
+                if (enumerator5 != null)
+                {
+                    await enumerator5.DisposeAsync();
+                }
+                if (enumerator6 != null)
+                {
+                    await enumerator6.DisposeAsync();
+                }
+                if (enumerator7 != null)
+                {
+                    await enumerator7.DisposeAsync();
+                }
+            }
+        }
+    }
+
+    internal class CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, TResult> : IUniTaskAsyncEnumerable<TResult>
+    {
+        readonly IUniTaskAsyncEnumerable<T1> source1;
+        readonly IUniTaskAsyncEnumerable<T2> source2;
+        readonly IUniTaskAsyncEnumerable<T3> source3;
+        readonly IUniTaskAsyncEnumerable<T4> source4;
+        readonly IUniTaskAsyncEnumerable<T5> source5;
+        readonly IUniTaskAsyncEnumerable<T6> source6;
+        readonly IUniTaskAsyncEnumerable<T7> source7;
+        readonly IUniTaskAsyncEnumerable<T8> source8;
+        
+        readonly Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> resultSelector;
+
+        public CombineLatest(IUniTaskAsyncEnumerable<T1> source1, IUniTaskAsyncEnumerable<T2> source2, IUniTaskAsyncEnumerable<T3> source3, IUniTaskAsyncEnumerable<T4> source4, IUniTaskAsyncEnumerable<T5> source5, IUniTaskAsyncEnumerable<T6> source6, IUniTaskAsyncEnumerable<T7> source7, IUniTaskAsyncEnumerable<T8> source8, Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> resultSelector)
+        {
+            this.source1 = source1;
+            this.source2 = source2;
+            this.source3 = source3;
+            this.source4 = source4;
+            this.source5 = source5;
+            this.source6 = source6;
+            this.source7 = source7;
+            this.source8 = source8;
+        
+            this.resultSelector = resultSelector;
+        }
+
+        public IUniTaskAsyncEnumerator<TResult> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _CombineLatest(source1, source2, source3, source4, source5, source6, source7, source8, resultSelector, cancellationToken);
+        }
+
+        class _CombineLatest : MoveNextSource, IUniTaskAsyncEnumerator<TResult>
+        {
+            static readonly Action<object> Completed1Delegate = Completed1;
+            static readonly Action<object> Completed2Delegate = Completed2;
+            static readonly Action<object> Completed3Delegate = Completed3;
+            static readonly Action<object> Completed4Delegate = Completed4;
+            static readonly Action<object> Completed5Delegate = Completed5;
+            static readonly Action<object> Completed6Delegate = Completed6;
+            static readonly Action<object> Completed7Delegate = Completed7;
+            static readonly Action<object> Completed8Delegate = Completed8;
+            const int CompleteCount = 8;
+
+            readonly IUniTaskAsyncEnumerable<T1> source1;
+            readonly IUniTaskAsyncEnumerable<T2> source2;
+            readonly IUniTaskAsyncEnumerable<T3> source3;
+            readonly IUniTaskAsyncEnumerable<T4> source4;
+            readonly IUniTaskAsyncEnumerable<T5> source5;
+            readonly IUniTaskAsyncEnumerable<T6> source6;
+            readonly IUniTaskAsyncEnumerable<T7> source7;
+            readonly IUniTaskAsyncEnumerable<T8> source8;
+       
+            readonly Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> resultSelector;
+            CancellationToken cancellationToken;
+
+            IUniTaskAsyncEnumerator<T1> enumerator1;
+            UniTask<bool>.Awaiter awaiter1;
+            bool hasCurrent1;
+            bool running1;
+            T1 current1;
+
+            IUniTaskAsyncEnumerator<T2> enumerator2;
+            UniTask<bool>.Awaiter awaiter2;
+            bool hasCurrent2;
+            bool running2;
+            T2 current2;
+
+            IUniTaskAsyncEnumerator<T3> enumerator3;
+            UniTask<bool>.Awaiter awaiter3;
+            bool hasCurrent3;
+            bool running3;
+            T3 current3;
+
+            IUniTaskAsyncEnumerator<T4> enumerator4;
+            UniTask<bool>.Awaiter awaiter4;
+            bool hasCurrent4;
+            bool running4;
+            T4 current4;
+
+            IUniTaskAsyncEnumerator<T5> enumerator5;
+            UniTask<bool>.Awaiter awaiter5;
+            bool hasCurrent5;
+            bool running5;
+            T5 current5;
+
+            IUniTaskAsyncEnumerator<T6> enumerator6;
+            UniTask<bool>.Awaiter awaiter6;
+            bool hasCurrent6;
+            bool running6;
+            T6 current6;
+
+            IUniTaskAsyncEnumerator<T7> enumerator7;
+            UniTask<bool>.Awaiter awaiter7;
+            bool hasCurrent7;
+            bool running7;
+            T7 current7;
+
+            IUniTaskAsyncEnumerator<T8> enumerator8;
+            UniTask<bool>.Awaiter awaiter8;
+            bool hasCurrent8;
+            bool running8;
+            T8 current8;
+
+            int completedCount;
+            bool syncRunning;
+            TResult result;
+
+            public _CombineLatest(IUniTaskAsyncEnumerable<T1> source1, IUniTaskAsyncEnumerable<T2> source2, IUniTaskAsyncEnumerable<T3> source3, IUniTaskAsyncEnumerable<T4> source4, IUniTaskAsyncEnumerable<T5> source5, IUniTaskAsyncEnumerable<T6> source6, IUniTaskAsyncEnumerable<T7> source7, IUniTaskAsyncEnumerable<T8> source8, Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> resultSelector, CancellationToken cancellationToken)
+            {
+                this.source1 = source1;
+                this.source2 = source2;
+                this.source3 = source3;
+                this.source4 = source4;
+                this.source5 = source5;
+                this.source6 = source6;
+                this.source7 = source7;
+                this.source8 = source8;
+                
+                this.resultSelector = resultSelector;
+                this.cancellationToken = cancellationToken;
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public TResult Current => result;
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (completedCount == CompleteCount) return CompletedTasks.False;
+
+                if (enumerator1 == null)
+                {
+                    enumerator1 = source1.GetAsyncEnumerator(cancellationToken);
+                    enumerator2 = source2.GetAsyncEnumerator(cancellationToken);
+                    enumerator3 = source3.GetAsyncEnumerator(cancellationToken);
+                    enumerator4 = source4.GetAsyncEnumerator(cancellationToken);
+                    enumerator5 = source5.GetAsyncEnumerator(cancellationToken);
+                    enumerator6 = source6.GetAsyncEnumerator(cancellationToken);
+                    enumerator7 = source7.GetAsyncEnumerator(cancellationToken);
+                    enumerator8 = source8.GetAsyncEnumerator(cancellationToken);
+                }
+
+                completionSource.Reset();
+
+                AGAIN:
+                syncRunning = true;
+                if (!running1)
+                {
+                    running1 = true;
+                    awaiter1 = enumerator1.MoveNextAsync().GetAwaiter();
+                    if (awaiter1.IsCompleted)
+                    {
+                        Completed1(this);
+                    }
+                    else
+                    {
+                        awaiter1.SourceOnCompleted(Completed1Delegate, this);
+                    }
+                }
+                if (!running2)
+                {
+                    running2 = true;
+                    awaiter2 = enumerator2.MoveNextAsync().GetAwaiter();
+                    if (awaiter2.IsCompleted)
+                    {
+                        Completed2(this);
+                    }
+                    else
+                    {
+                        awaiter2.SourceOnCompleted(Completed2Delegate, this);
+                    }
+                }
+                if (!running3)
+                {
+                    running3 = true;
+                    awaiter3 = enumerator3.MoveNextAsync().GetAwaiter();
+                    if (awaiter3.IsCompleted)
+                    {
+                        Completed3(this);
+                    }
+                    else
+                    {
+                        awaiter3.SourceOnCompleted(Completed3Delegate, this);
+                    }
+                }
+                if (!running4)
+                {
+                    running4 = true;
+                    awaiter4 = enumerator4.MoveNextAsync().GetAwaiter();
+                    if (awaiter4.IsCompleted)
+                    {
+                        Completed4(this);
+                    }
+                    else
+                    {
+                        awaiter4.SourceOnCompleted(Completed4Delegate, this);
+                    }
+                }
+                if (!running5)
+                {
+                    running5 = true;
+                    awaiter5 = enumerator5.MoveNextAsync().GetAwaiter();
+                    if (awaiter5.IsCompleted)
+                    {
+                        Completed5(this);
+                    }
+                    else
+                    {
+                        awaiter5.SourceOnCompleted(Completed5Delegate, this);
+                    }
+                }
+                if (!running6)
+                {
+                    running6 = true;
+                    awaiter6 = enumerator6.MoveNextAsync().GetAwaiter();
+                    if (awaiter6.IsCompleted)
+                    {
+                        Completed6(this);
+                    }
+                    else
+                    {
+                        awaiter6.SourceOnCompleted(Completed6Delegate, this);
+                    }
+                }
+                if (!running7)
+                {
+                    running7 = true;
+                    awaiter7 = enumerator7.MoveNextAsync().GetAwaiter();
+                    if (awaiter7.IsCompleted)
+                    {
+                        Completed7(this);
+                    }
+                    else
+                    {
+                        awaiter7.SourceOnCompleted(Completed7Delegate, this);
+                    }
+                }
+                if (!running8)
+                {
+                    running8 = true;
+                    awaiter8 = enumerator8.MoveNextAsync().GetAwaiter();
+                    if (awaiter8.IsCompleted)
+                    {
+                        Completed8(this);
+                    }
+                    else
+                    {
+                        awaiter8.SourceOnCompleted(Completed8Delegate, this);
+                    }
+                }
+
+                if (!running1 || !running2 || !running3 || !running4 || !running5 || !running6 || !running7 || !running8)
+                {
+                    goto AGAIN;
+                }
+                syncRunning = false;
+
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            static void Completed1(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running1 = false;
+
+                try
+                {
+                    if (self.awaiter1.GetResult())
+                    {
+                        self.hasCurrent1 = true;
+                        self.current1 = self.enumerator1.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running1 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running1 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running1 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter1 = self.enumerator1.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter1.SourceOnCompleted(Completed1Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed2(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running2 = false;
+
+                try
+                {
+                    if (self.awaiter2.GetResult())
+                    {
+                        self.hasCurrent2 = true;
+                        self.current2 = self.enumerator2.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running2 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running2 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running2 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter2 = self.enumerator2.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter2.SourceOnCompleted(Completed2Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed3(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running3 = false;
+
+                try
+                {
+                    if (self.awaiter3.GetResult())
+                    {
+                        self.hasCurrent3 = true;
+                        self.current3 = self.enumerator3.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running3 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running3 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running3 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter3 = self.enumerator3.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter3.SourceOnCompleted(Completed3Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed4(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running4 = false;
+
+                try
+                {
+                    if (self.awaiter4.GetResult())
+                    {
+                        self.hasCurrent4 = true;
+                        self.current4 = self.enumerator4.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running4 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running4 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running4 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter4 = self.enumerator4.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter4.SourceOnCompleted(Completed4Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed5(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running5 = false;
+
+                try
+                {
+                    if (self.awaiter5.GetResult())
+                    {
+                        self.hasCurrent5 = true;
+                        self.current5 = self.enumerator5.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running5 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running5 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running5 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter5 = self.enumerator5.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter5.SourceOnCompleted(Completed5Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed6(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running6 = false;
+
+                try
+                {
+                    if (self.awaiter6.GetResult())
+                    {
+                        self.hasCurrent6 = true;
+                        self.current6 = self.enumerator6.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running6 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running6 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running6 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter6 = self.enumerator6.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter6.SourceOnCompleted(Completed6Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed7(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running7 = false;
+
+                try
+                {
+                    if (self.awaiter7.GetResult())
+                    {
+                        self.hasCurrent7 = true;
+                        self.current7 = self.enumerator7.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running7 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running7 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running7 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter7 = self.enumerator7.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter7.SourceOnCompleted(Completed7Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed8(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running8 = false;
+
+                try
+                {
+                    if (self.awaiter8.GetResult())
+                    {
+                        self.hasCurrent8 = true;
+                        self.current8 = self.enumerator8.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running8 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running8 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running8 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter8 = self.enumerator8.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter8.SourceOnCompleted(Completed8Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            bool TrySetResult()
+            {
+                if (hasCurrent1 && hasCurrent2 && hasCurrent3 && hasCurrent4 && hasCurrent5 && hasCurrent6 && hasCurrent7 && hasCurrent8)
+                {
+                    result = resultSelector(current1, current2, current3, current4, current5, current6, current7, current8);
+                    completionSource.TrySetResult(true);
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
+            public async UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                if (enumerator1 != null)
+                {
+                    await enumerator1.DisposeAsync();
+                }
+                if (enumerator2 != null)
+                {
+                    await enumerator2.DisposeAsync();
+                }
+                if (enumerator3 != null)
+                {
+                    await enumerator3.DisposeAsync();
+                }
+                if (enumerator4 != null)
+                {
+                    await enumerator4.DisposeAsync();
+                }
+                if (enumerator5 != null)
+                {
+                    await enumerator5.DisposeAsync();
+                }
+                if (enumerator6 != null)
+                {
+                    await enumerator6.DisposeAsync();
+                }
+                if (enumerator7 != null)
+                {
+                    await enumerator7.DisposeAsync();
+                }
+                if (enumerator8 != null)
+                {
+                    await enumerator8.DisposeAsync();
+                }
+            }
+        }
+    }
+
+    internal class CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> : IUniTaskAsyncEnumerable<TResult>
+    {
+        readonly IUniTaskAsyncEnumerable<T1> source1;
+        readonly IUniTaskAsyncEnumerable<T2> source2;
+        readonly IUniTaskAsyncEnumerable<T3> source3;
+        readonly IUniTaskAsyncEnumerable<T4> source4;
+        readonly IUniTaskAsyncEnumerable<T5> source5;
+        readonly IUniTaskAsyncEnumerable<T6> source6;
+        readonly IUniTaskAsyncEnumerable<T7> source7;
+        readonly IUniTaskAsyncEnumerable<T8> source8;
+        readonly IUniTaskAsyncEnumerable<T9> source9;
+        
+        readonly Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> resultSelector;
+
+        public CombineLatest(IUniTaskAsyncEnumerable<T1> source1, IUniTaskAsyncEnumerable<T2> source2, IUniTaskAsyncEnumerable<T3> source3, IUniTaskAsyncEnumerable<T4> source4, IUniTaskAsyncEnumerable<T5> source5, IUniTaskAsyncEnumerable<T6> source6, IUniTaskAsyncEnumerable<T7> source7, IUniTaskAsyncEnumerable<T8> source8, IUniTaskAsyncEnumerable<T9> source9, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> resultSelector)
+        {
+            this.source1 = source1;
+            this.source2 = source2;
+            this.source3 = source3;
+            this.source4 = source4;
+            this.source5 = source5;
+            this.source6 = source6;
+            this.source7 = source7;
+            this.source8 = source8;
+            this.source9 = source9;
+        
+            this.resultSelector = resultSelector;
+        }
+
+        public IUniTaskAsyncEnumerator<TResult> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _CombineLatest(source1, source2, source3, source4, source5, source6, source7, source8, source9, resultSelector, cancellationToken);
+        }
+
+        class _CombineLatest : MoveNextSource, IUniTaskAsyncEnumerator<TResult>
+        {
+            static readonly Action<object> Completed1Delegate = Completed1;
+            static readonly Action<object> Completed2Delegate = Completed2;
+            static readonly Action<object> Completed3Delegate = Completed3;
+            static readonly Action<object> Completed4Delegate = Completed4;
+            static readonly Action<object> Completed5Delegate = Completed5;
+            static readonly Action<object> Completed6Delegate = Completed6;
+            static readonly Action<object> Completed7Delegate = Completed7;
+            static readonly Action<object> Completed8Delegate = Completed8;
+            static readonly Action<object> Completed9Delegate = Completed9;
+            const int CompleteCount = 9;
+
+            readonly IUniTaskAsyncEnumerable<T1> source1;
+            readonly IUniTaskAsyncEnumerable<T2> source2;
+            readonly IUniTaskAsyncEnumerable<T3> source3;
+            readonly IUniTaskAsyncEnumerable<T4> source4;
+            readonly IUniTaskAsyncEnumerable<T5> source5;
+            readonly IUniTaskAsyncEnumerable<T6> source6;
+            readonly IUniTaskAsyncEnumerable<T7> source7;
+            readonly IUniTaskAsyncEnumerable<T8> source8;
+            readonly IUniTaskAsyncEnumerable<T9> source9;
+       
+            readonly Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> resultSelector;
+            CancellationToken cancellationToken;
+
+            IUniTaskAsyncEnumerator<T1> enumerator1;
+            UniTask<bool>.Awaiter awaiter1;
+            bool hasCurrent1;
+            bool running1;
+            T1 current1;
+
+            IUniTaskAsyncEnumerator<T2> enumerator2;
+            UniTask<bool>.Awaiter awaiter2;
+            bool hasCurrent2;
+            bool running2;
+            T2 current2;
+
+            IUniTaskAsyncEnumerator<T3> enumerator3;
+            UniTask<bool>.Awaiter awaiter3;
+            bool hasCurrent3;
+            bool running3;
+            T3 current3;
+
+            IUniTaskAsyncEnumerator<T4> enumerator4;
+            UniTask<bool>.Awaiter awaiter4;
+            bool hasCurrent4;
+            bool running4;
+            T4 current4;
+
+            IUniTaskAsyncEnumerator<T5> enumerator5;
+            UniTask<bool>.Awaiter awaiter5;
+            bool hasCurrent5;
+            bool running5;
+            T5 current5;
+
+            IUniTaskAsyncEnumerator<T6> enumerator6;
+            UniTask<bool>.Awaiter awaiter6;
+            bool hasCurrent6;
+            bool running6;
+            T6 current6;
+
+            IUniTaskAsyncEnumerator<T7> enumerator7;
+            UniTask<bool>.Awaiter awaiter7;
+            bool hasCurrent7;
+            bool running7;
+            T7 current7;
+
+            IUniTaskAsyncEnumerator<T8> enumerator8;
+            UniTask<bool>.Awaiter awaiter8;
+            bool hasCurrent8;
+            bool running8;
+            T8 current8;
+
+            IUniTaskAsyncEnumerator<T9> enumerator9;
+            UniTask<bool>.Awaiter awaiter9;
+            bool hasCurrent9;
+            bool running9;
+            T9 current9;
+
+            int completedCount;
+            bool syncRunning;
+            TResult result;
+
+            public _CombineLatest(IUniTaskAsyncEnumerable<T1> source1, IUniTaskAsyncEnumerable<T2> source2, IUniTaskAsyncEnumerable<T3> source3, IUniTaskAsyncEnumerable<T4> source4, IUniTaskAsyncEnumerable<T5> source5, IUniTaskAsyncEnumerable<T6> source6, IUniTaskAsyncEnumerable<T7> source7, IUniTaskAsyncEnumerable<T8> source8, IUniTaskAsyncEnumerable<T9> source9, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> resultSelector, CancellationToken cancellationToken)
+            {
+                this.source1 = source1;
+                this.source2 = source2;
+                this.source3 = source3;
+                this.source4 = source4;
+                this.source5 = source5;
+                this.source6 = source6;
+                this.source7 = source7;
+                this.source8 = source8;
+                this.source9 = source9;
+                
+                this.resultSelector = resultSelector;
+                this.cancellationToken = cancellationToken;
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public TResult Current => result;
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (completedCount == CompleteCount) return CompletedTasks.False;
+
+                if (enumerator1 == null)
+                {
+                    enumerator1 = source1.GetAsyncEnumerator(cancellationToken);
+                    enumerator2 = source2.GetAsyncEnumerator(cancellationToken);
+                    enumerator3 = source3.GetAsyncEnumerator(cancellationToken);
+                    enumerator4 = source4.GetAsyncEnumerator(cancellationToken);
+                    enumerator5 = source5.GetAsyncEnumerator(cancellationToken);
+                    enumerator6 = source6.GetAsyncEnumerator(cancellationToken);
+                    enumerator7 = source7.GetAsyncEnumerator(cancellationToken);
+                    enumerator8 = source8.GetAsyncEnumerator(cancellationToken);
+                    enumerator9 = source9.GetAsyncEnumerator(cancellationToken);
+                }
+
+                completionSource.Reset();
+
+                AGAIN:
+                syncRunning = true;
+                if (!running1)
+                {
+                    running1 = true;
+                    awaiter1 = enumerator1.MoveNextAsync().GetAwaiter();
+                    if (awaiter1.IsCompleted)
+                    {
+                        Completed1(this);
+                    }
+                    else
+                    {
+                        awaiter1.SourceOnCompleted(Completed1Delegate, this);
+                    }
+                }
+                if (!running2)
+                {
+                    running2 = true;
+                    awaiter2 = enumerator2.MoveNextAsync().GetAwaiter();
+                    if (awaiter2.IsCompleted)
+                    {
+                        Completed2(this);
+                    }
+                    else
+                    {
+                        awaiter2.SourceOnCompleted(Completed2Delegate, this);
+                    }
+                }
+                if (!running3)
+                {
+                    running3 = true;
+                    awaiter3 = enumerator3.MoveNextAsync().GetAwaiter();
+                    if (awaiter3.IsCompleted)
+                    {
+                        Completed3(this);
+                    }
+                    else
+                    {
+                        awaiter3.SourceOnCompleted(Completed3Delegate, this);
+                    }
+                }
+                if (!running4)
+                {
+                    running4 = true;
+                    awaiter4 = enumerator4.MoveNextAsync().GetAwaiter();
+                    if (awaiter4.IsCompleted)
+                    {
+                        Completed4(this);
+                    }
+                    else
+                    {
+                        awaiter4.SourceOnCompleted(Completed4Delegate, this);
+                    }
+                }
+                if (!running5)
+                {
+                    running5 = true;
+                    awaiter5 = enumerator5.MoveNextAsync().GetAwaiter();
+                    if (awaiter5.IsCompleted)
+                    {
+                        Completed5(this);
+                    }
+                    else
+                    {
+                        awaiter5.SourceOnCompleted(Completed5Delegate, this);
+                    }
+                }
+                if (!running6)
+                {
+                    running6 = true;
+                    awaiter6 = enumerator6.MoveNextAsync().GetAwaiter();
+                    if (awaiter6.IsCompleted)
+                    {
+                        Completed6(this);
+                    }
+                    else
+                    {
+                        awaiter6.SourceOnCompleted(Completed6Delegate, this);
+                    }
+                }
+                if (!running7)
+                {
+                    running7 = true;
+                    awaiter7 = enumerator7.MoveNextAsync().GetAwaiter();
+                    if (awaiter7.IsCompleted)
+                    {
+                        Completed7(this);
+                    }
+                    else
+                    {
+                        awaiter7.SourceOnCompleted(Completed7Delegate, this);
+                    }
+                }
+                if (!running8)
+                {
+                    running8 = true;
+                    awaiter8 = enumerator8.MoveNextAsync().GetAwaiter();
+                    if (awaiter8.IsCompleted)
+                    {
+                        Completed8(this);
+                    }
+                    else
+                    {
+                        awaiter8.SourceOnCompleted(Completed8Delegate, this);
+                    }
+                }
+                if (!running9)
+                {
+                    running9 = true;
+                    awaiter9 = enumerator9.MoveNextAsync().GetAwaiter();
+                    if (awaiter9.IsCompleted)
+                    {
+                        Completed9(this);
+                    }
+                    else
+                    {
+                        awaiter9.SourceOnCompleted(Completed9Delegate, this);
+                    }
+                }
+
+                if (!running1 || !running2 || !running3 || !running4 || !running5 || !running6 || !running7 || !running8 || !running9)
+                {
+                    goto AGAIN;
+                }
+                syncRunning = false;
+
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            static void Completed1(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running1 = false;
+
+                try
+                {
+                    if (self.awaiter1.GetResult())
+                    {
+                        self.hasCurrent1 = true;
+                        self.current1 = self.enumerator1.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running1 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running1 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running1 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter1 = self.enumerator1.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter1.SourceOnCompleted(Completed1Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed2(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running2 = false;
+
+                try
+                {
+                    if (self.awaiter2.GetResult())
+                    {
+                        self.hasCurrent2 = true;
+                        self.current2 = self.enumerator2.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running2 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running2 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running2 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter2 = self.enumerator2.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter2.SourceOnCompleted(Completed2Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed3(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running3 = false;
+
+                try
+                {
+                    if (self.awaiter3.GetResult())
+                    {
+                        self.hasCurrent3 = true;
+                        self.current3 = self.enumerator3.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running3 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running3 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running3 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter3 = self.enumerator3.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter3.SourceOnCompleted(Completed3Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed4(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running4 = false;
+
+                try
+                {
+                    if (self.awaiter4.GetResult())
+                    {
+                        self.hasCurrent4 = true;
+                        self.current4 = self.enumerator4.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running4 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running4 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running4 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter4 = self.enumerator4.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter4.SourceOnCompleted(Completed4Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed5(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running5 = false;
+
+                try
+                {
+                    if (self.awaiter5.GetResult())
+                    {
+                        self.hasCurrent5 = true;
+                        self.current5 = self.enumerator5.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running5 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running5 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running5 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter5 = self.enumerator5.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter5.SourceOnCompleted(Completed5Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed6(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running6 = false;
+
+                try
+                {
+                    if (self.awaiter6.GetResult())
+                    {
+                        self.hasCurrent6 = true;
+                        self.current6 = self.enumerator6.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running6 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running6 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running6 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter6 = self.enumerator6.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter6.SourceOnCompleted(Completed6Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed7(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running7 = false;
+
+                try
+                {
+                    if (self.awaiter7.GetResult())
+                    {
+                        self.hasCurrent7 = true;
+                        self.current7 = self.enumerator7.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running7 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running7 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running7 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter7 = self.enumerator7.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter7.SourceOnCompleted(Completed7Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed8(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running8 = false;
+
+                try
+                {
+                    if (self.awaiter8.GetResult())
+                    {
+                        self.hasCurrent8 = true;
+                        self.current8 = self.enumerator8.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running8 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running8 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running8 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter8 = self.enumerator8.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter8.SourceOnCompleted(Completed8Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed9(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running9 = false;
+
+                try
+                {
+                    if (self.awaiter9.GetResult())
+                    {
+                        self.hasCurrent9 = true;
+                        self.current9 = self.enumerator9.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running9 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running9 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running9 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter9 = self.enumerator9.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter9.SourceOnCompleted(Completed9Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            bool TrySetResult()
+            {
+                if (hasCurrent1 && hasCurrent2 && hasCurrent3 && hasCurrent4 && hasCurrent5 && hasCurrent6 && hasCurrent7 && hasCurrent8 && hasCurrent9)
+                {
+                    result = resultSelector(current1, current2, current3, current4, current5, current6, current7, current8, current9);
+                    completionSource.TrySetResult(true);
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
+            public async UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                if (enumerator1 != null)
+                {
+                    await enumerator1.DisposeAsync();
+                }
+                if (enumerator2 != null)
+                {
+                    await enumerator2.DisposeAsync();
+                }
+                if (enumerator3 != null)
+                {
+                    await enumerator3.DisposeAsync();
+                }
+                if (enumerator4 != null)
+                {
+                    await enumerator4.DisposeAsync();
+                }
+                if (enumerator5 != null)
+                {
+                    await enumerator5.DisposeAsync();
+                }
+                if (enumerator6 != null)
+                {
+                    await enumerator6.DisposeAsync();
+                }
+                if (enumerator7 != null)
+                {
+                    await enumerator7.DisposeAsync();
+                }
+                if (enumerator8 != null)
+                {
+                    await enumerator8.DisposeAsync();
+                }
+                if (enumerator9 != null)
+                {
+                    await enumerator9.DisposeAsync();
+                }
+            }
+        }
+    }
+
+    internal class CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> : IUniTaskAsyncEnumerable<TResult>
+    {
+        readonly IUniTaskAsyncEnumerable<T1> source1;
+        readonly IUniTaskAsyncEnumerable<T2> source2;
+        readonly IUniTaskAsyncEnumerable<T3> source3;
+        readonly IUniTaskAsyncEnumerable<T4> source4;
+        readonly IUniTaskAsyncEnumerable<T5> source5;
+        readonly IUniTaskAsyncEnumerable<T6> source6;
+        readonly IUniTaskAsyncEnumerable<T7> source7;
+        readonly IUniTaskAsyncEnumerable<T8> source8;
+        readonly IUniTaskAsyncEnumerable<T9> source9;
+        readonly IUniTaskAsyncEnumerable<T10> source10;
+        
+        readonly Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> resultSelector;
+
+        public CombineLatest(IUniTaskAsyncEnumerable<T1> source1, IUniTaskAsyncEnumerable<T2> source2, IUniTaskAsyncEnumerable<T3> source3, IUniTaskAsyncEnumerable<T4> source4, IUniTaskAsyncEnumerable<T5> source5, IUniTaskAsyncEnumerable<T6> source6, IUniTaskAsyncEnumerable<T7> source7, IUniTaskAsyncEnumerable<T8> source8, IUniTaskAsyncEnumerable<T9> source9, IUniTaskAsyncEnumerable<T10> source10, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> resultSelector)
+        {
+            this.source1 = source1;
+            this.source2 = source2;
+            this.source3 = source3;
+            this.source4 = source4;
+            this.source5 = source5;
+            this.source6 = source6;
+            this.source7 = source7;
+            this.source8 = source8;
+            this.source9 = source9;
+            this.source10 = source10;
+        
+            this.resultSelector = resultSelector;
+        }
+
+        public IUniTaskAsyncEnumerator<TResult> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _CombineLatest(source1, source2, source3, source4, source5, source6, source7, source8, source9, source10, resultSelector, cancellationToken);
+        }
+
+        class _CombineLatest : MoveNextSource, IUniTaskAsyncEnumerator<TResult>
+        {
+            static readonly Action<object> Completed1Delegate = Completed1;
+            static readonly Action<object> Completed2Delegate = Completed2;
+            static readonly Action<object> Completed3Delegate = Completed3;
+            static readonly Action<object> Completed4Delegate = Completed4;
+            static readonly Action<object> Completed5Delegate = Completed5;
+            static readonly Action<object> Completed6Delegate = Completed6;
+            static readonly Action<object> Completed7Delegate = Completed7;
+            static readonly Action<object> Completed8Delegate = Completed8;
+            static readonly Action<object> Completed9Delegate = Completed9;
+            static readonly Action<object> Completed10Delegate = Completed10;
+            const int CompleteCount = 10;
+
+            readonly IUniTaskAsyncEnumerable<T1> source1;
+            readonly IUniTaskAsyncEnumerable<T2> source2;
+            readonly IUniTaskAsyncEnumerable<T3> source3;
+            readonly IUniTaskAsyncEnumerable<T4> source4;
+            readonly IUniTaskAsyncEnumerable<T5> source5;
+            readonly IUniTaskAsyncEnumerable<T6> source6;
+            readonly IUniTaskAsyncEnumerable<T7> source7;
+            readonly IUniTaskAsyncEnumerable<T8> source8;
+            readonly IUniTaskAsyncEnumerable<T9> source9;
+            readonly IUniTaskAsyncEnumerable<T10> source10;
+       
+            readonly Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> resultSelector;
+            CancellationToken cancellationToken;
+
+            IUniTaskAsyncEnumerator<T1> enumerator1;
+            UniTask<bool>.Awaiter awaiter1;
+            bool hasCurrent1;
+            bool running1;
+            T1 current1;
+
+            IUniTaskAsyncEnumerator<T2> enumerator2;
+            UniTask<bool>.Awaiter awaiter2;
+            bool hasCurrent2;
+            bool running2;
+            T2 current2;
+
+            IUniTaskAsyncEnumerator<T3> enumerator3;
+            UniTask<bool>.Awaiter awaiter3;
+            bool hasCurrent3;
+            bool running3;
+            T3 current3;
+
+            IUniTaskAsyncEnumerator<T4> enumerator4;
+            UniTask<bool>.Awaiter awaiter4;
+            bool hasCurrent4;
+            bool running4;
+            T4 current4;
+
+            IUniTaskAsyncEnumerator<T5> enumerator5;
+            UniTask<bool>.Awaiter awaiter5;
+            bool hasCurrent5;
+            bool running5;
+            T5 current5;
+
+            IUniTaskAsyncEnumerator<T6> enumerator6;
+            UniTask<bool>.Awaiter awaiter6;
+            bool hasCurrent6;
+            bool running6;
+            T6 current6;
+
+            IUniTaskAsyncEnumerator<T7> enumerator7;
+            UniTask<bool>.Awaiter awaiter7;
+            bool hasCurrent7;
+            bool running7;
+            T7 current7;
+
+            IUniTaskAsyncEnumerator<T8> enumerator8;
+            UniTask<bool>.Awaiter awaiter8;
+            bool hasCurrent8;
+            bool running8;
+            T8 current8;
+
+            IUniTaskAsyncEnumerator<T9> enumerator9;
+            UniTask<bool>.Awaiter awaiter9;
+            bool hasCurrent9;
+            bool running9;
+            T9 current9;
+
+            IUniTaskAsyncEnumerator<T10> enumerator10;
+            UniTask<bool>.Awaiter awaiter10;
+            bool hasCurrent10;
+            bool running10;
+            T10 current10;
+
+            int completedCount;
+            bool syncRunning;
+            TResult result;
+
+            public _CombineLatest(IUniTaskAsyncEnumerable<T1> source1, IUniTaskAsyncEnumerable<T2> source2, IUniTaskAsyncEnumerable<T3> source3, IUniTaskAsyncEnumerable<T4> source4, IUniTaskAsyncEnumerable<T5> source5, IUniTaskAsyncEnumerable<T6> source6, IUniTaskAsyncEnumerable<T7> source7, IUniTaskAsyncEnumerable<T8> source8, IUniTaskAsyncEnumerable<T9> source9, IUniTaskAsyncEnumerable<T10> source10, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> resultSelector, CancellationToken cancellationToken)
+            {
+                this.source1 = source1;
+                this.source2 = source2;
+                this.source3 = source3;
+                this.source4 = source4;
+                this.source5 = source5;
+                this.source6 = source6;
+                this.source7 = source7;
+                this.source8 = source8;
+                this.source9 = source9;
+                this.source10 = source10;
+                
+                this.resultSelector = resultSelector;
+                this.cancellationToken = cancellationToken;
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public TResult Current => result;
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (completedCount == CompleteCount) return CompletedTasks.False;
+
+                if (enumerator1 == null)
+                {
+                    enumerator1 = source1.GetAsyncEnumerator(cancellationToken);
+                    enumerator2 = source2.GetAsyncEnumerator(cancellationToken);
+                    enumerator3 = source3.GetAsyncEnumerator(cancellationToken);
+                    enumerator4 = source4.GetAsyncEnumerator(cancellationToken);
+                    enumerator5 = source5.GetAsyncEnumerator(cancellationToken);
+                    enumerator6 = source6.GetAsyncEnumerator(cancellationToken);
+                    enumerator7 = source7.GetAsyncEnumerator(cancellationToken);
+                    enumerator8 = source8.GetAsyncEnumerator(cancellationToken);
+                    enumerator9 = source9.GetAsyncEnumerator(cancellationToken);
+                    enumerator10 = source10.GetAsyncEnumerator(cancellationToken);
+                }
+
+                completionSource.Reset();
+
+                AGAIN:
+                syncRunning = true;
+                if (!running1)
+                {
+                    running1 = true;
+                    awaiter1 = enumerator1.MoveNextAsync().GetAwaiter();
+                    if (awaiter1.IsCompleted)
+                    {
+                        Completed1(this);
+                    }
+                    else
+                    {
+                        awaiter1.SourceOnCompleted(Completed1Delegate, this);
+                    }
+                }
+                if (!running2)
+                {
+                    running2 = true;
+                    awaiter2 = enumerator2.MoveNextAsync().GetAwaiter();
+                    if (awaiter2.IsCompleted)
+                    {
+                        Completed2(this);
+                    }
+                    else
+                    {
+                        awaiter2.SourceOnCompleted(Completed2Delegate, this);
+                    }
+                }
+                if (!running3)
+                {
+                    running3 = true;
+                    awaiter3 = enumerator3.MoveNextAsync().GetAwaiter();
+                    if (awaiter3.IsCompleted)
+                    {
+                        Completed3(this);
+                    }
+                    else
+                    {
+                        awaiter3.SourceOnCompleted(Completed3Delegate, this);
+                    }
+                }
+                if (!running4)
+                {
+                    running4 = true;
+                    awaiter4 = enumerator4.MoveNextAsync().GetAwaiter();
+                    if (awaiter4.IsCompleted)
+                    {
+                        Completed4(this);
+                    }
+                    else
+                    {
+                        awaiter4.SourceOnCompleted(Completed4Delegate, this);
+                    }
+                }
+                if (!running5)
+                {
+                    running5 = true;
+                    awaiter5 = enumerator5.MoveNextAsync().GetAwaiter();
+                    if (awaiter5.IsCompleted)
+                    {
+                        Completed5(this);
+                    }
+                    else
+                    {
+                        awaiter5.SourceOnCompleted(Completed5Delegate, this);
+                    }
+                }
+                if (!running6)
+                {
+                    running6 = true;
+                    awaiter6 = enumerator6.MoveNextAsync().GetAwaiter();
+                    if (awaiter6.IsCompleted)
+                    {
+                        Completed6(this);
+                    }
+                    else
+                    {
+                        awaiter6.SourceOnCompleted(Completed6Delegate, this);
+                    }
+                }
+                if (!running7)
+                {
+                    running7 = true;
+                    awaiter7 = enumerator7.MoveNextAsync().GetAwaiter();
+                    if (awaiter7.IsCompleted)
+                    {
+                        Completed7(this);
+                    }
+                    else
+                    {
+                        awaiter7.SourceOnCompleted(Completed7Delegate, this);
+                    }
+                }
+                if (!running8)
+                {
+                    running8 = true;
+                    awaiter8 = enumerator8.MoveNextAsync().GetAwaiter();
+                    if (awaiter8.IsCompleted)
+                    {
+                        Completed8(this);
+                    }
+                    else
+                    {
+                        awaiter8.SourceOnCompleted(Completed8Delegate, this);
+                    }
+                }
+                if (!running9)
+                {
+                    running9 = true;
+                    awaiter9 = enumerator9.MoveNextAsync().GetAwaiter();
+                    if (awaiter9.IsCompleted)
+                    {
+                        Completed9(this);
+                    }
+                    else
+                    {
+                        awaiter9.SourceOnCompleted(Completed9Delegate, this);
+                    }
+                }
+                if (!running10)
+                {
+                    running10 = true;
+                    awaiter10 = enumerator10.MoveNextAsync().GetAwaiter();
+                    if (awaiter10.IsCompleted)
+                    {
+                        Completed10(this);
+                    }
+                    else
+                    {
+                        awaiter10.SourceOnCompleted(Completed10Delegate, this);
+                    }
+                }
+
+                if (!running1 || !running2 || !running3 || !running4 || !running5 || !running6 || !running7 || !running8 || !running9 || !running10)
+                {
+                    goto AGAIN;
+                }
+                syncRunning = false;
+
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            static void Completed1(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running1 = false;
+
+                try
+                {
+                    if (self.awaiter1.GetResult())
+                    {
+                        self.hasCurrent1 = true;
+                        self.current1 = self.enumerator1.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running1 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running1 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running1 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter1 = self.enumerator1.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter1.SourceOnCompleted(Completed1Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed2(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running2 = false;
+
+                try
+                {
+                    if (self.awaiter2.GetResult())
+                    {
+                        self.hasCurrent2 = true;
+                        self.current2 = self.enumerator2.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running2 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running2 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running2 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter2 = self.enumerator2.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter2.SourceOnCompleted(Completed2Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed3(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running3 = false;
+
+                try
+                {
+                    if (self.awaiter3.GetResult())
+                    {
+                        self.hasCurrent3 = true;
+                        self.current3 = self.enumerator3.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running3 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running3 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running3 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter3 = self.enumerator3.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter3.SourceOnCompleted(Completed3Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed4(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running4 = false;
+
+                try
+                {
+                    if (self.awaiter4.GetResult())
+                    {
+                        self.hasCurrent4 = true;
+                        self.current4 = self.enumerator4.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running4 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running4 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running4 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter4 = self.enumerator4.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter4.SourceOnCompleted(Completed4Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed5(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running5 = false;
+
+                try
+                {
+                    if (self.awaiter5.GetResult())
+                    {
+                        self.hasCurrent5 = true;
+                        self.current5 = self.enumerator5.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running5 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running5 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running5 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter5 = self.enumerator5.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter5.SourceOnCompleted(Completed5Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed6(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running6 = false;
+
+                try
+                {
+                    if (self.awaiter6.GetResult())
+                    {
+                        self.hasCurrent6 = true;
+                        self.current6 = self.enumerator6.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running6 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running6 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running6 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter6 = self.enumerator6.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter6.SourceOnCompleted(Completed6Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed7(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running7 = false;
+
+                try
+                {
+                    if (self.awaiter7.GetResult())
+                    {
+                        self.hasCurrent7 = true;
+                        self.current7 = self.enumerator7.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running7 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running7 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running7 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter7 = self.enumerator7.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter7.SourceOnCompleted(Completed7Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed8(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running8 = false;
+
+                try
+                {
+                    if (self.awaiter8.GetResult())
+                    {
+                        self.hasCurrent8 = true;
+                        self.current8 = self.enumerator8.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running8 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running8 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running8 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter8 = self.enumerator8.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter8.SourceOnCompleted(Completed8Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed9(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running9 = false;
+
+                try
+                {
+                    if (self.awaiter9.GetResult())
+                    {
+                        self.hasCurrent9 = true;
+                        self.current9 = self.enumerator9.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running9 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running9 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running9 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter9 = self.enumerator9.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter9.SourceOnCompleted(Completed9Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed10(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running10 = false;
+
+                try
+                {
+                    if (self.awaiter10.GetResult())
+                    {
+                        self.hasCurrent10 = true;
+                        self.current10 = self.enumerator10.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running10 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running10 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running10 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter10 = self.enumerator10.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter10.SourceOnCompleted(Completed10Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            bool TrySetResult()
+            {
+                if (hasCurrent1 && hasCurrent2 && hasCurrent3 && hasCurrent4 && hasCurrent5 && hasCurrent6 && hasCurrent7 && hasCurrent8 && hasCurrent9 && hasCurrent10)
+                {
+                    result = resultSelector(current1, current2, current3, current4, current5, current6, current7, current8, current9, current10);
+                    completionSource.TrySetResult(true);
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
+            public async UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                if (enumerator1 != null)
+                {
+                    await enumerator1.DisposeAsync();
+                }
+                if (enumerator2 != null)
+                {
+                    await enumerator2.DisposeAsync();
+                }
+                if (enumerator3 != null)
+                {
+                    await enumerator3.DisposeAsync();
+                }
+                if (enumerator4 != null)
+                {
+                    await enumerator4.DisposeAsync();
+                }
+                if (enumerator5 != null)
+                {
+                    await enumerator5.DisposeAsync();
+                }
+                if (enumerator6 != null)
+                {
+                    await enumerator6.DisposeAsync();
+                }
+                if (enumerator7 != null)
+                {
+                    await enumerator7.DisposeAsync();
+                }
+                if (enumerator8 != null)
+                {
+                    await enumerator8.DisposeAsync();
+                }
+                if (enumerator9 != null)
+                {
+                    await enumerator9.DisposeAsync();
+                }
+                if (enumerator10 != null)
+                {
+                    await enumerator10.DisposeAsync();
+                }
+            }
+        }
+    }
+
+    internal class CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> : IUniTaskAsyncEnumerable<TResult>
+    {
+        readonly IUniTaskAsyncEnumerable<T1> source1;
+        readonly IUniTaskAsyncEnumerable<T2> source2;
+        readonly IUniTaskAsyncEnumerable<T3> source3;
+        readonly IUniTaskAsyncEnumerable<T4> source4;
+        readonly IUniTaskAsyncEnumerable<T5> source5;
+        readonly IUniTaskAsyncEnumerable<T6> source6;
+        readonly IUniTaskAsyncEnumerable<T7> source7;
+        readonly IUniTaskAsyncEnumerable<T8> source8;
+        readonly IUniTaskAsyncEnumerable<T9> source9;
+        readonly IUniTaskAsyncEnumerable<T10> source10;
+        readonly IUniTaskAsyncEnumerable<T11> source11;
+        
+        readonly Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> resultSelector;
+
+        public CombineLatest(IUniTaskAsyncEnumerable<T1> source1, IUniTaskAsyncEnumerable<T2> source2, IUniTaskAsyncEnumerable<T3> source3, IUniTaskAsyncEnumerable<T4> source4, IUniTaskAsyncEnumerable<T5> source5, IUniTaskAsyncEnumerable<T6> source6, IUniTaskAsyncEnumerable<T7> source7, IUniTaskAsyncEnumerable<T8> source8, IUniTaskAsyncEnumerable<T9> source9, IUniTaskAsyncEnumerable<T10> source10, IUniTaskAsyncEnumerable<T11> source11, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> resultSelector)
+        {
+            this.source1 = source1;
+            this.source2 = source2;
+            this.source3 = source3;
+            this.source4 = source4;
+            this.source5 = source5;
+            this.source6 = source6;
+            this.source7 = source7;
+            this.source8 = source8;
+            this.source9 = source9;
+            this.source10 = source10;
+            this.source11 = source11;
+        
+            this.resultSelector = resultSelector;
+        }
+
+        public IUniTaskAsyncEnumerator<TResult> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _CombineLatest(source1, source2, source3, source4, source5, source6, source7, source8, source9, source10, source11, resultSelector, cancellationToken);
+        }
+
+        class _CombineLatest : MoveNextSource, IUniTaskAsyncEnumerator<TResult>
+        {
+            static readonly Action<object> Completed1Delegate = Completed1;
+            static readonly Action<object> Completed2Delegate = Completed2;
+            static readonly Action<object> Completed3Delegate = Completed3;
+            static readonly Action<object> Completed4Delegate = Completed4;
+            static readonly Action<object> Completed5Delegate = Completed5;
+            static readonly Action<object> Completed6Delegate = Completed6;
+            static readonly Action<object> Completed7Delegate = Completed7;
+            static readonly Action<object> Completed8Delegate = Completed8;
+            static readonly Action<object> Completed9Delegate = Completed9;
+            static readonly Action<object> Completed10Delegate = Completed10;
+            static readonly Action<object> Completed11Delegate = Completed11;
+            const int CompleteCount = 11;
+
+            readonly IUniTaskAsyncEnumerable<T1> source1;
+            readonly IUniTaskAsyncEnumerable<T2> source2;
+            readonly IUniTaskAsyncEnumerable<T3> source3;
+            readonly IUniTaskAsyncEnumerable<T4> source4;
+            readonly IUniTaskAsyncEnumerable<T5> source5;
+            readonly IUniTaskAsyncEnumerable<T6> source6;
+            readonly IUniTaskAsyncEnumerable<T7> source7;
+            readonly IUniTaskAsyncEnumerable<T8> source8;
+            readonly IUniTaskAsyncEnumerable<T9> source9;
+            readonly IUniTaskAsyncEnumerable<T10> source10;
+            readonly IUniTaskAsyncEnumerable<T11> source11;
+       
+            readonly Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> resultSelector;
+            CancellationToken cancellationToken;
+
+            IUniTaskAsyncEnumerator<T1> enumerator1;
+            UniTask<bool>.Awaiter awaiter1;
+            bool hasCurrent1;
+            bool running1;
+            T1 current1;
+
+            IUniTaskAsyncEnumerator<T2> enumerator2;
+            UniTask<bool>.Awaiter awaiter2;
+            bool hasCurrent2;
+            bool running2;
+            T2 current2;
+
+            IUniTaskAsyncEnumerator<T3> enumerator3;
+            UniTask<bool>.Awaiter awaiter3;
+            bool hasCurrent3;
+            bool running3;
+            T3 current3;
+
+            IUniTaskAsyncEnumerator<T4> enumerator4;
+            UniTask<bool>.Awaiter awaiter4;
+            bool hasCurrent4;
+            bool running4;
+            T4 current4;
+
+            IUniTaskAsyncEnumerator<T5> enumerator5;
+            UniTask<bool>.Awaiter awaiter5;
+            bool hasCurrent5;
+            bool running5;
+            T5 current5;
+
+            IUniTaskAsyncEnumerator<T6> enumerator6;
+            UniTask<bool>.Awaiter awaiter6;
+            bool hasCurrent6;
+            bool running6;
+            T6 current6;
+
+            IUniTaskAsyncEnumerator<T7> enumerator7;
+            UniTask<bool>.Awaiter awaiter7;
+            bool hasCurrent7;
+            bool running7;
+            T7 current7;
+
+            IUniTaskAsyncEnumerator<T8> enumerator8;
+            UniTask<bool>.Awaiter awaiter8;
+            bool hasCurrent8;
+            bool running8;
+            T8 current8;
+
+            IUniTaskAsyncEnumerator<T9> enumerator9;
+            UniTask<bool>.Awaiter awaiter9;
+            bool hasCurrent9;
+            bool running9;
+            T9 current9;
+
+            IUniTaskAsyncEnumerator<T10> enumerator10;
+            UniTask<bool>.Awaiter awaiter10;
+            bool hasCurrent10;
+            bool running10;
+            T10 current10;
+
+            IUniTaskAsyncEnumerator<T11> enumerator11;
+            UniTask<bool>.Awaiter awaiter11;
+            bool hasCurrent11;
+            bool running11;
+            T11 current11;
+
+            int completedCount;
+            bool syncRunning;
+            TResult result;
+
+            public _CombineLatest(IUniTaskAsyncEnumerable<T1> source1, IUniTaskAsyncEnumerable<T2> source2, IUniTaskAsyncEnumerable<T3> source3, IUniTaskAsyncEnumerable<T4> source4, IUniTaskAsyncEnumerable<T5> source5, IUniTaskAsyncEnumerable<T6> source6, IUniTaskAsyncEnumerable<T7> source7, IUniTaskAsyncEnumerable<T8> source8, IUniTaskAsyncEnumerable<T9> source9, IUniTaskAsyncEnumerable<T10> source10, IUniTaskAsyncEnumerable<T11> source11, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> resultSelector, CancellationToken cancellationToken)
+            {
+                this.source1 = source1;
+                this.source2 = source2;
+                this.source3 = source3;
+                this.source4 = source4;
+                this.source5 = source5;
+                this.source6 = source6;
+                this.source7 = source7;
+                this.source8 = source8;
+                this.source9 = source9;
+                this.source10 = source10;
+                this.source11 = source11;
+                
+                this.resultSelector = resultSelector;
+                this.cancellationToken = cancellationToken;
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public TResult Current => result;
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (completedCount == CompleteCount) return CompletedTasks.False;
+
+                if (enumerator1 == null)
+                {
+                    enumerator1 = source1.GetAsyncEnumerator(cancellationToken);
+                    enumerator2 = source2.GetAsyncEnumerator(cancellationToken);
+                    enumerator3 = source3.GetAsyncEnumerator(cancellationToken);
+                    enumerator4 = source4.GetAsyncEnumerator(cancellationToken);
+                    enumerator5 = source5.GetAsyncEnumerator(cancellationToken);
+                    enumerator6 = source6.GetAsyncEnumerator(cancellationToken);
+                    enumerator7 = source7.GetAsyncEnumerator(cancellationToken);
+                    enumerator8 = source8.GetAsyncEnumerator(cancellationToken);
+                    enumerator9 = source9.GetAsyncEnumerator(cancellationToken);
+                    enumerator10 = source10.GetAsyncEnumerator(cancellationToken);
+                    enumerator11 = source11.GetAsyncEnumerator(cancellationToken);
+                }
+
+                completionSource.Reset();
+
+                AGAIN:
+                syncRunning = true;
+                if (!running1)
+                {
+                    running1 = true;
+                    awaiter1 = enumerator1.MoveNextAsync().GetAwaiter();
+                    if (awaiter1.IsCompleted)
+                    {
+                        Completed1(this);
+                    }
+                    else
+                    {
+                        awaiter1.SourceOnCompleted(Completed1Delegate, this);
+                    }
+                }
+                if (!running2)
+                {
+                    running2 = true;
+                    awaiter2 = enumerator2.MoveNextAsync().GetAwaiter();
+                    if (awaiter2.IsCompleted)
+                    {
+                        Completed2(this);
+                    }
+                    else
+                    {
+                        awaiter2.SourceOnCompleted(Completed2Delegate, this);
+                    }
+                }
+                if (!running3)
+                {
+                    running3 = true;
+                    awaiter3 = enumerator3.MoveNextAsync().GetAwaiter();
+                    if (awaiter3.IsCompleted)
+                    {
+                        Completed3(this);
+                    }
+                    else
+                    {
+                        awaiter3.SourceOnCompleted(Completed3Delegate, this);
+                    }
+                }
+                if (!running4)
+                {
+                    running4 = true;
+                    awaiter4 = enumerator4.MoveNextAsync().GetAwaiter();
+                    if (awaiter4.IsCompleted)
+                    {
+                        Completed4(this);
+                    }
+                    else
+                    {
+                        awaiter4.SourceOnCompleted(Completed4Delegate, this);
+                    }
+                }
+                if (!running5)
+                {
+                    running5 = true;
+                    awaiter5 = enumerator5.MoveNextAsync().GetAwaiter();
+                    if (awaiter5.IsCompleted)
+                    {
+                        Completed5(this);
+                    }
+                    else
+                    {
+                        awaiter5.SourceOnCompleted(Completed5Delegate, this);
+                    }
+                }
+                if (!running6)
+                {
+                    running6 = true;
+                    awaiter6 = enumerator6.MoveNextAsync().GetAwaiter();
+                    if (awaiter6.IsCompleted)
+                    {
+                        Completed6(this);
+                    }
+                    else
+                    {
+                        awaiter6.SourceOnCompleted(Completed6Delegate, this);
+                    }
+                }
+                if (!running7)
+                {
+                    running7 = true;
+                    awaiter7 = enumerator7.MoveNextAsync().GetAwaiter();
+                    if (awaiter7.IsCompleted)
+                    {
+                        Completed7(this);
+                    }
+                    else
+                    {
+                        awaiter7.SourceOnCompleted(Completed7Delegate, this);
+                    }
+                }
+                if (!running8)
+                {
+                    running8 = true;
+                    awaiter8 = enumerator8.MoveNextAsync().GetAwaiter();
+                    if (awaiter8.IsCompleted)
+                    {
+                        Completed8(this);
+                    }
+                    else
+                    {
+                        awaiter8.SourceOnCompleted(Completed8Delegate, this);
+                    }
+                }
+                if (!running9)
+                {
+                    running9 = true;
+                    awaiter9 = enumerator9.MoveNextAsync().GetAwaiter();
+                    if (awaiter9.IsCompleted)
+                    {
+                        Completed9(this);
+                    }
+                    else
+                    {
+                        awaiter9.SourceOnCompleted(Completed9Delegate, this);
+                    }
+                }
+                if (!running10)
+                {
+                    running10 = true;
+                    awaiter10 = enumerator10.MoveNextAsync().GetAwaiter();
+                    if (awaiter10.IsCompleted)
+                    {
+                        Completed10(this);
+                    }
+                    else
+                    {
+                        awaiter10.SourceOnCompleted(Completed10Delegate, this);
+                    }
+                }
+                if (!running11)
+                {
+                    running11 = true;
+                    awaiter11 = enumerator11.MoveNextAsync().GetAwaiter();
+                    if (awaiter11.IsCompleted)
+                    {
+                        Completed11(this);
+                    }
+                    else
+                    {
+                        awaiter11.SourceOnCompleted(Completed11Delegate, this);
+                    }
+                }
+
+                if (!running1 || !running2 || !running3 || !running4 || !running5 || !running6 || !running7 || !running8 || !running9 || !running10 || !running11)
+                {
+                    goto AGAIN;
+                }
+                syncRunning = false;
+
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            static void Completed1(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running1 = false;
+
+                try
+                {
+                    if (self.awaiter1.GetResult())
+                    {
+                        self.hasCurrent1 = true;
+                        self.current1 = self.enumerator1.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running1 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running1 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running1 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter1 = self.enumerator1.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter1.SourceOnCompleted(Completed1Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed2(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running2 = false;
+
+                try
+                {
+                    if (self.awaiter2.GetResult())
+                    {
+                        self.hasCurrent2 = true;
+                        self.current2 = self.enumerator2.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running2 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running2 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running2 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter2 = self.enumerator2.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter2.SourceOnCompleted(Completed2Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed3(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running3 = false;
+
+                try
+                {
+                    if (self.awaiter3.GetResult())
+                    {
+                        self.hasCurrent3 = true;
+                        self.current3 = self.enumerator3.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running3 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running3 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running3 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter3 = self.enumerator3.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter3.SourceOnCompleted(Completed3Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed4(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running4 = false;
+
+                try
+                {
+                    if (self.awaiter4.GetResult())
+                    {
+                        self.hasCurrent4 = true;
+                        self.current4 = self.enumerator4.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running4 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running4 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running4 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter4 = self.enumerator4.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter4.SourceOnCompleted(Completed4Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed5(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running5 = false;
+
+                try
+                {
+                    if (self.awaiter5.GetResult())
+                    {
+                        self.hasCurrent5 = true;
+                        self.current5 = self.enumerator5.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running5 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running5 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running5 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter5 = self.enumerator5.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter5.SourceOnCompleted(Completed5Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed6(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running6 = false;
+
+                try
+                {
+                    if (self.awaiter6.GetResult())
+                    {
+                        self.hasCurrent6 = true;
+                        self.current6 = self.enumerator6.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running6 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running6 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running6 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter6 = self.enumerator6.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter6.SourceOnCompleted(Completed6Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed7(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running7 = false;
+
+                try
+                {
+                    if (self.awaiter7.GetResult())
+                    {
+                        self.hasCurrent7 = true;
+                        self.current7 = self.enumerator7.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running7 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running7 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running7 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter7 = self.enumerator7.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter7.SourceOnCompleted(Completed7Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed8(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running8 = false;
+
+                try
+                {
+                    if (self.awaiter8.GetResult())
+                    {
+                        self.hasCurrent8 = true;
+                        self.current8 = self.enumerator8.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running8 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running8 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running8 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter8 = self.enumerator8.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter8.SourceOnCompleted(Completed8Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed9(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running9 = false;
+
+                try
+                {
+                    if (self.awaiter9.GetResult())
+                    {
+                        self.hasCurrent9 = true;
+                        self.current9 = self.enumerator9.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running9 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running9 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running9 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter9 = self.enumerator9.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter9.SourceOnCompleted(Completed9Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed10(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running10 = false;
+
+                try
+                {
+                    if (self.awaiter10.GetResult())
+                    {
+                        self.hasCurrent10 = true;
+                        self.current10 = self.enumerator10.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running10 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running10 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running10 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter10 = self.enumerator10.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter10.SourceOnCompleted(Completed10Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed11(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running11 = false;
+
+                try
+                {
+                    if (self.awaiter11.GetResult())
+                    {
+                        self.hasCurrent11 = true;
+                        self.current11 = self.enumerator11.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running11 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running11 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running11 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter11 = self.enumerator11.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter11.SourceOnCompleted(Completed11Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            bool TrySetResult()
+            {
+                if (hasCurrent1 && hasCurrent2 && hasCurrent3 && hasCurrent4 && hasCurrent5 && hasCurrent6 && hasCurrent7 && hasCurrent8 && hasCurrent9 && hasCurrent10 && hasCurrent11)
+                {
+                    result = resultSelector(current1, current2, current3, current4, current5, current6, current7, current8, current9, current10, current11);
+                    completionSource.TrySetResult(true);
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
+            public async UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                if (enumerator1 != null)
+                {
+                    await enumerator1.DisposeAsync();
+                }
+                if (enumerator2 != null)
+                {
+                    await enumerator2.DisposeAsync();
+                }
+                if (enumerator3 != null)
+                {
+                    await enumerator3.DisposeAsync();
+                }
+                if (enumerator4 != null)
+                {
+                    await enumerator4.DisposeAsync();
+                }
+                if (enumerator5 != null)
+                {
+                    await enumerator5.DisposeAsync();
+                }
+                if (enumerator6 != null)
+                {
+                    await enumerator6.DisposeAsync();
+                }
+                if (enumerator7 != null)
+                {
+                    await enumerator7.DisposeAsync();
+                }
+                if (enumerator8 != null)
+                {
+                    await enumerator8.DisposeAsync();
+                }
+                if (enumerator9 != null)
+                {
+                    await enumerator9.DisposeAsync();
+                }
+                if (enumerator10 != null)
+                {
+                    await enumerator10.DisposeAsync();
+                }
+                if (enumerator11 != null)
+                {
+                    await enumerator11.DisposeAsync();
+                }
+            }
+        }
+    }
+
+    internal class CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> : IUniTaskAsyncEnumerable<TResult>
+    {
+        readonly IUniTaskAsyncEnumerable<T1> source1;
+        readonly IUniTaskAsyncEnumerable<T2> source2;
+        readonly IUniTaskAsyncEnumerable<T3> source3;
+        readonly IUniTaskAsyncEnumerable<T4> source4;
+        readonly IUniTaskAsyncEnumerable<T5> source5;
+        readonly IUniTaskAsyncEnumerable<T6> source6;
+        readonly IUniTaskAsyncEnumerable<T7> source7;
+        readonly IUniTaskAsyncEnumerable<T8> source8;
+        readonly IUniTaskAsyncEnumerable<T9> source9;
+        readonly IUniTaskAsyncEnumerable<T10> source10;
+        readonly IUniTaskAsyncEnumerable<T11> source11;
+        readonly IUniTaskAsyncEnumerable<T12> source12;
+        
+        readonly Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> resultSelector;
+
+        public CombineLatest(IUniTaskAsyncEnumerable<T1> source1, IUniTaskAsyncEnumerable<T2> source2, IUniTaskAsyncEnumerable<T3> source3, IUniTaskAsyncEnumerable<T4> source4, IUniTaskAsyncEnumerable<T5> source5, IUniTaskAsyncEnumerable<T6> source6, IUniTaskAsyncEnumerable<T7> source7, IUniTaskAsyncEnumerable<T8> source8, IUniTaskAsyncEnumerable<T9> source9, IUniTaskAsyncEnumerable<T10> source10, IUniTaskAsyncEnumerable<T11> source11, IUniTaskAsyncEnumerable<T12> source12, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> resultSelector)
+        {
+            this.source1 = source1;
+            this.source2 = source2;
+            this.source3 = source3;
+            this.source4 = source4;
+            this.source5 = source5;
+            this.source6 = source6;
+            this.source7 = source7;
+            this.source8 = source8;
+            this.source9 = source9;
+            this.source10 = source10;
+            this.source11 = source11;
+            this.source12 = source12;
+        
+            this.resultSelector = resultSelector;
+        }
+
+        public IUniTaskAsyncEnumerator<TResult> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _CombineLatest(source1, source2, source3, source4, source5, source6, source7, source8, source9, source10, source11, source12, resultSelector, cancellationToken);
+        }
+
+        class _CombineLatest : MoveNextSource, IUniTaskAsyncEnumerator<TResult>
+        {
+            static readonly Action<object> Completed1Delegate = Completed1;
+            static readonly Action<object> Completed2Delegate = Completed2;
+            static readonly Action<object> Completed3Delegate = Completed3;
+            static readonly Action<object> Completed4Delegate = Completed4;
+            static readonly Action<object> Completed5Delegate = Completed5;
+            static readonly Action<object> Completed6Delegate = Completed6;
+            static readonly Action<object> Completed7Delegate = Completed7;
+            static readonly Action<object> Completed8Delegate = Completed8;
+            static readonly Action<object> Completed9Delegate = Completed9;
+            static readonly Action<object> Completed10Delegate = Completed10;
+            static readonly Action<object> Completed11Delegate = Completed11;
+            static readonly Action<object> Completed12Delegate = Completed12;
+            const int CompleteCount = 12;
+
+            readonly IUniTaskAsyncEnumerable<T1> source1;
+            readonly IUniTaskAsyncEnumerable<T2> source2;
+            readonly IUniTaskAsyncEnumerable<T3> source3;
+            readonly IUniTaskAsyncEnumerable<T4> source4;
+            readonly IUniTaskAsyncEnumerable<T5> source5;
+            readonly IUniTaskAsyncEnumerable<T6> source6;
+            readonly IUniTaskAsyncEnumerable<T7> source7;
+            readonly IUniTaskAsyncEnumerable<T8> source8;
+            readonly IUniTaskAsyncEnumerable<T9> source9;
+            readonly IUniTaskAsyncEnumerable<T10> source10;
+            readonly IUniTaskAsyncEnumerable<T11> source11;
+            readonly IUniTaskAsyncEnumerable<T12> source12;
+       
+            readonly Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> resultSelector;
+            CancellationToken cancellationToken;
+
+            IUniTaskAsyncEnumerator<T1> enumerator1;
+            UniTask<bool>.Awaiter awaiter1;
+            bool hasCurrent1;
+            bool running1;
+            T1 current1;
+
+            IUniTaskAsyncEnumerator<T2> enumerator2;
+            UniTask<bool>.Awaiter awaiter2;
+            bool hasCurrent2;
+            bool running2;
+            T2 current2;
+
+            IUniTaskAsyncEnumerator<T3> enumerator3;
+            UniTask<bool>.Awaiter awaiter3;
+            bool hasCurrent3;
+            bool running3;
+            T3 current3;
+
+            IUniTaskAsyncEnumerator<T4> enumerator4;
+            UniTask<bool>.Awaiter awaiter4;
+            bool hasCurrent4;
+            bool running4;
+            T4 current4;
+
+            IUniTaskAsyncEnumerator<T5> enumerator5;
+            UniTask<bool>.Awaiter awaiter5;
+            bool hasCurrent5;
+            bool running5;
+            T5 current5;
+
+            IUniTaskAsyncEnumerator<T6> enumerator6;
+            UniTask<bool>.Awaiter awaiter6;
+            bool hasCurrent6;
+            bool running6;
+            T6 current6;
+
+            IUniTaskAsyncEnumerator<T7> enumerator7;
+            UniTask<bool>.Awaiter awaiter7;
+            bool hasCurrent7;
+            bool running7;
+            T7 current7;
+
+            IUniTaskAsyncEnumerator<T8> enumerator8;
+            UniTask<bool>.Awaiter awaiter8;
+            bool hasCurrent8;
+            bool running8;
+            T8 current8;
+
+            IUniTaskAsyncEnumerator<T9> enumerator9;
+            UniTask<bool>.Awaiter awaiter9;
+            bool hasCurrent9;
+            bool running9;
+            T9 current9;
+
+            IUniTaskAsyncEnumerator<T10> enumerator10;
+            UniTask<bool>.Awaiter awaiter10;
+            bool hasCurrent10;
+            bool running10;
+            T10 current10;
+
+            IUniTaskAsyncEnumerator<T11> enumerator11;
+            UniTask<bool>.Awaiter awaiter11;
+            bool hasCurrent11;
+            bool running11;
+            T11 current11;
+
+            IUniTaskAsyncEnumerator<T12> enumerator12;
+            UniTask<bool>.Awaiter awaiter12;
+            bool hasCurrent12;
+            bool running12;
+            T12 current12;
+
+            int completedCount;
+            bool syncRunning;
+            TResult result;
+
+            public _CombineLatest(IUniTaskAsyncEnumerable<T1> source1, IUniTaskAsyncEnumerable<T2> source2, IUniTaskAsyncEnumerable<T3> source3, IUniTaskAsyncEnumerable<T4> source4, IUniTaskAsyncEnumerable<T5> source5, IUniTaskAsyncEnumerable<T6> source6, IUniTaskAsyncEnumerable<T7> source7, IUniTaskAsyncEnumerable<T8> source8, IUniTaskAsyncEnumerable<T9> source9, IUniTaskAsyncEnumerable<T10> source10, IUniTaskAsyncEnumerable<T11> source11, IUniTaskAsyncEnumerable<T12> source12, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> resultSelector, CancellationToken cancellationToken)
+            {
+                this.source1 = source1;
+                this.source2 = source2;
+                this.source3 = source3;
+                this.source4 = source4;
+                this.source5 = source5;
+                this.source6 = source6;
+                this.source7 = source7;
+                this.source8 = source8;
+                this.source9 = source9;
+                this.source10 = source10;
+                this.source11 = source11;
+                this.source12 = source12;
+                
+                this.resultSelector = resultSelector;
+                this.cancellationToken = cancellationToken;
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public TResult Current => result;
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (completedCount == CompleteCount) return CompletedTasks.False;
+
+                if (enumerator1 == null)
+                {
+                    enumerator1 = source1.GetAsyncEnumerator(cancellationToken);
+                    enumerator2 = source2.GetAsyncEnumerator(cancellationToken);
+                    enumerator3 = source3.GetAsyncEnumerator(cancellationToken);
+                    enumerator4 = source4.GetAsyncEnumerator(cancellationToken);
+                    enumerator5 = source5.GetAsyncEnumerator(cancellationToken);
+                    enumerator6 = source6.GetAsyncEnumerator(cancellationToken);
+                    enumerator7 = source7.GetAsyncEnumerator(cancellationToken);
+                    enumerator8 = source8.GetAsyncEnumerator(cancellationToken);
+                    enumerator9 = source9.GetAsyncEnumerator(cancellationToken);
+                    enumerator10 = source10.GetAsyncEnumerator(cancellationToken);
+                    enumerator11 = source11.GetAsyncEnumerator(cancellationToken);
+                    enumerator12 = source12.GetAsyncEnumerator(cancellationToken);
+                }
+
+                completionSource.Reset();
+
+                AGAIN:
+                syncRunning = true;
+                if (!running1)
+                {
+                    running1 = true;
+                    awaiter1 = enumerator1.MoveNextAsync().GetAwaiter();
+                    if (awaiter1.IsCompleted)
+                    {
+                        Completed1(this);
+                    }
+                    else
+                    {
+                        awaiter1.SourceOnCompleted(Completed1Delegate, this);
+                    }
+                }
+                if (!running2)
+                {
+                    running2 = true;
+                    awaiter2 = enumerator2.MoveNextAsync().GetAwaiter();
+                    if (awaiter2.IsCompleted)
+                    {
+                        Completed2(this);
+                    }
+                    else
+                    {
+                        awaiter2.SourceOnCompleted(Completed2Delegate, this);
+                    }
+                }
+                if (!running3)
+                {
+                    running3 = true;
+                    awaiter3 = enumerator3.MoveNextAsync().GetAwaiter();
+                    if (awaiter3.IsCompleted)
+                    {
+                        Completed3(this);
+                    }
+                    else
+                    {
+                        awaiter3.SourceOnCompleted(Completed3Delegate, this);
+                    }
+                }
+                if (!running4)
+                {
+                    running4 = true;
+                    awaiter4 = enumerator4.MoveNextAsync().GetAwaiter();
+                    if (awaiter4.IsCompleted)
+                    {
+                        Completed4(this);
+                    }
+                    else
+                    {
+                        awaiter4.SourceOnCompleted(Completed4Delegate, this);
+                    }
+                }
+                if (!running5)
+                {
+                    running5 = true;
+                    awaiter5 = enumerator5.MoveNextAsync().GetAwaiter();
+                    if (awaiter5.IsCompleted)
+                    {
+                        Completed5(this);
+                    }
+                    else
+                    {
+                        awaiter5.SourceOnCompleted(Completed5Delegate, this);
+                    }
+                }
+                if (!running6)
+                {
+                    running6 = true;
+                    awaiter6 = enumerator6.MoveNextAsync().GetAwaiter();
+                    if (awaiter6.IsCompleted)
+                    {
+                        Completed6(this);
+                    }
+                    else
+                    {
+                        awaiter6.SourceOnCompleted(Completed6Delegate, this);
+                    }
+                }
+                if (!running7)
+                {
+                    running7 = true;
+                    awaiter7 = enumerator7.MoveNextAsync().GetAwaiter();
+                    if (awaiter7.IsCompleted)
+                    {
+                        Completed7(this);
+                    }
+                    else
+                    {
+                        awaiter7.SourceOnCompleted(Completed7Delegate, this);
+                    }
+                }
+                if (!running8)
+                {
+                    running8 = true;
+                    awaiter8 = enumerator8.MoveNextAsync().GetAwaiter();
+                    if (awaiter8.IsCompleted)
+                    {
+                        Completed8(this);
+                    }
+                    else
+                    {
+                        awaiter8.SourceOnCompleted(Completed8Delegate, this);
+                    }
+                }
+                if (!running9)
+                {
+                    running9 = true;
+                    awaiter9 = enumerator9.MoveNextAsync().GetAwaiter();
+                    if (awaiter9.IsCompleted)
+                    {
+                        Completed9(this);
+                    }
+                    else
+                    {
+                        awaiter9.SourceOnCompleted(Completed9Delegate, this);
+                    }
+                }
+                if (!running10)
+                {
+                    running10 = true;
+                    awaiter10 = enumerator10.MoveNextAsync().GetAwaiter();
+                    if (awaiter10.IsCompleted)
+                    {
+                        Completed10(this);
+                    }
+                    else
+                    {
+                        awaiter10.SourceOnCompleted(Completed10Delegate, this);
+                    }
+                }
+                if (!running11)
+                {
+                    running11 = true;
+                    awaiter11 = enumerator11.MoveNextAsync().GetAwaiter();
+                    if (awaiter11.IsCompleted)
+                    {
+                        Completed11(this);
+                    }
+                    else
+                    {
+                        awaiter11.SourceOnCompleted(Completed11Delegate, this);
+                    }
+                }
+                if (!running12)
+                {
+                    running12 = true;
+                    awaiter12 = enumerator12.MoveNextAsync().GetAwaiter();
+                    if (awaiter12.IsCompleted)
+                    {
+                        Completed12(this);
+                    }
+                    else
+                    {
+                        awaiter12.SourceOnCompleted(Completed12Delegate, this);
+                    }
+                }
+
+                if (!running1 || !running2 || !running3 || !running4 || !running5 || !running6 || !running7 || !running8 || !running9 || !running10 || !running11 || !running12)
+                {
+                    goto AGAIN;
+                }
+                syncRunning = false;
+
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            static void Completed1(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running1 = false;
+
+                try
+                {
+                    if (self.awaiter1.GetResult())
+                    {
+                        self.hasCurrent1 = true;
+                        self.current1 = self.enumerator1.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running1 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running1 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running1 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter1 = self.enumerator1.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter1.SourceOnCompleted(Completed1Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed2(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running2 = false;
+
+                try
+                {
+                    if (self.awaiter2.GetResult())
+                    {
+                        self.hasCurrent2 = true;
+                        self.current2 = self.enumerator2.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running2 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running2 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running2 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter2 = self.enumerator2.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter2.SourceOnCompleted(Completed2Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed3(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running3 = false;
+
+                try
+                {
+                    if (self.awaiter3.GetResult())
+                    {
+                        self.hasCurrent3 = true;
+                        self.current3 = self.enumerator3.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running3 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running3 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running3 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter3 = self.enumerator3.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter3.SourceOnCompleted(Completed3Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed4(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running4 = false;
+
+                try
+                {
+                    if (self.awaiter4.GetResult())
+                    {
+                        self.hasCurrent4 = true;
+                        self.current4 = self.enumerator4.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running4 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running4 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running4 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter4 = self.enumerator4.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter4.SourceOnCompleted(Completed4Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed5(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running5 = false;
+
+                try
+                {
+                    if (self.awaiter5.GetResult())
+                    {
+                        self.hasCurrent5 = true;
+                        self.current5 = self.enumerator5.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running5 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running5 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running5 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter5 = self.enumerator5.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter5.SourceOnCompleted(Completed5Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed6(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running6 = false;
+
+                try
+                {
+                    if (self.awaiter6.GetResult())
+                    {
+                        self.hasCurrent6 = true;
+                        self.current6 = self.enumerator6.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running6 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running6 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running6 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter6 = self.enumerator6.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter6.SourceOnCompleted(Completed6Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed7(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running7 = false;
+
+                try
+                {
+                    if (self.awaiter7.GetResult())
+                    {
+                        self.hasCurrent7 = true;
+                        self.current7 = self.enumerator7.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running7 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running7 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running7 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter7 = self.enumerator7.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter7.SourceOnCompleted(Completed7Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed8(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running8 = false;
+
+                try
+                {
+                    if (self.awaiter8.GetResult())
+                    {
+                        self.hasCurrent8 = true;
+                        self.current8 = self.enumerator8.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running8 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running8 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running8 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter8 = self.enumerator8.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter8.SourceOnCompleted(Completed8Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed9(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running9 = false;
+
+                try
+                {
+                    if (self.awaiter9.GetResult())
+                    {
+                        self.hasCurrent9 = true;
+                        self.current9 = self.enumerator9.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running9 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running9 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running9 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter9 = self.enumerator9.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter9.SourceOnCompleted(Completed9Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed10(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running10 = false;
+
+                try
+                {
+                    if (self.awaiter10.GetResult())
+                    {
+                        self.hasCurrent10 = true;
+                        self.current10 = self.enumerator10.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running10 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running10 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running10 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter10 = self.enumerator10.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter10.SourceOnCompleted(Completed10Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed11(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running11 = false;
+
+                try
+                {
+                    if (self.awaiter11.GetResult())
+                    {
+                        self.hasCurrent11 = true;
+                        self.current11 = self.enumerator11.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running11 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running11 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running11 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter11 = self.enumerator11.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter11.SourceOnCompleted(Completed11Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed12(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running12 = false;
+
+                try
+                {
+                    if (self.awaiter12.GetResult())
+                    {
+                        self.hasCurrent12 = true;
+                        self.current12 = self.enumerator12.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running12 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running12 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running12 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter12 = self.enumerator12.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter12.SourceOnCompleted(Completed12Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            bool TrySetResult()
+            {
+                if (hasCurrent1 && hasCurrent2 && hasCurrent3 && hasCurrent4 && hasCurrent5 && hasCurrent6 && hasCurrent7 && hasCurrent8 && hasCurrent9 && hasCurrent10 && hasCurrent11 && hasCurrent12)
+                {
+                    result = resultSelector(current1, current2, current3, current4, current5, current6, current7, current8, current9, current10, current11, current12);
+                    completionSource.TrySetResult(true);
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
+            public async UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                if (enumerator1 != null)
+                {
+                    await enumerator1.DisposeAsync();
+                }
+                if (enumerator2 != null)
+                {
+                    await enumerator2.DisposeAsync();
+                }
+                if (enumerator3 != null)
+                {
+                    await enumerator3.DisposeAsync();
+                }
+                if (enumerator4 != null)
+                {
+                    await enumerator4.DisposeAsync();
+                }
+                if (enumerator5 != null)
+                {
+                    await enumerator5.DisposeAsync();
+                }
+                if (enumerator6 != null)
+                {
+                    await enumerator6.DisposeAsync();
+                }
+                if (enumerator7 != null)
+                {
+                    await enumerator7.DisposeAsync();
+                }
+                if (enumerator8 != null)
+                {
+                    await enumerator8.DisposeAsync();
+                }
+                if (enumerator9 != null)
+                {
+                    await enumerator9.DisposeAsync();
+                }
+                if (enumerator10 != null)
+                {
+                    await enumerator10.DisposeAsync();
+                }
+                if (enumerator11 != null)
+                {
+                    await enumerator11.DisposeAsync();
+                }
+                if (enumerator12 != null)
+                {
+                    await enumerator12.DisposeAsync();
+                }
+            }
+        }
+    }
+
+    internal class CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> : IUniTaskAsyncEnumerable<TResult>
+    {
+        readonly IUniTaskAsyncEnumerable<T1> source1;
+        readonly IUniTaskAsyncEnumerable<T2> source2;
+        readonly IUniTaskAsyncEnumerable<T3> source3;
+        readonly IUniTaskAsyncEnumerable<T4> source4;
+        readonly IUniTaskAsyncEnumerable<T5> source5;
+        readonly IUniTaskAsyncEnumerable<T6> source6;
+        readonly IUniTaskAsyncEnumerable<T7> source7;
+        readonly IUniTaskAsyncEnumerable<T8> source8;
+        readonly IUniTaskAsyncEnumerable<T9> source9;
+        readonly IUniTaskAsyncEnumerable<T10> source10;
+        readonly IUniTaskAsyncEnumerable<T11> source11;
+        readonly IUniTaskAsyncEnumerable<T12> source12;
+        readonly IUniTaskAsyncEnumerable<T13> source13;
+        
+        readonly Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> resultSelector;
+
+        public CombineLatest(IUniTaskAsyncEnumerable<T1> source1, IUniTaskAsyncEnumerable<T2> source2, IUniTaskAsyncEnumerable<T3> source3, IUniTaskAsyncEnumerable<T4> source4, IUniTaskAsyncEnumerable<T5> source5, IUniTaskAsyncEnumerable<T6> source6, IUniTaskAsyncEnumerable<T7> source7, IUniTaskAsyncEnumerable<T8> source8, IUniTaskAsyncEnumerable<T9> source9, IUniTaskAsyncEnumerable<T10> source10, IUniTaskAsyncEnumerable<T11> source11, IUniTaskAsyncEnumerable<T12> source12, IUniTaskAsyncEnumerable<T13> source13, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> resultSelector)
+        {
+            this.source1 = source1;
+            this.source2 = source2;
+            this.source3 = source3;
+            this.source4 = source4;
+            this.source5 = source5;
+            this.source6 = source6;
+            this.source7 = source7;
+            this.source8 = source8;
+            this.source9 = source9;
+            this.source10 = source10;
+            this.source11 = source11;
+            this.source12 = source12;
+            this.source13 = source13;
+        
+            this.resultSelector = resultSelector;
+        }
+
+        public IUniTaskAsyncEnumerator<TResult> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _CombineLatest(source1, source2, source3, source4, source5, source6, source7, source8, source9, source10, source11, source12, source13, resultSelector, cancellationToken);
+        }
+
+        class _CombineLatest : MoveNextSource, IUniTaskAsyncEnumerator<TResult>
+        {
+            static readonly Action<object> Completed1Delegate = Completed1;
+            static readonly Action<object> Completed2Delegate = Completed2;
+            static readonly Action<object> Completed3Delegate = Completed3;
+            static readonly Action<object> Completed4Delegate = Completed4;
+            static readonly Action<object> Completed5Delegate = Completed5;
+            static readonly Action<object> Completed6Delegate = Completed6;
+            static readonly Action<object> Completed7Delegate = Completed7;
+            static readonly Action<object> Completed8Delegate = Completed8;
+            static readonly Action<object> Completed9Delegate = Completed9;
+            static readonly Action<object> Completed10Delegate = Completed10;
+            static readonly Action<object> Completed11Delegate = Completed11;
+            static readonly Action<object> Completed12Delegate = Completed12;
+            static readonly Action<object> Completed13Delegate = Completed13;
+            const int CompleteCount = 13;
+
+            readonly IUniTaskAsyncEnumerable<T1> source1;
+            readonly IUniTaskAsyncEnumerable<T2> source2;
+            readonly IUniTaskAsyncEnumerable<T3> source3;
+            readonly IUniTaskAsyncEnumerable<T4> source4;
+            readonly IUniTaskAsyncEnumerable<T5> source5;
+            readonly IUniTaskAsyncEnumerable<T6> source6;
+            readonly IUniTaskAsyncEnumerable<T7> source7;
+            readonly IUniTaskAsyncEnumerable<T8> source8;
+            readonly IUniTaskAsyncEnumerable<T9> source9;
+            readonly IUniTaskAsyncEnumerable<T10> source10;
+            readonly IUniTaskAsyncEnumerable<T11> source11;
+            readonly IUniTaskAsyncEnumerable<T12> source12;
+            readonly IUniTaskAsyncEnumerable<T13> source13;
+       
+            readonly Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> resultSelector;
+            CancellationToken cancellationToken;
+
+            IUniTaskAsyncEnumerator<T1> enumerator1;
+            UniTask<bool>.Awaiter awaiter1;
+            bool hasCurrent1;
+            bool running1;
+            T1 current1;
+
+            IUniTaskAsyncEnumerator<T2> enumerator2;
+            UniTask<bool>.Awaiter awaiter2;
+            bool hasCurrent2;
+            bool running2;
+            T2 current2;
+
+            IUniTaskAsyncEnumerator<T3> enumerator3;
+            UniTask<bool>.Awaiter awaiter3;
+            bool hasCurrent3;
+            bool running3;
+            T3 current3;
+
+            IUniTaskAsyncEnumerator<T4> enumerator4;
+            UniTask<bool>.Awaiter awaiter4;
+            bool hasCurrent4;
+            bool running4;
+            T4 current4;
+
+            IUniTaskAsyncEnumerator<T5> enumerator5;
+            UniTask<bool>.Awaiter awaiter5;
+            bool hasCurrent5;
+            bool running5;
+            T5 current5;
+
+            IUniTaskAsyncEnumerator<T6> enumerator6;
+            UniTask<bool>.Awaiter awaiter6;
+            bool hasCurrent6;
+            bool running6;
+            T6 current6;
+
+            IUniTaskAsyncEnumerator<T7> enumerator7;
+            UniTask<bool>.Awaiter awaiter7;
+            bool hasCurrent7;
+            bool running7;
+            T7 current7;
+
+            IUniTaskAsyncEnumerator<T8> enumerator8;
+            UniTask<bool>.Awaiter awaiter8;
+            bool hasCurrent8;
+            bool running8;
+            T8 current8;
+
+            IUniTaskAsyncEnumerator<T9> enumerator9;
+            UniTask<bool>.Awaiter awaiter9;
+            bool hasCurrent9;
+            bool running9;
+            T9 current9;
+
+            IUniTaskAsyncEnumerator<T10> enumerator10;
+            UniTask<bool>.Awaiter awaiter10;
+            bool hasCurrent10;
+            bool running10;
+            T10 current10;
+
+            IUniTaskAsyncEnumerator<T11> enumerator11;
+            UniTask<bool>.Awaiter awaiter11;
+            bool hasCurrent11;
+            bool running11;
+            T11 current11;
+
+            IUniTaskAsyncEnumerator<T12> enumerator12;
+            UniTask<bool>.Awaiter awaiter12;
+            bool hasCurrent12;
+            bool running12;
+            T12 current12;
+
+            IUniTaskAsyncEnumerator<T13> enumerator13;
+            UniTask<bool>.Awaiter awaiter13;
+            bool hasCurrent13;
+            bool running13;
+            T13 current13;
+
+            int completedCount;
+            bool syncRunning;
+            TResult result;
+
+            public _CombineLatest(IUniTaskAsyncEnumerable<T1> source1, IUniTaskAsyncEnumerable<T2> source2, IUniTaskAsyncEnumerable<T3> source3, IUniTaskAsyncEnumerable<T4> source4, IUniTaskAsyncEnumerable<T5> source5, IUniTaskAsyncEnumerable<T6> source6, IUniTaskAsyncEnumerable<T7> source7, IUniTaskAsyncEnumerable<T8> source8, IUniTaskAsyncEnumerable<T9> source9, IUniTaskAsyncEnumerable<T10> source10, IUniTaskAsyncEnumerable<T11> source11, IUniTaskAsyncEnumerable<T12> source12, IUniTaskAsyncEnumerable<T13> source13, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> resultSelector, CancellationToken cancellationToken)
+            {
+                this.source1 = source1;
+                this.source2 = source2;
+                this.source3 = source3;
+                this.source4 = source4;
+                this.source5 = source5;
+                this.source6 = source6;
+                this.source7 = source7;
+                this.source8 = source8;
+                this.source9 = source9;
+                this.source10 = source10;
+                this.source11 = source11;
+                this.source12 = source12;
+                this.source13 = source13;
+                
+                this.resultSelector = resultSelector;
+                this.cancellationToken = cancellationToken;
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public TResult Current => result;
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (completedCount == CompleteCount) return CompletedTasks.False;
+
+                if (enumerator1 == null)
+                {
+                    enumerator1 = source1.GetAsyncEnumerator(cancellationToken);
+                    enumerator2 = source2.GetAsyncEnumerator(cancellationToken);
+                    enumerator3 = source3.GetAsyncEnumerator(cancellationToken);
+                    enumerator4 = source4.GetAsyncEnumerator(cancellationToken);
+                    enumerator5 = source5.GetAsyncEnumerator(cancellationToken);
+                    enumerator6 = source6.GetAsyncEnumerator(cancellationToken);
+                    enumerator7 = source7.GetAsyncEnumerator(cancellationToken);
+                    enumerator8 = source8.GetAsyncEnumerator(cancellationToken);
+                    enumerator9 = source9.GetAsyncEnumerator(cancellationToken);
+                    enumerator10 = source10.GetAsyncEnumerator(cancellationToken);
+                    enumerator11 = source11.GetAsyncEnumerator(cancellationToken);
+                    enumerator12 = source12.GetAsyncEnumerator(cancellationToken);
+                    enumerator13 = source13.GetAsyncEnumerator(cancellationToken);
+                }
+
+                completionSource.Reset();
+
+                AGAIN:
+                syncRunning = true;
+                if (!running1)
+                {
+                    running1 = true;
+                    awaiter1 = enumerator1.MoveNextAsync().GetAwaiter();
+                    if (awaiter1.IsCompleted)
+                    {
+                        Completed1(this);
+                    }
+                    else
+                    {
+                        awaiter1.SourceOnCompleted(Completed1Delegate, this);
+                    }
+                }
+                if (!running2)
+                {
+                    running2 = true;
+                    awaiter2 = enumerator2.MoveNextAsync().GetAwaiter();
+                    if (awaiter2.IsCompleted)
+                    {
+                        Completed2(this);
+                    }
+                    else
+                    {
+                        awaiter2.SourceOnCompleted(Completed2Delegate, this);
+                    }
+                }
+                if (!running3)
+                {
+                    running3 = true;
+                    awaiter3 = enumerator3.MoveNextAsync().GetAwaiter();
+                    if (awaiter3.IsCompleted)
+                    {
+                        Completed3(this);
+                    }
+                    else
+                    {
+                        awaiter3.SourceOnCompleted(Completed3Delegate, this);
+                    }
+                }
+                if (!running4)
+                {
+                    running4 = true;
+                    awaiter4 = enumerator4.MoveNextAsync().GetAwaiter();
+                    if (awaiter4.IsCompleted)
+                    {
+                        Completed4(this);
+                    }
+                    else
+                    {
+                        awaiter4.SourceOnCompleted(Completed4Delegate, this);
+                    }
+                }
+                if (!running5)
+                {
+                    running5 = true;
+                    awaiter5 = enumerator5.MoveNextAsync().GetAwaiter();
+                    if (awaiter5.IsCompleted)
+                    {
+                        Completed5(this);
+                    }
+                    else
+                    {
+                        awaiter5.SourceOnCompleted(Completed5Delegate, this);
+                    }
+                }
+                if (!running6)
+                {
+                    running6 = true;
+                    awaiter6 = enumerator6.MoveNextAsync().GetAwaiter();
+                    if (awaiter6.IsCompleted)
+                    {
+                        Completed6(this);
+                    }
+                    else
+                    {
+                        awaiter6.SourceOnCompleted(Completed6Delegate, this);
+                    }
+                }
+                if (!running7)
+                {
+                    running7 = true;
+                    awaiter7 = enumerator7.MoveNextAsync().GetAwaiter();
+                    if (awaiter7.IsCompleted)
+                    {
+                        Completed7(this);
+                    }
+                    else
+                    {
+                        awaiter7.SourceOnCompleted(Completed7Delegate, this);
+                    }
+                }
+                if (!running8)
+                {
+                    running8 = true;
+                    awaiter8 = enumerator8.MoveNextAsync().GetAwaiter();
+                    if (awaiter8.IsCompleted)
+                    {
+                        Completed8(this);
+                    }
+                    else
+                    {
+                        awaiter8.SourceOnCompleted(Completed8Delegate, this);
+                    }
+                }
+                if (!running9)
+                {
+                    running9 = true;
+                    awaiter9 = enumerator9.MoveNextAsync().GetAwaiter();
+                    if (awaiter9.IsCompleted)
+                    {
+                        Completed9(this);
+                    }
+                    else
+                    {
+                        awaiter9.SourceOnCompleted(Completed9Delegate, this);
+                    }
+                }
+                if (!running10)
+                {
+                    running10 = true;
+                    awaiter10 = enumerator10.MoveNextAsync().GetAwaiter();
+                    if (awaiter10.IsCompleted)
+                    {
+                        Completed10(this);
+                    }
+                    else
+                    {
+                        awaiter10.SourceOnCompleted(Completed10Delegate, this);
+                    }
+                }
+                if (!running11)
+                {
+                    running11 = true;
+                    awaiter11 = enumerator11.MoveNextAsync().GetAwaiter();
+                    if (awaiter11.IsCompleted)
+                    {
+                        Completed11(this);
+                    }
+                    else
+                    {
+                        awaiter11.SourceOnCompleted(Completed11Delegate, this);
+                    }
+                }
+                if (!running12)
+                {
+                    running12 = true;
+                    awaiter12 = enumerator12.MoveNextAsync().GetAwaiter();
+                    if (awaiter12.IsCompleted)
+                    {
+                        Completed12(this);
+                    }
+                    else
+                    {
+                        awaiter12.SourceOnCompleted(Completed12Delegate, this);
+                    }
+                }
+                if (!running13)
+                {
+                    running13 = true;
+                    awaiter13 = enumerator13.MoveNextAsync().GetAwaiter();
+                    if (awaiter13.IsCompleted)
+                    {
+                        Completed13(this);
+                    }
+                    else
+                    {
+                        awaiter13.SourceOnCompleted(Completed13Delegate, this);
+                    }
+                }
+
+                if (!running1 || !running2 || !running3 || !running4 || !running5 || !running6 || !running7 || !running8 || !running9 || !running10 || !running11 || !running12 || !running13)
+                {
+                    goto AGAIN;
+                }
+                syncRunning = false;
+
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            static void Completed1(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running1 = false;
+
+                try
+                {
+                    if (self.awaiter1.GetResult())
+                    {
+                        self.hasCurrent1 = true;
+                        self.current1 = self.enumerator1.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running1 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running1 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running1 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter1 = self.enumerator1.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter1.SourceOnCompleted(Completed1Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed2(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running2 = false;
+
+                try
+                {
+                    if (self.awaiter2.GetResult())
+                    {
+                        self.hasCurrent2 = true;
+                        self.current2 = self.enumerator2.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running2 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running2 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running2 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter2 = self.enumerator2.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter2.SourceOnCompleted(Completed2Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed3(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running3 = false;
+
+                try
+                {
+                    if (self.awaiter3.GetResult())
+                    {
+                        self.hasCurrent3 = true;
+                        self.current3 = self.enumerator3.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running3 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running3 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running3 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter3 = self.enumerator3.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter3.SourceOnCompleted(Completed3Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed4(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running4 = false;
+
+                try
+                {
+                    if (self.awaiter4.GetResult())
+                    {
+                        self.hasCurrent4 = true;
+                        self.current4 = self.enumerator4.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running4 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running4 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running4 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter4 = self.enumerator4.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter4.SourceOnCompleted(Completed4Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed5(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running5 = false;
+
+                try
+                {
+                    if (self.awaiter5.GetResult())
+                    {
+                        self.hasCurrent5 = true;
+                        self.current5 = self.enumerator5.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running5 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running5 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running5 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter5 = self.enumerator5.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter5.SourceOnCompleted(Completed5Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed6(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running6 = false;
+
+                try
+                {
+                    if (self.awaiter6.GetResult())
+                    {
+                        self.hasCurrent6 = true;
+                        self.current6 = self.enumerator6.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running6 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running6 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running6 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter6 = self.enumerator6.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter6.SourceOnCompleted(Completed6Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed7(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running7 = false;
+
+                try
+                {
+                    if (self.awaiter7.GetResult())
+                    {
+                        self.hasCurrent7 = true;
+                        self.current7 = self.enumerator7.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running7 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running7 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running7 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter7 = self.enumerator7.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter7.SourceOnCompleted(Completed7Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed8(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running8 = false;
+
+                try
+                {
+                    if (self.awaiter8.GetResult())
+                    {
+                        self.hasCurrent8 = true;
+                        self.current8 = self.enumerator8.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running8 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running8 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running8 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter8 = self.enumerator8.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter8.SourceOnCompleted(Completed8Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed9(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running9 = false;
+
+                try
+                {
+                    if (self.awaiter9.GetResult())
+                    {
+                        self.hasCurrent9 = true;
+                        self.current9 = self.enumerator9.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running9 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running9 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running9 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter9 = self.enumerator9.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter9.SourceOnCompleted(Completed9Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed10(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running10 = false;
+
+                try
+                {
+                    if (self.awaiter10.GetResult())
+                    {
+                        self.hasCurrent10 = true;
+                        self.current10 = self.enumerator10.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running10 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running10 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running10 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter10 = self.enumerator10.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter10.SourceOnCompleted(Completed10Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed11(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running11 = false;
+
+                try
+                {
+                    if (self.awaiter11.GetResult())
+                    {
+                        self.hasCurrent11 = true;
+                        self.current11 = self.enumerator11.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running11 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running11 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running11 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter11 = self.enumerator11.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter11.SourceOnCompleted(Completed11Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed12(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running12 = false;
+
+                try
+                {
+                    if (self.awaiter12.GetResult())
+                    {
+                        self.hasCurrent12 = true;
+                        self.current12 = self.enumerator12.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running12 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running12 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running12 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter12 = self.enumerator12.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter12.SourceOnCompleted(Completed12Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed13(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running13 = false;
+
+                try
+                {
+                    if (self.awaiter13.GetResult())
+                    {
+                        self.hasCurrent13 = true;
+                        self.current13 = self.enumerator13.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running13 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running13 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running13 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter13 = self.enumerator13.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter13.SourceOnCompleted(Completed13Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            bool TrySetResult()
+            {
+                if (hasCurrent1 && hasCurrent2 && hasCurrent3 && hasCurrent4 && hasCurrent5 && hasCurrent6 && hasCurrent7 && hasCurrent8 && hasCurrent9 && hasCurrent10 && hasCurrent11 && hasCurrent12 && hasCurrent13)
+                {
+                    result = resultSelector(current1, current2, current3, current4, current5, current6, current7, current8, current9, current10, current11, current12, current13);
+                    completionSource.TrySetResult(true);
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
+            public async UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                if (enumerator1 != null)
+                {
+                    await enumerator1.DisposeAsync();
+                }
+                if (enumerator2 != null)
+                {
+                    await enumerator2.DisposeAsync();
+                }
+                if (enumerator3 != null)
+                {
+                    await enumerator3.DisposeAsync();
+                }
+                if (enumerator4 != null)
+                {
+                    await enumerator4.DisposeAsync();
+                }
+                if (enumerator5 != null)
+                {
+                    await enumerator5.DisposeAsync();
+                }
+                if (enumerator6 != null)
+                {
+                    await enumerator6.DisposeAsync();
+                }
+                if (enumerator7 != null)
+                {
+                    await enumerator7.DisposeAsync();
+                }
+                if (enumerator8 != null)
+                {
+                    await enumerator8.DisposeAsync();
+                }
+                if (enumerator9 != null)
+                {
+                    await enumerator9.DisposeAsync();
+                }
+                if (enumerator10 != null)
+                {
+                    await enumerator10.DisposeAsync();
+                }
+                if (enumerator11 != null)
+                {
+                    await enumerator11.DisposeAsync();
+                }
+                if (enumerator12 != null)
+                {
+                    await enumerator12.DisposeAsync();
+                }
+                if (enumerator13 != null)
+                {
+                    await enumerator13.DisposeAsync();
+                }
+            }
+        }
+    }
+
+    internal class CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> : IUniTaskAsyncEnumerable<TResult>
+    {
+        readonly IUniTaskAsyncEnumerable<T1> source1;
+        readonly IUniTaskAsyncEnumerable<T2> source2;
+        readonly IUniTaskAsyncEnumerable<T3> source3;
+        readonly IUniTaskAsyncEnumerable<T4> source4;
+        readonly IUniTaskAsyncEnumerable<T5> source5;
+        readonly IUniTaskAsyncEnumerable<T6> source6;
+        readonly IUniTaskAsyncEnumerable<T7> source7;
+        readonly IUniTaskAsyncEnumerable<T8> source8;
+        readonly IUniTaskAsyncEnumerable<T9> source9;
+        readonly IUniTaskAsyncEnumerable<T10> source10;
+        readonly IUniTaskAsyncEnumerable<T11> source11;
+        readonly IUniTaskAsyncEnumerable<T12> source12;
+        readonly IUniTaskAsyncEnumerable<T13> source13;
+        readonly IUniTaskAsyncEnumerable<T14> source14;
+        
+        readonly Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> resultSelector;
+
+        public CombineLatest(IUniTaskAsyncEnumerable<T1> source1, IUniTaskAsyncEnumerable<T2> source2, IUniTaskAsyncEnumerable<T3> source3, IUniTaskAsyncEnumerable<T4> source4, IUniTaskAsyncEnumerable<T5> source5, IUniTaskAsyncEnumerable<T6> source6, IUniTaskAsyncEnumerable<T7> source7, IUniTaskAsyncEnumerable<T8> source8, IUniTaskAsyncEnumerable<T9> source9, IUniTaskAsyncEnumerable<T10> source10, IUniTaskAsyncEnumerable<T11> source11, IUniTaskAsyncEnumerable<T12> source12, IUniTaskAsyncEnumerable<T13> source13, IUniTaskAsyncEnumerable<T14> source14, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> resultSelector)
+        {
+            this.source1 = source1;
+            this.source2 = source2;
+            this.source3 = source3;
+            this.source4 = source4;
+            this.source5 = source5;
+            this.source6 = source6;
+            this.source7 = source7;
+            this.source8 = source8;
+            this.source9 = source9;
+            this.source10 = source10;
+            this.source11 = source11;
+            this.source12 = source12;
+            this.source13 = source13;
+            this.source14 = source14;
+        
+            this.resultSelector = resultSelector;
+        }
+
+        public IUniTaskAsyncEnumerator<TResult> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _CombineLatest(source1, source2, source3, source4, source5, source6, source7, source8, source9, source10, source11, source12, source13, source14, resultSelector, cancellationToken);
+        }
+
+        class _CombineLatest : MoveNextSource, IUniTaskAsyncEnumerator<TResult>
+        {
+            static readonly Action<object> Completed1Delegate = Completed1;
+            static readonly Action<object> Completed2Delegate = Completed2;
+            static readonly Action<object> Completed3Delegate = Completed3;
+            static readonly Action<object> Completed4Delegate = Completed4;
+            static readonly Action<object> Completed5Delegate = Completed5;
+            static readonly Action<object> Completed6Delegate = Completed6;
+            static readonly Action<object> Completed7Delegate = Completed7;
+            static readonly Action<object> Completed8Delegate = Completed8;
+            static readonly Action<object> Completed9Delegate = Completed9;
+            static readonly Action<object> Completed10Delegate = Completed10;
+            static readonly Action<object> Completed11Delegate = Completed11;
+            static readonly Action<object> Completed12Delegate = Completed12;
+            static readonly Action<object> Completed13Delegate = Completed13;
+            static readonly Action<object> Completed14Delegate = Completed14;
+            const int CompleteCount = 14;
+
+            readonly IUniTaskAsyncEnumerable<T1> source1;
+            readonly IUniTaskAsyncEnumerable<T2> source2;
+            readonly IUniTaskAsyncEnumerable<T3> source3;
+            readonly IUniTaskAsyncEnumerable<T4> source4;
+            readonly IUniTaskAsyncEnumerable<T5> source5;
+            readonly IUniTaskAsyncEnumerable<T6> source6;
+            readonly IUniTaskAsyncEnumerable<T7> source7;
+            readonly IUniTaskAsyncEnumerable<T8> source8;
+            readonly IUniTaskAsyncEnumerable<T9> source9;
+            readonly IUniTaskAsyncEnumerable<T10> source10;
+            readonly IUniTaskAsyncEnumerable<T11> source11;
+            readonly IUniTaskAsyncEnumerable<T12> source12;
+            readonly IUniTaskAsyncEnumerable<T13> source13;
+            readonly IUniTaskAsyncEnumerable<T14> source14;
+       
+            readonly Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> resultSelector;
+            CancellationToken cancellationToken;
+
+            IUniTaskAsyncEnumerator<T1> enumerator1;
+            UniTask<bool>.Awaiter awaiter1;
+            bool hasCurrent1;
+            bool running1;
+            T1 current1;
+
+            IUniTaskAsyncEnumerator<T2> enumerator2;
+            UniTask<bool>.Awaiter awaiter2;
+            bool hasCurrent2;
+            bool running2;
+            T2 current2;
+
+            IUniTaskAsyncEnumerator<T3> enumerator3;
+            UniTask<bool>.Awaiter awaiter3;
+            bool hasCurrent3;
+            bool running3;
+            T3 current3;
+
+            IUniTaskAsyncEnumerator<T4> enumerator4;
+            UniTask<bool>.Awaiter awaiter4;
+            bool hasCurrent4;
+            bool running4;
+            T4 current4;
+
+            IUniTaskAsyncEnumerator<T5> enumerator5;
+            UniTask<bool>.Awaiter awaiter5;
+            bool hasCurrent5;
+            bool running5;
+            T5 current5;
+
+            IUniTaskAsyncEnumerator<T6> enumerator6;
+            UniTask<bool>.Awaiter awaiter6;
+            bool hasCurrent6;
+            bool running6;
+            T6 current6;
+
+            IUniTaskAsyncEnumerator<T7> enumerator7;
+            UniTask<bool>.Awaiter awaiter7;
+            bool hasCurrent7;
+            bool running7;
+            T7 current7;
+
+            IUniTaskAsyncEnumerator<T8> enumerator8;
+            UniTask<bool>.Awaiter awaiter8;
+            bool hasCurrent8;
+            bool running8;
+            T8 current8;
+
+            IUniTaskAsyncEnumerator<T9> enumerator9;
+            UniTask<bool>.Awaiter awaiter9;
+            bool hasCurrent9;
+            bool running9;
+            T9 current9;
+
+            IUniTaskAsyncEnumerator<T10> enumerator10;
+            UniTask<bool>.Awaiter awaiter10;
+            bool hasCurrent10;
+            bool running10;
+            T10 current10;
+
+            IUniTaskAsyncEnumerator<T11> enumerator11;
+            UniTask<bool>.Awaiter awaiter11;
+            bool hasCurrent11;
+            bool running11;
+            T11 current11;
+
+            IUniTaskAsyncEnumerator<T12> enumerator12;
+            UniTask<bool>.Awaiter awaiter12;
+            bool hasCurrent12;
+            bool running12;
+            T12 current12;
+
+            IUniTaskAsyncEnumerator<T13> enumerator13;
+            UniTask<bool>.Awaiter awaiter13;
+            bool hasCurrent13;
+            bool running13;
+            T13 current13;
+
+            IUniTaskAsyncEnumerator<T14> enumerator14;
+            UniTask<bool>.Awaiter awaiter14;
+            bool hasCurrent14;
+            bool running14;
+            T14 current14;
+
+            int completedCount;
+            bool syncRunning;
+            TResult result;
+
+            public _CombineLatest(IUniTaskAsyncEnumerable<T1> source1, IUniTaskAsyncEnumerable<T2> source2, IUniTaskAsyncEnumerable<T3> source3, IUniTaskAsyncEnumerable<T4> source4, IUniTaskAsyncEnumerable<T5> source5, IUniTaskAsyncEnumerable<T6> source6, IUniTaskAsyncEnumerable<T7> source7, IUniTaskAsyncEnumerable<T8> source8, IUniTaskAsyncEnumerable<T9> source9, IUniTaskAsyncEnumerable<T10> source10, IUniTaskAsyncEnumerable<T11> source11, IUniTaskAsyncEnumerable<T12> source12, IUniTaskAsyncEnumerable<T13> source13, IUniTaskAsyncEnumerable<T14> source14, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> resultSelector, CancellationToken cancellationToken)
+            {
+                this.source1 = source1;
+                this.source2 = source2;
+                this.source3 = source3;
+                this.source4 = source4;
+                this.source5 = source5;
+                this.source6 = source6;
+                this.source7 = source7;
+                this.source8 = source8;
+                this.source9 = source9;
+                this.source10 = source10;
+                this.source11 = source11;
+                this.source12 = source12;
+                this.source13 = source13;
+                this.source14 = source14;
+                
+                this.resultSelector = resultSelector;
+                this.cancellationToken = cancellationToken;
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public TResult Current => result;
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (completedCount == CompleteCount) return CompletedTasks.False;
+
+                if (enumerator1 == null)
+                {
+                    enumerator1 = source1.GetAsyncEnumerator(cancellationToken);
+                    enumerator2 = source2.GetAsyncEnumerator(cancellationToken);
+                    enumerator3 = source3.GetAsyncEnumerator(cancellationToken);
+                    enumerator4 = source4.GetAsyncEnumerator(cancellationToken);
+                    enumerator5 = source5.GetAsyncEnumerator(cancellationToken);
+                    enumerator6 = source6.GetAsyncEnumerator(cancellationToken);
+                    enumerator7 = source7.GetAsyncEnumerator(cancellationToken);
+                    enumerator8 = source8.GetAsyncEnumerator(cancellationToken);
+                    enumerator9 = source9.GetAsyncEnumerator(cancellationToken);
+                    enumerator10 = source10.GetAsyncEnumerator(cancellationToken);
+                    enumerator11 = source11.GetAsyncEnumerator(cancellationToken);
+                    enumerator12 = source12.GetAsyncEnumerator(cancellationToken);
+                    enumerator13 = source13.GetAsyncEnumerator(cancellationToken);
+                    enumerator14 = source14.GetAsyncEnumerator(cancellationToken);
+                }
+
+                completionSource.Reset();
+
+                AGAIN:
+                syncRunning = true;
+                if (!running1)
+                {
+                    running1 = true;
+                    awaiter1 = enumerator1.MoveNextAsync().GetAwaiter();
+                    if (awaiter1.IsCompleted)
+                    {
+                        Completed1(this);
+                    }
+                    else
+                    {
+                        awaiter1.SourceOnCompleted(Completed1Delegate, this);
+                    }
+                }
+                if (!running2)
+                {
+                    running2 = true;
+                    awaiter2 = enumerator2.MoveNextAsync().GetAwaiter();
+                    if (awaiter2.IsCompleted)
+                    {
+                        Completed2(this);
+                    }
+                    else
+                    {
+                        awaiter2.SourceOnCompleted(Completed2Delegate, this);
+                    }
+                }
+                if (!running3)
+                {
+                    running3 = true;
+                    awaiter3 = enumerator3.MoveNextAsync().GetAwaiter();
+                    if (awaiter3.IsCompleted)
+                    {
+                        Completed3(this);
+                    }
+                    else
+                    {
+                        awaiter3.SourceOnCompleted(Completed3Delegate, this);
+                    }
+                }
+                if (!running4)
+                {
+                    running4 = true;
+                    awaiter4 = enumerator4.MoveNextAsync().GetAwaiter();
+                    if (awaiter4.IsCompleted)
+                    {
+                        Completed4(this);
+                    }
+                    else
+                    {
+                        awaiter4.SourceOnCompleted(Completed4Delegate, this);
+                    }
+                }
+                if (!running5)
+                {
+                    running5 = true;
+                    awaiter5 = enumerator5.MoveNextAsync().GetAwaiter();
+                    if (awaiter5.IsCompleted)
+                    {
+                        Completed5(this);
+                    }
+                    else
+                    {
+                        awaiter5.SourceOnCompleted(Completed5Delegate, this);
+                    }
+                }
+                if (!running6)
+                {
+                    running6 = true;
+                    awaiter6 = enumerator6.MoveNextAsync().GetAwaiter();
+                    if (awaiter6.IsCompleted)
+                    {
+                        Completed6(this);
+                    }
+                    else
+                    {
+                        awaiter6.SourceOnCompleted(Completed6Delegate, this);
+                    }
+                }
+                if (!running7)
+                {
+                    running7 = true;
+                    awaiter7 = enumerator7.MoveNextAsync().GetAwaiter();
+                    if (awaiter7.IsCompleted)
+                    {
+                        Completed7(this);
+                    }
+                    else
+                    {
+                        awaiter7.SourceOnCompleted(Completed7Delegate, this);
+                    }
+                }
+                if (!running8)
+                {
+                    running8 = true;
+                    awaiter8 = enumerator8.MoveNextAsync().GetAwaiter();
+                    if (awaiter8.IsCompleted)
+                    {
+                        Completed8(this);
+                    }
+                    else
+                    {
+                        awaiter8.SourceOnCompleted(Completed8Delegate, this);
+                    }
+                }
+                if (!running9)
+                {
+                    running9 = true;
+                    awaiter9 = enumerator9.MoveNextAsync().GetAwaiter();
+                    if (awaiter9.IsCompleted)
+                    {
+                        Completed9(this);
+                    }
+                    else
+                    {
+                        awaiter9.SourceOnCompleted(Completed9Delegate, this);
+                    }
+                }
+                if (!running10)
+                {
+                    running10 = true;
+                    awaiter10 = enumerator10.MoveNextAsync().GetAwaiter();
+                    if (awaiter10.IsCompleted)
+                    {
+                        Completed10(this);
+                    }
+                    else
+                    {
+                        awaiter10.SourceOnCompleted(Completed10Delegate, this);
+                    }
+                }
+                if (!running11)
+                {
+                    running11 = true;
+                    awaiter11 = enumerator11.MoveNextAsync().GetAwaiter();
+                    if (awaiter11.IsCompleted)
+                    {
+                        Completed11(this);
+                    }
+                    else
+                    {
+                        awaiter11.SourceOnCompleted(Completed11Delegate, this);
+                    }
+                }
+                if (!running12)
+                {
+                    running12 = true;
+                    awaiter12 = enumerator12.MoveNextAsync().GetAwaiter();
+                    if (awaiter12.IsCompleted)
+                    {
+                        Completed12(this);
+                    }
+                    else
+                    {
+                        awaiter12.SourceOnCompleted(Completed12Delegate, this);
+                    }
+                }
+                if (!running13)
+                {
+                    running13 = true;
+                    awaiter13 = enumerator13.MoveNextAsync().GetAwaiter();
+                    if (awaiter13.IsCompleted)
+                    {
+                        Completed13(this);
+                    }
+                    else
+                    {
+                        awaiter13.SourceOnCompleted(Completed13Delegate, this);
+                    }
+                }
+                if (!running14)
+                {
+                    running14 = true;
+                    awaiter14 = enumerator14.MoveNextAsync().GetAwaiter();
+                    if (awaiter14.IsCompleted)
+                    {
+                        Completed14(this);
+                    }
+                    else
+                    {
+                        awaiter14.SourceOnCompleted(Completed14Delegate, this);
+                    }
+                }
+
+                if (!running1 || !running2 || !running3 || !running4 || !running5 || !running6 || !running7 || !running8 || !running9 || !running10 || !running11 || !running12 || !running13 || !running14)
+                {
+                    goto AGAIN;
+                }
+                syncRunning = false;
+
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            static void Completed1(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running1 = false;
+
+                try
+                {
+                    if (self.awaiter1.GetResult())
+                    {
+                        self.hasCurrent1 = true;
+                        self.current1 = self.enumerator1.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running1 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running1 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running1 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter1 = self.enumerator1.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter1.SourceOnCompleted(Completed1Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed2(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running2 = false;
+
+                try
+                {
+                    if (self.awaiter2.GetResult())
+                    {
+                        self.hasCurrent2 = true;
+                        self.current2 = self.enumerator2.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running2 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running2 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running2 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter2 = self.enumerator2.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter2.SourceOnCompleted(Completed2Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed3(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running3 = false;
+
+                try
+                {
+                    if (self.awaiter3.GetResult())
+                    {
+                        self.hasCurrent3 = true;
+                        self.current3 = self.enumerator3.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running3 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running3 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running3 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter3 = self.enumerator3.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter3.SourceOnCompleted(Completed3Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed4(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running4 = false;
+
+                try
+                {
+                    if (self.awaiter4.GetResult())
+                    {
+                        self.hasCurrent4 = true;
+                        self.current4 = self.enumerator4.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running4 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running4 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running4 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter4 = self.enumerator4.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter4.SourceOnCompleted(Completed4Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed5(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running5 = false;
+
+                try
+                {
+                    if (self.awaiter5.GetResult())
+                    {
+                        self.hasCurrent5 = true;
+                        self.current5 = self.enumerator5.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running5 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running5 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running5 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter5 = self.enumerator5.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter5.SourceOnCompleted(Completed5Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed6(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running6 = false;
+
+                try
+                {
+                    if (self.awaiter6.GetResult())
+                    {
+                        self.hasCurrent6 = true;
+                        self.current6 = self.enumerator6.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running6 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running6 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running6 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter6 = self.enumerator6.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter6.SourceOnCompleted(Completed6Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed7(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running7 = false;
+
+                try
+                {
+                    if (self.awaiter7.GetResult())
+                    {
+                        self.hasCurrent7 = true;
+                        self.current7 = self.enumerator7.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running7 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running7 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running7 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter7 = self.enumerator7.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter7.SourceOnCompleted(Completed7Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed8(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running8 = false;
+
+                try
+                {
+                    if (self.awaiter8.GetResult())
+                    {
+                        self.hasCurrent8 = true;
+                        self.current8 = self.enumerator8.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running8 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running8 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running8 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter8 = self.enumerator8.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter8.SourceOnCompleted(Completed8Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed9(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running9 = false;
+
+                try
+                {
+                    if (self.awaiter9.GetResult())
+                    {
+                        self.hasCurrent9 = true;
+                        self.current9 = self.enumerator9.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running9 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running9 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running9 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter9 = self.enumerator9.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter9.SourceOnCompleted(Completed9Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed10(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running10 = false;
+
+                try
+                {
+                    if (self.awaiter10.GetResult())
+                    {
+                        self.hasCurrent10 = true;
+                        self.current10 = self.enumerator10.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running10 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running10 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running10 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter10 = self.enumerator10.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter10.SourceOnCompleted(Completed10Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed11(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running11 = false;
+
+                try
+                {
+                    if (self.awaiter11.GetResult())
+                    {
+                        self.hasCurrent11 = true;
+                        self.current11 = self.enumerator11.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running11 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running11 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running11 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter11 = self.enumerator11.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter11.SourceOnCompleted(Completed11Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed12(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running12 = false;
+
+                try
+                {
+                    if (self.awaiter12.GetResult())
+                    {
+                        self.hasCurrent12 = true;
+                        self.current12 = self.enumerator12.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running12 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running12 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running12 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter12 = self.enumerator12.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter12.SourceOnCompleted(Completed12Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed13(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running13 = false;
+
+                try
+                {
+                    if (self.awaiter13.GetResult())
+                    {
+                        self.hasCurrent13 = true;
+                        self.current13 = self.enumerator13.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running13 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running13 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running13 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter13 = self.enumerator13.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter13.SourceOnCompleted(Completed13Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed14(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running14 = false;
+
+                try
+                {
+                    if (self.awaiter14.GetResult())
+                    {
+                        self.hasCurrent14 = true;
+                        self.current14 = self.enumerator14.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running14 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running14 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running14 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter14 = self.enumerator14.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter14.SourceOnCompleted(Completed14Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            bool TrySetResult()
+            {
+                if (hasCurrent1 && hasCurrent2 && hasCurrent3 && hasCurrent4 && hasCurrent5 && hasCurrent6 && hasCurrent7 && hasCurrent8 && hasCurrent9 && hasCurrent10 && hasCurrent11 && hasCurrent12 && hasCurrent13 && hasCurrent14)
+                {
+                    result = resultSelector(current1, current2, current3, current4, current5, current6, current7, current8, current9, current10, current11, current12, current13, current14);
+                    completionSource.TrySetResult(true);
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
+            public async UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                if (enumerator1 != null)
+                {
+                    await enumerator1.DisposeAsync();
+                }
+                if (enumerator2 != null)
+                {
+                    await enumerator2.DisposeAsync();
+                }
+                if (enumerator3 != null)
+                {
+                    await enumerator3.DisposeAsync();
+                }
+                if (enumerator4 != null)
+                {
+                    await enumerator4.DisposeAsync();
+                }
+                if (enumerator5 != null)
+                {
+                    await enumerator5.DisposeAsync();
+                }
+                if (enumerator6 != null)
+                {
+                    await enumerator6.DisposeAsync();
+                }
+                if (enumerator7 != null)
+                {
+                    await enumerator7.DisposeAsync();
+                }
+                if (enumerator8 != null)
+                {
+                    await enumerator8.DisposeAsync();
+                }
+                if (enumerator9 != null)
+                {
+                    await enumerator9.DisposeAsync();
+                }
+                if (enumerator10 != null)
+                {
+                    await enumerator10.DisposeAsync();
+                }
+                if (enumerator11 != null)
+                {
+                    await enumerator11.DisposeAsync();
+                }
+                if (enumerator12 != null)
+                {
+                    await enumerator12.DisposeAsync();
+                }
+                if (enumerator13 != null)
+                {
+                    await enumerator13.DisposeAsync();
+                }
+                if (enumerator14 != null)
+                {
+                    await enumerator14.DisposeAsync();
+                }
+            }
+        }
+    }
+
+    internal class CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> : IUniTaskAsyncEnumerable<TResult>
+    {
+        readonly IUniTaskAsyncEnumerable<T1> source1;
+        readonly IUniTaskAsyncEnumerable<T2> source2;
+        readonly IUniTaskAsyncEnumerable<T3> source3;
+        readonly IUniTaskAsyncEnumerable<T4> source4;
+        readonly IUniTaskAsyncEnumerable<T5> source5;
+        readonly IUniTaskAsyncEnumerable<T6> source6;
+        readonly IUniTaskAsyncEnumerable<T7> source7;
+        readonly IUniTaskAsyncEnumerable<T8> source8;
+        readonly IUniTaskAsyncEnumerable<T9> source9;
+        readonly IUniTaskAsyncEnumerable<T10> source10;
+        readonly IUniTaskAsyncEnumerable<T11> source11;
+        readonly IUniTaskAsyncEnumerable<T12> source12;
+        readonly IUniTaskAsyncEnumerable<T13> source13;
+        readonly IUniTaskAsyncEnumerable<T14> source14;
+        readonly IUniTaskAsyncEnumerable<T15> source15;
+        
+        readonly Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> resultSelector;
+
+        public CombineLatest(IUniTaskAsyncEnumerable<T1> source1, IUniTaskAsyncEnumerable<T2> source2, IUniTaskAsyncEnumerable<T3> source3, IUniTaskAsyncEnumerable<T4> source4, IUniTaskAsyncEnumerable<T5> source5, IUniTaskAsyncEnumerable<T6> source6, IUniTaskAsyncEnumerable<T7> source7, IUniTaskAsyncEnumerable<T8> source8, IUniTaskAsyncEnumerable<T9> source9, IUniTaskAsyncEnumerable<T10> source10, IUniTaskAsyncEnumerable<T11> source11, IUniTaskAsyncEnumerable<T12> source12, IUniTaskAsyncEnumerable<T13> source13, IUniTaskAsyncEnumerable<T14> source14, IUniTaskAsyncEnumerable<T15> source15, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> resultSelector)
+        {
+            this.source1 = source1;
+            this.source2 = source2;
+            this.source3 = source3;
+            this.source4 = source4;
+            this.source5 = source5;
+            this.source6 = source6;
+            this.source7 = source7;
+            this.source8 = source8;
+            this.source9 = source9;
+            this.source10 = source10;
+            this.source11 = source11;
+            this.source12 = source12;
+            this.source13 = source13;
+            this.source14 = source14;
+            this.source15 = source15;
+        
+            this.resultSelector = resultSelector;
+        }
+
+        public IUniTaskAsyncEnumerator<TResult> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _CombineLatest(source1, source2, source3, source4, source5, source6, source7, source8, source9, source10, source11, source12, source13, source14, source15, resultSelector, cancellationToken);
+        }
+
+        class _CombineLatest : MoveNextSource, IUniTaskAsyncEnumerator<TResult>
+        {
+            static readonly Action<object> Completed1Delegate = Completed1;
+            static readonly Action<object> Completed2Delegate = Completed2;
+            static readonly Action<object> Completed3Delegate = Completed3;
+            static readonly Action<object> Completed4Delegate = Completed4;
+            static readonly Action<object> Completed5Delegate = Completed5;
+            static readonly Action<object> Completed6Delegate = Completed6;
+            static readonly Action<object> Completed7Delegate = Completed7;
+            static readonly Action<object> Completed8Delegate = Completed8;
+            static readonly Action<object> Completed9Delegate = Completed9;
+            static readonly Action<object> Completed10Delegate = Completed10;
+            static readonly Action<object> Completed11Delegate = Completed11;
+            static readonly Action<object> Completed12Delegate = Completed12;
+            static readonly Action<object> Completed13Delegate = Completed13;
+            static readonly Action<object> Completed14Delegate = Completed14;
+            static readonly Action<object> Completed15Delegate = Completed15;
+            const int CompleteCount = 15;
+
+            readonly IUniTaskAsyncEnumerable<T1> source1;
+            readonly IUniTaskAsyncEnumerable<T2> source2;
+            readonly IUniTaskAsyncEnumerable<T3> source3;
+            readonly IUniTaskAsyncEnumerable<T4> source4;
+            readonly IUniTaskAsyncEnumerable<T5> source5;
+            readonly IUniTaskAsyncEnumerable<T6> source6;
+            readonly IUniTaskAsyncEnumerable<T7> source7;
+            readonly IUniTaskAsyncEnumerable<T8> source8;
+            readonly IUniTaskAsyncEnumerable<T9> source9;
+            readonly IUniTaskAsyncEnumerable<T10> source10;
+            readonly IUniTaskAsyncEnumerable<T11> source11;
+            readonly IUniTaskAsyncEnumerable<T12> source12;
+            readonly IUniTaskAsyncEnumerable<T13> source13;
+            readonly IUniTaskAsyncEnumerable<T14> source14;
+            readonly IUniTaskAsyncEnumerable<T15> source15;
+       
+            readonly Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> resultSelector;
+            CancellationToken cancellationToken;
+
+            IUniTaskAsyncEnumerator<T1> enumerator1;
+            UniTask<bool>.Awaiter awaiter1;
+            bool hasCurrent1;
+            bool running1;
+            T1 current1;
+
+            IUniTaskAsyncEnumerator<T2> enumerator2;
+            UniTask<bool>.Awaiter awaiter2;
+            bool hasCurrent2;
+            bool running2;
+            T2 current2;
+
+            IUniTaskAsyncEnumerator<T3> enumerator3;
+            UniTask<bool>.Awaiter awaiter3;
+            bool hasCurrent3;
+            bool running3;
+            T3 current3;
+
+            IUniTaskAsyncEnumerator<T4> enumerator4;
+            UniTask<bool>.Awaiter awaiter4;
+            bool hasCurrent4;
+            bool running4;
+            T4 current4;
+
+            IUniTaskAsyncEnumerator<T5> enumerator5;
+            UniTask<bool>.Awaiter awaiter5;
+            bool hasCurrent5;
+            bool running5;
+            T5 current5;
+
+            IUniTaskAsyncEnumerator<T6> enumerator6;
+            UniTask<bool>.Awaiter awaiter6;
+            bool hasCurrent6;
+            bool running6;
+            T6 current6;
+
+            IUniTaskAsyncEnumerator<T7> enumerator7;
+            UniTask<bool>.Awaiter awaiter7;
+            bool hasCurrent7;
+            bool running7;
+            T7 current7;
+
+            IUniTaskAsyncEnumerator<T8> enumerator8;
+            UniTask<bool>.Awaiter awaiter8;
+            bool hasCurrent8;
+            bool running8;
+            T8 current8;
+
+            IUniTaskAsyncEnumerator<T9> enumerator9;
+            UniTask<bool>.Awaiter awaiter9;
+            bool hasCurrent9;
+            bool running9;
+            T9 current9;
+
+            IUniTaskAsyncEnumerator<T10> enumerator10;
+            UniTask<bool>.Awaiter awaiter10;
+            bool hasCurrent10;
+            bool running10;
+            T10 current10;
+
+            IUniTaskAsyncEnumerator<T11> enumerator11;
+            UniTask<bool>.Awaiter awaiter11;
+            bool hasCurrent11;
+            bool running11;
+            T11 current11;
+
+            IUniTaskAsyncEnumerator<T12> enumerator12;
+            UniTask<bool>.Awaiter awaiter12;
+            bool hasCurrent12;
+            bool running12;
+            T12 current12;
+
+            IUniTaskAsyncEnumerator<T13> enumerator13;
+            UniTask<bool>.Awaiter awaiter13;
+            bool hasCurrent13;
+            bool running13;
+            T13 current13;
+
+            IUniTaskAsyncEnumerator<T14> enumerator14;
+            UniTask<bool>.Awaiter awaiter14;
+            bool hasCurrent14;
+            bool running14;
+            T14 current14;
+
+            IUniTaskAsyncEnumerator<T15> enumerator15;
+            UniTask<bool>.Awaiter awaiter15;
+            bool hasCurrent15;
+            bool running15;
+            T15 current15;
+
+            int completedCount;
+            bool syncRunning;
+            TResult result;
+
+            public _CombineLatest(IUniTaskAsyncEnumerable<T1> source1, IUniTaskAsyncEnumerable<T2> source2, IUniTaskAsyncEnumerable<T3> source3, IUniTaskAsyncEnumerable<T4> source4, IUniTaskAsyncEnumerable<T5> source5, IUniTaskAsyncEnumerable<T6> source6, IUniTaskAsyncEnumerable<T7> source7, IUniTaskAsyncEnumerable<T8> source8, IUniTaskAsyncEnumerable<T9> source9, IUniTaskAsyncEnumerable<T10> source10, IUniTaskAsyncEnumerable<T11> source11, IUniTaskAsyncEnumerable<T12> source12, IUniTaskAsyncEnumerable<T13> source13, IUniTaskAsyncEnumerable<T14> source14, IUniTaskAsyncEnumerable<T15> source15, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> resultSelector, CancellationToken cancellationToken)
+            {
+                this.source1 = source1;
+                this.source2 = source2;
+                this.source3 = source3;
+                this.source4 = source4;
+                this.source5 = source5;
+                this.source6 = source6;
+                this.source7 = source7;
+                this.source8 = source8;
+                this.source9 = source9;
+                this.source10 = source10;
+                this.source11 = source11;
+                this.source12 = source12;
+                this.source13 = source13;
+                this.source14 = source14;
+                this.source15 = source15;
+                
+                this.resultSelector = resultSelector;
+                this.cancellationToken = cancellationToken;
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public TResult Current => result;
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (completedCount == CompleteCount) return CompletedTasks.False;
+
+                if (enumerator1 == null)
+                {
+                    enumerator1 = source1.GetAsyncEnumerator(cancellationToken);
+                    enumerator2 = source2.GetAsyncEnumerator(cancellationToken);
+                    enumerator3 = source3.GetAsyncEnumerator(cancellationToken);
+                    enumerator4 = source4.GetAsyncEnumerator(cancellationToken);
+                    enumerator5 = source5.GetAsyncEnumerator(cancellationToken);
+                    enumerator6 = source6.GetAsyncEnumerator(cancellationToken);
+                    enumerator7 = source7.GetAsyncEnumerator(cancellationToken);
+                    enumerator8 = source8.GetAsyncEnumerator(cancellationToken);
+                    enumerator9 = source9.GetAsyncEnumerator(cancellationToken);
+                    enumerator10 = source10.GetAsyncEnumerator(cancellationToken);
+                    enumerator11 = source11.GetAsyncEnumerator(cancellationToken);
+                    enumerator12 = source12.GetAsyncEnumerator(cancellationToken);
+                    enumerator13 = source13.GetAsyncEnumerator(cancellationToken);
+                    enumerator14 = source14.GetAsyncEnumerator(cancellationToken);
+                    enumerator15 = source15.GetAsyncEnumerator(cancellationToken);
+                }
+
+                completionSource.Reset();
+
+                AGAIN:
+                syncRunning = true;
+                if (!running1)
+                {
+                    running1 = true;
+                    awaiter1 = enumerator1.MoveNextAsync().GetAwaiter();
+                    if (awaiter1.IsCompleted)
+                    {
+                        Completed1(this);
+                    }
+                    else
+                    {
+                        awaiter1.SourceOnCompleted(Completed1Delegate, this);
+                    }
+                }
+                if (!running2)
+                {
+                    running2 = true;
+                    awaiter2 = enumerator2.MoveNextAsync().GetAwaiter();
+                    if (awaiter2.IsCompleted)
+                    {
+                        Completed2(this);
+                    }
+                    else
+                    {
+                        awaiter2.SourceOnCompleted(Completed2Delegate, this);
+                    }
+                }
+                if (!running3)
+                {
+                    running3 = true;
+                    awaiter3 = enumerator3.MoveNextAsync().GetAwaiter();
+                    if (awaiter3.IsCompleted)
+                    {
+                        Completed3(this);
+                    }
+                    else
+                    {
+                        awaiter3.SourceOnCompleted(Completed3Delegate, this);
+                    }
+                }
+                if (!running4)
+                {
+                    running4 = true;
+                    awaiter4 = enumerator4.MoveNextAsync().GetAwaiter();
+                    if (awaiter4.IsCompleted)
+                    {
+                        Completed4(this);
+                    }
+                    else
+                    {
+                        awaiter4.SourceOnCompleted(Completed4Delegate, this);
+                    }
+                }
+                if (!running5)
+                {
+                    running5 = true;
+                    awaiter5 = enumerator5.MoveNextAsync().GetAwaiter();
+                    if (awaiter5.IsCompleted)
+                    {
+                        Completed5(this);
+                    }
+                    else
+                    {
+                        awaiter5.SourceOnCompleted(Completed5Delegate, this);
+                    }
+                }
+                if (!running6)
+                {
+                    running6 = true;
+                    awaiter6 = enumerator6.MoveNextAsync().GetAwaiter();
+                    if (awaiter6.IsCompleted)
+                    {
+                        Completed6(this);
+                    }
+                    else
+                    {
+                        awaiter6.SourceOnCompleted(Completed6Delegate, this);
+                    }
+                }
+                if (!running7)
+                {
+                    running7 = true;
+                    awaiter7 = enumerator7.MoveNextAsync().GetAwaiter();
+                    if (awaiter7.IsCompleted)
+                    {
+                        Completed7(this);
+                    }
+                    else
+                    {
+                        awaiter7.SourceOnCompleted(Completed7Delegate, this);
+                    }
+                }
+                if (!running8)
+                {
+                    running8 = true;
+                    awaiter8 = enumerator8.MoveNextAsync().GetAwaiter();
+                    if (awaiter8.IsCompleted)
+                    {
+                        Completed8(this);
+                    }
+                    else
+                    {
+                        awaiter8.SourceOnCompleted(Completed8Delegate, this);
+                    }
+                }
+                if (!running9)
+                {
+                    running9 = true;
+                    awaiter9 = enumerator9.MoveNextAsync().GetAwaiter();
+                    if (awaiter9.IsCompleted)
+                    {
+                        Completed9(this);
+                    }
+                    else
+                    {
+                        awaiter9.SourceOnCompleted(Completed9Delegate, this);
+                    }
+                }
+                if (!running10)
+                {
+                    running10 = true;
+                    awaiter10 = enumerator10.MoveNextAsync().GetAwaiter();
+                    if (awaiter10.IsCompleted)
+                    {
+                        Completed10(this);
+                    }
+                    else
+                    {
+                        awaiter10.SourceOnCompleted(Completed10Delegate, this);
+                    }
+                }
+                if (!running11)
+                {
+                    running11 = true;
+                    awaiter11 = enumerator11.MoveNextAsync().GetAwaiter();
+                    if (awaiter11.IsCompleted)
+                    {
+                        Completed11(this);
+                    }
+                    else
+                    {
+                        awaiter11.SourceOnCompleted(Completed11Delegate, this);
+                    }
+                }
+                if (!running12)
+                {
+                    running12 = true;
+                    awaiter12 = enumerator12.MoveNextAsync().GetAwaiter();
+                    if (awaiter12.IsCompleted)
+                    {
+                        Completed12(this);
+                    }
+                    else
+                    {
+                        awaiter12.SourceOnCompleted(Completed12Delegate, this);
+                    }
+                }
+                if (!running13)
+                {
+                    running13 = true;
+                    awaiter13 = enumerator13.MoveNextAsync().GetAwaiter();
+                    if (awaiter13.IsCompleted)
+                    {
+                        Completed13(this);
+                    }
+                    else
+                    {
+                        awaiter13.SourceOnCompleted(Completed13Delegate, this);
+                    }
+                }
+                if (!running14)
+                {
+                    running14 = true;
+                    awaiter14 = enumerator14.MoveNextAsync().GetAwaiter();
+                    if (awaiter14.IsCompleted)
+                    {
+                        Completed14(this);
+                    }
+                    else
+                    {
+                        awaiter14.SourceOnCompleted(Completed14Delegate, this);
+                    }
+                }
+                if (!running15)
+                {
+                    running15 = true;
+                    awaiter15 = enumerator15.MoveNextAsync().GetAwaiter();
+                    if (awaiter15.IsCompleted)
+                    {
+                        Completed15(this);
+                    }
+                    else
+                    {
+                        awaiter15.SourceOnCompleted(Completed15Delegate, this);
+                    }
+                }
+
+                if (!running1 || !running2 || !running3 || !running4 || !running5 || !running6 || !running7 || !running8 || !running9 || !running10 || !running11 || !running12 || !running13 || !running14 || !running15)
+                {
+                    goto AGAIN;
+                }
+                syncRunning = false;
+
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            static void Completed1(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running1 = false;
+
+                try
+                {
+                    if (self.awaiter1.GetResult())
+                    {
+                        self.hasCurrent1 = true;
+                        self.current1 = self.enumerator1.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running1 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running1 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running1 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter1 = self.enumerator1.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter1.SourceOnCompleted(Completed1Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed2(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running2 = false;
+
+                try
+                {
+                    if (self.awaiter2.GetResult())
+                    {
+                        self.hasCurrent2 = true;
+                        self.current2 = self.enumerator2.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running2 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running2 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running2 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter2 = self.enumerator2.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter2.SourceOnCompleted(Completed2Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed3(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running3 = false;
+
+                try
+                {
+                    if (self.awaiter3.GetResult())
+                    {
+                        self.hasCurrent3 = true;
+                        self.current3 = self.enumerator3.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running3 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running3 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running3 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter3 = self.enumerator3.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter3.SourceOnCompleted(Completed3Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed4(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running4 = false;
+
+                try
+                {
+                    if (self.awaiter4.GetResult())
+                    {
+                        self.hasCurrent4 = true;
+                        self.current4 = self.enumerator4.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running4 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running4 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running4 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter4 = self.enumerator4.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter4.SourceOnCompleted(Completed4Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed5(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running5 = false;
+
+                try
+                {
+                    if (self.awaiter5.GetResult())
+                    {
+                        self.hasCurrent5 = true;
+                        self.current5 = self.enumerator5.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running5 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running5 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running5 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter5 = self.enumerator5.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter5.SourceOnCompleted(Completed5Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed6(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running6 = false;
+
+                try
+                {
+                    if (self.awaiter6.GetResult())
+                    {
+                        self.hasCurrent6 = true;
+                        self.current6 = self.enumerator6.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running6 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running6 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running6 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter6 = self.enumerator6.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter6.SourceOnCompleted(Completed6Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed7(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running7 = false;
+
+                try
+                {
+                    if (self.awaiter7.GetResult())
+                    {
+                        self.hasCurrent7 = true;
+                        self.current7 = self.enumerator7.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running7 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running7 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running7 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter7 = self.enumerator7.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter7.SourceOnCompleted(Completed7Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed8(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running8 = false;
+
+                try
+                {
+                    if (self.awaiter8.GetResult())
+                    {
+                        self.hasCurrent8 = true;
+                        self.current8 = self.enumerator8.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running8 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running8 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running8 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter8 = self.enumerator8.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter8.SourceOnCompleted(Completed8Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed9(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running9 = false;
+
+                try
+                {
+                    if (self.awaiter9.GetResult())
+                    {
+                        self.hasCurrent9 = true;
+                        self.current9 = self.enumerator9.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running9 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running9 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running9 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter9 = self.enumerator9.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter9.SourceOnCompleted(Completed9Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed10(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running10 = false;
+
+                try
+                {
+                    if (self.awaiter10.GetResult())
+                    {
+                        self.hasCurrent10 = true;
+                        self.current10 = self.enumerator10.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running10 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running10 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running10 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter10 = self.enumerator10.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter10.SourceOnCompleted(Completed10Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed11(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running11 = false;
+
+                try
+                {
+                    if (self.awaiter11.GetResult())
+                    {
+                        self.hasCurrent11 = true;
+                        self.current11 = self.enumerator11.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running11 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running11 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running11 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter11 = self.enumerator11.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter11.SourceOnCompleted(Completed11Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed12(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running12 = false;
+
+                try
+                {
+                    if (self.awaiter12.GetResult())
+                    {
+                        self.hasCurrent12 = true;
+                        self.current12 = self.enumerator12.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running12 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running12 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running12 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter12 = self.enumerator12.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter12.SourceOnCompleted(Completed12Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed13(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running13 = false;
+
+                try
+                {
+                    if (self.awaiter13.GetResult())
+                    {
+                        self.hasCurrent13 = true;
+                        self.current13 = self.enumerator13.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running13 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running13 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running13 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter13 = self.enumerator13.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter13.SourceOnCompleted(Completed13Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed14(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running14 = false;
+
+                try
+                {
+                    if (self.awaiter14.GetResult())
+                    {
+                        self.hasCurrent14 = true;
+                        self.current14 = self.enumerator14.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running14 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running14 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running14 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter14 = self.enumerator14.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter14.SourceOnCompleted(Completed14Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            static void Completed15(object state)
+            {
+                var self = (_CombineLatest)state;
+                self.running15 = false;
+
+                try
+                {
+                    if (self.awaiter15.GetResult())
+                    {
+                        self.hasCurrent15 = true;
+                        self.current15 = self.enumerator15.Current;
+                        goto SUCCESS;
+                    }
+                    else
+                    {
+                        self.running15 = true; // as complete, no more call MoveNextAsync.
+                        if (Interlocked.Increment(ref self.completedCount) == CompleteCount)
+                        {
+                            goto COMPLETE;
+                        }
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    self.running15 = true; // as complete, no more call MoveNextAsync.
+                    self.completedCount = CompleteCount;
+                    self.completionSource.TrySetException(ex);
+                    return;
+                }
+
+                SUCCESS:
+                if (!self.TrySetResult())
+                {
+                    if (self.syncRunning) return;
+                    self.running15 = true; // as complete, no more call MoveNextAsync.
+                    try
+                    {
+                        self.awaiter15 = self.enumerator15.MoveNextAsync().GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completedCount = CompleteCount;
+                        self.completionSource.TrySetException(ex);
+                        return;
+                    }
+
+                    self.awaiter15.SourceOnCompleted(Completed15Delegate, self);
+                }
+                return;
+                COMPLETE:
+                self.completionSource.TrySetResult(false);
+                return;
+            }
+
+            bool TrySetResult()
+            {
+                if (hasCurrent1 && hasCurrent2 && hasCurrent3 && hasCurrent4 && hasCurrent5 && hasCurrent6 && hasCurrent7 && hasCurrent8 && hasCurrent9 && hasCurrent10 && hasCurrent11 && hasCurrent12 && hasCurrent13 && hasCurrent14 && hasCurrent15)
+                {
+                    result = resultSelector(current1, current2, current3, current4, current5, current6, current7, current8, current9, current10, current11, current12, current13, current14, current15);
+                    completionSource.TrySetResult(true);
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
+            public async UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                if (enumerator1 != null)
+                {
+                    await enumerator1.DisposeAsync();
+                }
+                if (enumerator2 != null)
+                {
+                    await enumerator2.DisposeAsync();
+                }
+                if (enumerator3 != null)
+                {
+                    await enumerator3.DisposeAsync();
+                }
+                if (enumerator4 != null)
+                {
+                    await enumerator4.DisposeAsync();
+                }
+                if (enumerator5 != null)
+                {
+                    await enumerator5.DisposeAsync();
+                }
+                if (enumerator6 != null)
+                {
+                    await enumerator6.DisposeAsync();
+                }
+                if (enumerator7 != null)
+                {
+                    await enumerator7.DisposeAsync();
+                }
+                if (enumerator8 != null)
+                {
+                    await enumerator8.DisposeAsync();
+                }
+                if (enumerator9 != null)
+                {
+                    await enumerator9.DisposeAsync();
+                }
+                if (enumerator10 != null)
+                {
+                    await enumerator10.DisposeAsync();
+                }
+                if (enumerator11 != null)
+                {
+                    await enumerator11.DisposeAsync();
+                }
+                if (enumerator12 != null)
+                {
+                    await enumerator12.DisposeAsync();
+                }
+                if (enumerator13 != null)
+                {
+                    await enumerator13.DisposeAsync();
+                }
+                if (enumerator14 != null)
+                {
+                    await enumerator14.DisposeAsync();
+                }
+                if (enumerator15 != null)
+                {
+                    await enumerator15.DisposeAsync();
+                }
+            }
+        }
+    }
+
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/CombineLatest.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/CombineLatest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6cb07f6e88287e34d9b9301a572284a5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Concat.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Concat.cs
@@ -1,0 +1,164 @@
+﻿using Cysharp.Threading.Tasks.Internal;
+using System;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static IUniTaskAsyncEnumerable<TSource> Concat<TSource>(this IUniTaskAsyncEnumerable<TSource> first, IUniTaskAsyncEnumerable<TSource> second)
+        {
+            Error.ThrowArgumentNullException(first, nameof(first));
+            Error.ThrowArgumentNullException(second, nameof(second));
+
+            return new Concat<TSource>(first, second);
+        }
+    }
+
+    internal sealed class Concat<TSource> : IUniTaskAsyncEnumerable<TSource>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> first;
+        readonly IUniTaskAsyncEnumerable<TSource> second;
+
+        public Concat(IUniTaskAsyncEnumerable<TSource> first, IUniTaskAsyncEnumerable<TSource> second)
+        {
+            this.first = first;
+            this.second = second;
+        }
+
+        public IUniTaskAsyncEnumerator<TSource> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _Concat(first, second, cancellationToken);
+        }
+
+        sealed class _Concat : MoveNextSource, IUniTaskAsyncEnumerator<TSource>
+        {
+            static readonly Action<object> MoveNextCoreDelegate = MoveNextCore;
+
+            enum IteratingState
+            {
+                IteratingFirst,
+                IteratingSecond,
+                Complete
+            }
+
+            readonly IUniTaskAsyncEnumerable<TSource> first;
+            readonly IUniTaskAsyncEnumerable<TSource> second;
+            CancellationToken cancellationToken;
+
+            IteratingState iteratingState;
+
+            IUniTaskAsyncEnumerator<TSource> enumerator;
+            UniTask<bool>.Awaiter awaiter;
+
+            public _Concat(IUniTaskAsyncEnumerable<TSource> first, IUniTaskAsyncEnumerable<TSource> second, CancellationToken cancellationToken)
+            {
+                this.first = first;
+                this.second = second;
+                this.cancellationToken = cancellationToken;
+                this.iteratingState = IteratingState.IteratingFirst;
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public TSource Current { get; private set; }
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (iteratingState == IteratingState.Complete) return CompletedTasks.False;
+
+                completionSource.Reset();
+                StartIterate();
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            void StartIterate()
+            {
+                if (enumerator == null)
+                {
+                    if (iteratingState == IteratingState.IteratingFirst)
+                    {
+                        enumerator = first.GetAsyncEnumerator(cancellationToken);
+                    }
+                    else if (iteratingState == IteratingState.IteratingSecond)
+                    {
+                        enumerator = second.GetAsyncEnumerator(cancellationToken);
+                    }
+                }
+
+                try
+                {
+                    awaiter = enumerator.MoveNextAsync().GetAwaiter();
+                }
+                catch (Exception ex)
+                {
+                    completionSource.TrySetException(ex);
+                    return;
+                }
+
+                if (awaiter.IsCompleted)
+                {
+                    MoveNextCoreDelegate(this);
+                }
+                else
+                {
+                    awaiter.SourceOnCompleted(MoveNextCoreDelegate, this);
+                }
+            }
+
+            static void MoveNextCore(object state)
+            {
+                var self = (_Concat)state;
+
+                if (self.TryGetResult(self.awaiter, out var result))
+                {
+                    if (result)
+                    {
+                        self.Current = self.enumerator.Current;
+                        self.completionSource.TrySetResult(true);
+                    }
+                    else
+                    {
+                        if (self.iteratingState == IteratingState.IteratingFirst)
+                        {
+                            self.RunSecondAfterDisposeAsync().Forget();
+                            return;
+                        }
+
+                        self.iteratingState = IteratingState.Complete;
+                        self.completionSource.TrySetResult(false);
+                    }
+                }
+            }
+
+            async UniTaskVoid RunSecondAfterDisposeAsync()
+            {
+                try
+                {
+                    await enumerator.DisposeAsync();
+                    enumerator = null;
+                    awaiter = default;
+                    iteratingState = IteratingState.IteratingSecond;
+                }
+                catch (Exception ex)
+                {
+                    completionSource.TrySetException(ex);
+                }
+
+                StartIterate();
+            }
+
+            public UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                if (enumerator != null)
+                {
+                    return enumerator.DisposeAsync();
+                }
+
+                return default;
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Concat.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Concat.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7cb9e19c449127a459851a135ce7d527
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Contains.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Contains.cs
@@ -1,0 +1,50 @@
+﻿using Cysharp.Threading.Tasks.Internal;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static UniTask<Boolean> ContainsAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, TSource value, CancellationToken cancellationToken = default)
+        {
+            return ContainsAsync(source, value, EqualityComparer<TSource>.Default, cancellationToken);
+        }
+
+        public static UniTask<Boolean> ContainsAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, TSource value, IEqualityComparer<TSource> comparer, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(comparer, nameof(comparer));
+
+            return Contains.ContainsAsync(source, value, comparer, cancellationToken);
+        }
+    }
+
+    internal static class Contains
+    {
+        internal static async UniTask<bool> ContainsAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, TSource value, IEqualityComparer<TSource> comparer, CancellationToken cancellationToken)
+        {
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    if (comparer.Equals(value, e.Current))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Contains.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Contains.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 36ab06d30f3223048b4f676e05431a7f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Count.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Count.cs
@@ -1,0 +1,144 @@
+﻿using Cysharp.Threading.Tasks.Internal;
+using System;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static UniTask<Int32> CountAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return Count.CountAsync(source, cancellationToken);
+        }
+
+        public static UniTask<Int32> CountAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Boolean> predicate, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(predicate, nameof(predicate));
+
+            return Count.CountAsync(source, predicate, cancellationToken);
+        }
+
+        public static UniTask<Int32> CountAwaitAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Boolean>> predicate, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(predicate, nameof(predicate));
+
+            return Count.CountAwaitAsync(source, predicate, cancellationToken);
+        }
+
+        public static UniTask<Int32> CountAwaitWithCancellationAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Boolean>> predicate, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(predicate, nameof(predicate));
+
+            return Count.CountAwaitWithCancellationAsync(source, predicate, cancellationToken);
+        }
+    }
+
+    internal static class Count
+    {
+        internal static async UniTask<int> CountAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, CancellationToken cancellationToken)
+        {
+            var count = 0;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    checked { count++; }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return count;
+        }
+
+        internal static async UniTask<int> CountAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Boolean> predicate, CancellationToken cancellationToken)
+        {
+            var count = 0;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    if (predicate(e.Current))
+                    {
+                        checked { count++; }
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return count;
+        }
+
+        internal static async UniTask<int> CountAwaitAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Boolean>> predicate, CancellationToken cancellationToken)
+        {
+            var count = 0;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    if (await predicate(e.Current))
+                    {
+                        checked { count++; }
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return count;
+        }
+
+        internal static async UniTask<int> CountAwaitWithCancellationAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Boolean>> predicate, CancellationToken cancellationToken)
+        {
+            var count = 0;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    if (await predicate(e.Current, cancellationToken))
+                    {
+                        checked { count++; }
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return count;
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Count.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Count.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e606d38eed688574bb2ba89d983cc9bb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Create.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Create.cs
@@ -1,0 +1,174 @@
+﻿using Cysharp.Threading.Tasks.Internal;
+using System;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static IUniTaskAsyncEnumerable<T> Create<T>(Func<IAsyncWriter<T>, CancellationToken, UniTask> create)
+        {
+            Error.ThrowArgumentNullException(create, nameof(create));
+            return new Create<T>(create);
+        }
+    }
+
+    public interface IAsyncWriter<T>
+    {
+        UniTask YieldAsync(T value);
+    }
+
+    internal sealed class Create<T> : IUniTaskAsyncEnumerable<T>
+    {
+        readonly Func<IAsyncWriter<T>, CancellationToken, UniTask> create;
+
+        public Create(Func<IAsyncWriter<T>, CancellationToken, UniTask> create)
+        {
+            this.create = create;
+        }
+
+        public IUniTaskAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _Create(create, cancellationToken);
+        }
+
+        sealed class _Create : MoveNextSource, IUniTaskAsyncEnumerator<T>
+        {
+            readonly Func<IAsyncWriter<T>, CancellationToken, UniTask> create;
+            readonly CancellationToken cancellationToken;
+
+            int state = -1;
+            AsyncWriter writer;
+
+            public _Create(Func<IAsyncWriter<T>, CancellationToken, UniTask> create, CancellationToken cancellationToken)
+            {
+                this.create = create;
+                this.cancellationToken = cancellationToken;
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public T Current { get; private set; }
+
+            public UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                return default;
+            }
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                if (state == -2) return default;
+
+                completionSource.Reset();
+                MoveNext();
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            void MoveNext()
+            {
+                try
+                {
+                    switch (state)
+                    {
+                        case -1: // init
+                            {
+                                writer = new AsyncWriter(this);
+                                RunWriterTask(create(writer, cancellationToken)).Forget();
+                                if (Volatile.Read(ref state) == -2)
+                                {
+                                    return; // complete synchronously
+                                }
+                                state = 0; // wait YieldAsync, it set TrySetResult(true)
+                                return;
+                            }
+                        case 0:
+                            writer.SignalWriter();
+                            return;
+                        default:
+                            goto DONE;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    state = -2;
+                    completionSource.TrySetException(ex);
+                    return;
+                }
+
+                DONE:
+                state = -2;
+                completionSource.TrySetResult(false);
+                return;
+            }
+
+            async UniTaskVoid RunWriterTask(UniTask task)
+            {
+                try
+                {
+                    await task;
+                    goto DONE;
+                }
+                catch (Exception ex)
+                {
+                    Volatile.Write(ref state, -2);
+                    completionSource.TrySetException(ex);
+                    return;
+                }
+
+                DONE:
+                Volatile.Write(ref state, -2);
+                completionSource.TrySetResult(false);
+            }
+
+            public void SetResult(T value)
+            {
+                Current = value;
+                completionSource.TrySetResult(true);
+            }
+        }
+
+        sealed class AsyncWriter : IUniTaskSource, IAsyncWriter<T>
+        {
+            readonly _Create enumerator;
+
+            UniTaskCompletionSourceCore<AsyncUnit> core;
+
+            public AsyncWriter(_Create enumerator)
+            {
+                this.enumerator = enumerator;
+            }
+
+            public void GetResult(short token)
+            {
+                core.GetResult(token);
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+
+            public UniTask YieldAsync(T value)
+            {
+                core.Reset();
+                enumerator.SetResult(value);
+                return new UniTask(this, core.Version);
+            }
+
+            public void SignalWriter()
+            {
+                core.TrySetResult(AsyncUnit.Default);
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Create.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Create.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0202f723469f93945afa063bfb440d15
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/DefaultIfEmpty.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/DefaultIfEmpty.cs
@@ -1,0 +1,142 @@
+﻿using Cysharp.Threading.Tasks.Internal;
+using System;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static IUniTaskAsyncEnumerable<TSource> DefaultIfEmpty<TSource>(this IUniTaskAsyncEnumerable<TSource> source)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return new DefaultIfEmpty<TSource>(source, default);
+        }
+
+        public static IUniTaskAsyncEnumerable<TSource> DefaultIfEmpty<TSource>(this IUniTaskAsyncEnumerable<TSource> source, TSource defaultValue)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return new DefaultIfEmpty<TSource>(source, defaultValue);
+        }
+    }
+
+    internal sealed class DefaultIfEmpty<TSource> : IUniTaskAsyncEnumerable<TSource>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+        readonly TSource defaultValue;
+
+        public DefaultIfEmpty(IUniTaskAsyncEnumerable<TSource> source, TSource defaultValue)
+        {
+            this.source = source;
+            this.defaultValue = defaultValue;
+        }
+
+        public IUniTaskAsyncEnumerator<TSource> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _DefaultIfEmpty(source, defaultValue, cancellationToken);
+        }
+
+        sealed class _DefaultIfEmpty : MoveNextSource, IUniTaskAsyncEnumerator<TSource>
+        {
+            enum IteratingState : byte
+            {
+                Empty,
+                Iterating,
+                Completed
+            }
+
+            static readonly Action<object> MoveNextCoreDelegate = MoveNextCore;
+
+            readonly IUniTaskAsyncEnumerable<TSource> source;
+            readonly TSource defaultValue;
+            CancellationToken cancellationToken;
+
+            IteratingState iteratingState;
+            IUniTaskAsyncEnumerator<TSource> enumerator;
+            UniTask<bool>.Awaiter awaiter;
+
+            public _DefaultIfEmpty(IUniTaskAsyncEnumerable<TSource> source, TSource defaultValue, CancellationToken cancellationToken)
+            {
+                this.source = source;
+                this.defaultValue = defaultValue;
+                this.cancellationToken = cancellationToken;
+
+                this.iteratingState = IteratingState.Empty;
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public TSource Current { get; private set; }
+
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                completionSource.Reset();
+
+                if (iteratingState == IteratingState.Completed)
+                {
+                    return CompletedTasks.False;
+                }
+
+                if (enumerator == null)
+                {
+                    enumerator = source.GetAsyncEnumerator(cancellationToken);
+                }
+
+                awaiter = enumerator.MoveNextAsync().GetAwaiter();
+
+                if (awaiter.IsCompleted)
+                {
+                    MoveNextCore(this);
+                }
+                else
+                {
+                    awaiter.SourceOnCompleted(MoveNextCoreDelegate, this);
+                }
+
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            static void MoveNextCore(object state)
+            {
+                var self = (_DefaultIfEmpty)state;
+
+                if (self.TryGetResult(self.awaiter, out var result))
+                {
+                    if (result)
+                    {
+                        self.iteratingState = IteratingState.Iterating;
+                        self.Current = self.enumerator.Current;
+                        self.completionSource.TrySetResult(true);
+                    }
+                    else
+                    {
+                        if (self.iteratingState == IteratingState.Empty)
+                        {
+                            self.iteratingState = IteratingState.Completed;
+
+                            self.Current = self.defaultValue;
+                            self.completionSource.TrySetResult(true);
+                        }
+                        else
+                        {
+                            self.completionSource.TrySetResult(false);
+                        }
+                    }
+                }
+            }
+
+            public UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                if (enumerator != null)
+                {
+                    return enumerator.DisposeAsync();
+                }
+                return default;
+            }
+        }
+    }
+
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/DefaultIfEmpty.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/DefaultIfEmpty.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 19e437c039ad7e1478dbce1779ef8660
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Distinct.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Distinct.cs
@@ -1,0 +1,277 @@
+﻿using Cysharp.Threading.Tasks.Internal;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static IUniTaskAsyncEnumerable<TSource> Distinct<TSource>(this IUniTaskAsyncEnumerable<TSource> source)
+        {
+            return Distinct(source, EqualityComparer<TSource>.Default);
+        }
+
+        public static IUniTaskAsyncEnumerable<TSource> Distinct<TSource>(this IUniTaskAsyncEnumerable<TSource> source, IEqualityComparer<TSource> comparer)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(comparer, nameof(comparer));
+
+            return new Distinct<TSource>(source, comparer);
+        }
+
+        public static IUniTaskAsyncEnumerable<TSource> Distinct<TSource, TKey>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector)
+        {
+            return Distinct(source, keySelector, EqualityComparer<TKey>.Default);
+        }
+
+        public static IUniTaskAsyncEnumerable<TSource> Distinct<TSource, TKey>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            Error.ThrowArgumentNullException(comparer, nameof(comparer));
+
+            return new Distinct<TSource, TKey>(source, keySelector, comparer);
+        }
+
+        public static IUniTaskAsyncEnumerable<TSource> DistinctAwait<TSource, TKey>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<TKey>> keySelector)
+        {
+            return DistinctAwait(source, keySelector, EqualityComparer<TKey>.Default);
+        }
+
+        public static IUniTaskAsyncEnumerable<TSource> DistinctAwait<TSource, TKey>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<TKey>> keySelector, IEqualityComparer<TKey> comparer)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            Error.ThrowArgumentNullException(comparer, nameof(comparer));
+
+            return new DistinctAwait<TSource, TKey>(source, keySelector, comparer);
+        }
+
+        public static IUniTaskAsyncEnumerable<TSource> DistinctAwaitWithCancellation<TSource, TKey>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<TKey>> keySelector)
+        {
+            return DistinctAwaitWithCancellation(source, keySelector, EqualityComparer<TKey>.Default);
+        }
+
+        public static IUniTaskAsyncEnumerable<TSource> DistinctAwaitWithCancellation<TSource, TKey>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<TKey>> keySelector, IEqualityComparer<TKey> comparer)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            Error.ThrowArgumentNullException(comparer, nameof(comparer));
+
+            return new DistinctAwaitWithCancellation<TSource, TKey>(source, keySelector, comparer);
+        }
+    }
+
+    internal sealed class Distinct<TSource> : IUniTaskAsyncEnumerable<TSource>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+        readonly IEqualityComparer<TSource> comparer;
+
+        public Distinct(IUniTaskAsyncEnumerable<TSource> source, IEqualityComparer<TSource> comparer)
+        {
+            this.source = source;
+            this.comparer = comparer;
+        }
+
+        public IUniTaskAsyncEnumerator<TSource> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _Distinct(source, comparer, cancellationToken);
+        }
+
+        class _Distinct : AsyncEnumeratorBase<TSource, TSource>
+        {
+            readonly HashSet<TSource> set;
+
+            public _Distinct(IUniTaskAsyncEnumerable<TSource> source, IEqualityComparer<TSource> comparer, CancellationToken cancellationToken)
+
+                : base(source, cancellationToken)
+            {
+                this.set = new HashSet<TSource>(comparer);
+            }
+
+            protected override bool TryMoveNextCore(bool sourceHasCurrent, out bool result)
+            {
+                if (sourceHasCurrent)
+                {
+                    var v = SourceCurrent;
+                    if (set.Add(v))
+                    {
+                        Current = v;
+                        result = true;
+                        return true;
+                    }
+                    else
+                    {
+                        result = default;
+                        return false;
+                    }
+                }
+
+                result = false;
+                return true;
+            }
+        }
+    }
+
+    internal sealed class Distinct<TSource, TKey> : IUniTaskAsyncEnumerable<TSource>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+        readonly Func<TSource, TKey> keySelector;
+        readonly IEqualityComparer<TKey> comparer;
+
+        public Distinct(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
+        {
+            this.source = source;
+            this.keySelector = keySelector;
+            this.comparer = comparer;
+        }
+
+        public IUniTaskAsyncEnumerator<TSource> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _Distinct(source, keySelector, comparer, cancellationToken);
+        }
+
+        class _Distinct : AsyncEnumeratorBase<TSource, TSource>
+        {
+            readonly HashSet<TKey> set;
+            readonly Func<TSource, TKey> keySelector;
+
+            public _Distinct(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer, CancellationToken cancellationToken)
+
+                : base(source, cancellationToken)
+            {
+                this.set = new HashSet<TKey>(comparer);
+                this.keySelector = keySelector;
+            }
+
+            protected override bool TryMoveNextCore(bool sourceHasCurrent, out bool result)
+            {
+                if (sourceHasCurrent)
+                {
+                    var v = SourceCurrent;
+                    if (set.Add(keySelector(v)))
+                    {
+                        Current = v;
+                        result = true;
+                        return true;
+                    }
+                    else
+                    {
+                        result = default;
+                        return false;
+                    }
+                }
+
+                result = false;
+                return true;
+            }
+        }
+    }
+
+    internal sealed class DistinctAwait<TSource, TKey> : IUniTaskAsyncEnumerable<TSource>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+        readonly Func<TSource, UniTask<TKey>> keySelector;
+        readonly IEqualityComparer<TKey> comparer;
+
+        public DistinctAwait(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<TKey>> keySelector, IEqualityComparer<TKey> comparer)
+        {
+            this.source = source;
+            this.keySelector = keySelector;
+            this.comparer = comparer;
+        }
+
+        public IUniTaskAsyncEnumerator<TSource> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _DistinctAwait(source, keySelector, comparer, cancellationToken);
+        }
+
+        class _DistinctAwait : AsyncEnumeratorAwaitSelectorBase<TSource, TSource, TKey>
+        {
+            readonly HashSet<TKey> set;
+            readonly Func<TSource, UniTask<TKey>> keySelector;
+
+            public _DistinctAwait(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<TKey>> keySelector, IEqualityComparer<TKey> comparer, CancellationToken cancellationToken)
+
+                : base(source, cancellationToken)
+            {
+                this.set = new HashSet<TKey>(comparer);
+                this.keySelector = keySelector;
+            }
+
+            protected override UniTask<TKey> TransformAsync(TSource sourceCurrent)
+            {
+                return keySelector(sourceCurrent);
+            }
+
+            protected override bool TrySetCurrentCore(TKey awaitResult, out bool terminateIteration)
+            {
+                if (set.Add(awaitResult))
+                {
+                    Current = SourceCurrent;
+                    terminateIteration = false;
+                    return true;
+                }
+                else
+                {
+                    terminateIteration = false;
+                    return false;
+                }
+            }
+        }
+    }
+
+    internal sealed class DistinctAwaitWithCancellation<TSource, TKey> : IUniTaskAsyncEnumerable<TSource>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+        readonly Func<TSource, CancellationToken, UniTask<TKey>> keySelector;
+        readonly IEqualityComparer<TKey> comparer;
+
+        public DistinctAwaitWithCancellation(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<TKey>> keySelector, IEqualityComparer<TKey> comparer)
+        {
+            this.source = source;
+            this.keySelector = keySelector;
+            this.comparer = comparer;
+        }
+
+        public IUniTaskAsyncEnumerator<TSource> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _DistinctAwaitWithCancellation(source, keySelector, comparer, cancellationToken);
+        }
+
+        class _DistinctAwaitWithCancellation : AsyncEnumeratorAwaitSelectorBase<TSource, TSource, TKey>
+        {
+            readonly HashSet<TKey> set;
+            readonly Func<TSource, CancellationToken, UniTask<TKey>> keySelector;
+
+            public _DistinctAwaitWithCancellation(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<TKey>> keySelector, IEqualityComparer<TKey> comparer, CancellationToken cancellationToken)
+
+                : base(source, cancellationToken)
+            {
+                this.set = new HashSet<TKey>(comparer);
+                this.keySelector = keySelector;
+            }
+
+            protected override UniTask<TKey> TransformAsync(TSource sourceCurrent)
+            {
+                return keySelector(sourceCurrent, cancellationToken);
+            }
+
+            protected override bool TrySetCurrentCore(TKey awaitResult, out bool terminateIteration)
+            {
+                if (set.Add(awaitResult))
+                {
+                    Current = SourceCurrent;
+                    terminateIteration = false;
+                    return true;
+                }
+                else
+                {
+                    terminateIteration = false;
+                    return false;
+                }
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Distinct.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Distinct.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8f09903be66e5d943b243d7c19cb3811
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/DistinctUntilChanged.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/DistinctUntilChanged.cs
@@ -1,0 +1,662 @@
+﻿using Cysharp.Threading.Tasks.Internal;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static IUniTaskAsyncEnumerable<TSource> DistinctUntilChanged<TSource>(this IUniTaskAsyncEnumerable<TSource> source)
+        {
+            return DistinctUntilChanged(source, EqualityComparer<TSource>.Default);
+        }
+
+        public static IUniTaskAsyncEnumerable<TSource> DistinctUntilChanged<TSource>(this IUniTaskAsyncEnumerable<TSource> source, IEqualityComparer<TSource> comparer)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(comparer, nameof(comparer));
+
+            return new DistinctUntilChanged<TSource>(source, comparer);
+        }
+
+        public static IUniTaskAsyncEnumerable<TSource> DistinctUntilChanged<TSource, TKey>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector)
+        {
+            return DistinctUntilChanged(source, keySelector, EqualityComparer<TKey>.Default);
+        }
+
+        public static IUniTaskAsyncEnumerable<TSource> DistinctUntilChanged<TSource, TKey>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            Error.ThrowArgumentNullException(comparer, nameof(comparer));
+
+            return new DistinctUntilChanged<TSource, TKey>(source, keySelector, comparer);
+        }
+
+        public static IUniTaskAsyncEnumerable<TSource> DistinctUntilChangedAwait<TSource, TKey>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<TKey>> keySelector)
+        {
+            return DistinctUntilChangedAwait(source, keySelector, EqualityComparer<TKey>.Default);
+        }
+
+        public static IUniTaskAsyncEnumerable<TSource> DistinctUntilChangedAwait<TSource, TKey>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<TKey>> keySelector, IEqualityComparer<TKey> comparer)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            Error.ThrowArgumentNullException(comparer, nameof(comparer));
+
+            return new DistinctUntilChangedAwait<TSource, TKey>(source, keySelector, comparer);
+        }
+
+        public static IUniTaskAsyncEnumerable<TSource> DistinctUntilChangedAwaitWithCancellation<TSource, TKey>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<TKey>> keySelector)
+        {
+            return DistinctUntilChangedAwaitWithCancellation(source, keySelector, EqualityComparer<TKey>.Default);
+        }
+
+        public static IUniTaskAsyncEnumerable<TSource> DistinctUntilChangedAwaitWithCancellation<TSource, TKey>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<TKey>> keySelector, IEqualityComparer<TKey> comparer)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            Error.ThrowArgumentNullException(comparer, nameof(comparer));
+
+            return new DistinctUntilChangedAwaitWithCancellation<TSource, TKey>(source, keySelector, comparer);
+        }
+    }
+
+    internal sealed class DistinctUntilChanged<TSource> : IUniTaskAsyncEnumerable<TSource>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+        readonly IEqualityComparer<TSource> comparer;
+
+        public DistinctUntilChanged(IUniTaskAsyncEnumerable<TSource> source, IEqualityComparer<TSource> comparer)
+        {
+            this.source = source;
+            this.comparer = comparer;
+        }
+
+        public IUniTaskAsyncEnumerator<TSource> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _DistinctUntilChanged(source, comparer, cancellationToken);
+        }
+
+        sealed class _DistinctUntilChanged : MoveNextSource, IUniTaskAsyncEnumerator<TSource>
+        {
+            readonly IUniTaskAsyncEnumerable<TSource> source;
+            readonly IEqualityComparer<TSource> comparer;
+            readonly CancellationToken cancellationToken;
+
+            int state = -1;
+            IUniTaskAsyncEnumerator<TSource> enumerator;
+            UniTask<bool>.Awaiter awaiter;
+            Action moveNextAction;
+
+            public _DistinctUntilChanged(IUniTaskAsyncEnumerable<TSource> source, IEqualityComparer<TSource> comparer, CancellationToken cancellationToken)
+            {
+                this.source = source;
+                this.comparer = comparer;
+                this.cancellationToken = cancellationToken;
+                this.moveNextAction = MoveNext;
+            }
+
+            public TSource Current { get; private set; }
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                if (state == -2) return default;
+
+                completionSource.Reset();
+                MoveNext();
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            void MoveNext()
+            {
+                REPEAT:
+                try
+                {
+                    switch (state)
+                    {
+                        case -1: // init
+                            enumerator = source.GetAsyncEnumerator(cancellationToken);
+                            awaiter = enumerator.MoveNextAsync().GetAwaiter();
+                            if (awaiter.IsCompleted)
+                            {
+                                goto case -3;
+                            }
+                            else
+                            {
+                                state = -3;
+                                awaiter.UnsafeOnCompleted(moveNextAction);
+                                return;
+                            }
+                        case -3: // first
+                            if (awaiter.GetResult())
+                            {
+                                Current = enumerator.Current;
+                                goto CONTINUE;
+                            }
+                            else
+                            {
+                                goto DONE;
+                            }
+                        case 0: // normal
+                            awaiter = enumerator.MoveNextAsync().GetAwaiter();
+                            if (awaiter.IsCompleted)
+                            {
+                                goto case 1;
+                            }
+                            else
+                            {
+                                state = 1;
+                                awaiter.UnsafeOnCompleted(moveNextAction);
+                                return;
+                            }
+                        case 1:
+                            if (awaiter.GetResult())
+                            {
+                                var v = enumerator.Current;
+                                if (!comparer.Equals(Current, v))
+                                {
+                                    Current = v;
+                                    goto CONTINUE;
+                                }
+                                else
+                                {
+                                    state = 0;
+                                    goto REPEAT;
+                                }
+                            }
+                            else
+                            {
+                                goto DONE;
+                            }
+                        case -2:
+                        default:
+                            goto DONE;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    state = -2;
+                    completionSource.TrySetException(ex);
+                    return;
+                }
+
+                DONE:
+                state = -2;
+                completionSource.TrySetResult(false);
+                return;
+
+                CONTINUE:
+                state = 0;
+                completionSource.TrySetResult(true);
+                return;
+            }
+
+            public UniTask DisposeAsync()
+            {
+                return enumerator.DisposeAsync();
+            }
+        }
+    }
+
+    internal sealed class DistinctUntilChanged<TSource, TKey> : IUniTaskAsyncEnumerable<TSource>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+        readonly Func<TSource, TKey> keySelector;
+        readonly IEqualityComparer<TKey> comparer;
+
+        public DistinctUntilChanged(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
+        {
+            this.source = source;
+            this.keySelector = keySelector;
+            this.comparer = comparer;
+        }
+
+        public IUniTaskAsyncEnumerator<TSource> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _DistinctUntilChanged(source, keySelector, comparer, cancellationToken);
+        }
+
+        sealed class _DistinctUntilChanged : MoveNextSource, IUniTaskAsyncEnumerator<TSource>
+        {
+            readonly IUniTaskAsyncEnumerable<TSource> source;
+            readonly Func<TSource, TKey> keySelector;
+            readonly IEqualityComparer<TKey> comparer;
+            readonly CancellationToken cancellationToken;
+
+            int state = -1;
+            IUniTaskAsyncEnumerator<TSource> enumerator;
+            UniTask<bool>.Awaiter awaiter;
+            Action moveNextAction;
+            TKey prev;
+
+            public _DistinctUntilChanged(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer, CancellationToken cancellationToken)
+            {
+                this.source = source;
+                this.keySelector = keySelector;
+                this.comparer = comparer;
+                this.cancellationToken = cancellationToken;
+                this.moveNextAction = MoveNext;
+            }
+
+            public TSource Current { get; private set; }
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                if (state == -2) return default;
+
+                completionSource.Reset();
+                MoveNext();
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            void MoveNext()
+            {
+                REPEAT:
+                try
+                {
+                    switch (state)
+                    {
+                        case -1: // init
+                            enumerator = source.GetAsyncEnumerator(cancellationToken);
+                            awaiter = enumerator.MoveNextAsync().GetAwaiter();
+                            if (awaiter.IsCompleted)
+                            {
+                                goto case -3;
+                            }
+                            else
+                            {
+                                state = -3;
+                                awaiter.UnsafeOnCompleted(moveNextAction);
+                                return;
+                            }
+                        case -3: // first
+                            if (awaiter.GetResult())
+                            {
+                                Current = enumerator.Current;
+                                goto CONTINUE;
+                            }
+                            else
+                            {
+                                goto DONE;
+                            }
+                        case 0: // normal
+                            awaiter = enumerator.MoveNextAsync().GetAwaiter();
+                            if (awaiter.IsCompleted)
+                            {
+                                goto case 1;
+                            }
+                            else
+                            {
+                                state = 1;
+                                awaiter.UnsafeOnCompleted(moveNextAction);
+                                return;
+                            }
+                        case 1:
+                            if (awaiter.GetResult())
+                            {
+                                var v = enumerator.Current;
+                                var key = keySelector(v);
+                                if (!comparer.Equals(prev, key))
+                                {
+                                    prev = key;
+                                    Current = v;
+                                    goto CONTINUE;
+                                }
+                                else
+                                {
+                                    state = 0;
+                                    goto REPEAT;
+                                }
+                            }
+                            else
+                            {
+                                goto DONE;
+                            }
+                        case -2:
+                        default:
+                            goto DONE;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    state = -2;
+                    completionSource.TrySetException(ex);
+                    return;
+                }
+
+                DONE:
+                state = -2;
+                completionSource.TrySetResult(false);
+                return;
+
+                CONTINUE:
+                state = 0;
+                completionSource.TrySetResult(true);
+                return;
+            }
+
+            public UniTask DisposeAsync()
+            {
+                return enumerator.DisposeAsync();
+            }
+        }
+    }
+
+    internal sealed class DistinctUntilChangedAwait<TSource, TKey> : IUniTaskAsyncEnumerable<TSource>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+        readonly Func<TSource, UniTask<TKey>> keySelector;
+        readonly IEqualityComparer<TKey> comparer;
+
+        public DistinctUntilChangedAwait(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<TKey>> keySelector, IEqualityComparer<TKey> comparer)
+        {
+            this.source = source;
+            this.keySelector = keySelector;
+            this.comparer = comparer;
+        }
+
+        public IUniTaskAsyncEnumerator<TSource> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _DistinctUntilChangedAwait(source, keySelector, comparer, cancellationToken);
+        }
+
+        sealed class _DistinctUntilChangedAwait : MoveNextSource, IUniTaskAsyncEnumerator<TSource>
+        {
+            readonly IUniTaskAsyncEnumerable<TSource> source;
+            readonly Func<TSource, UniTask<TKey>> keySelector;
+            readonly IEqualityComparer<TKey> comparer;
+            readonly CancellationToken cancellationToken;
+
+            int state = -1;
+            IUniTaskAsyncEnumerator<TSource> enumerator;
+            UniTask<bool>.Awaiter awaiter;
+            UniTask<TKey>.Awaiter awaiter2;
+            Action moveNextAction;
+            TSource enumeratorCurrent;
+            TKey prev;
+
+            public _DistinctUntilChangedAwait(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<TKey>> keySelector, IEqualityComparer<TKey> comparer, CancellationToken cancellationToken)
+            {
+                this.source = source;
+                this.keySelector = keySelector;
+                this.comparer = comparer;
+                this.cancellationToken = cancellationToken;
+                this.moveNextAction = MoveNext;
+            }
+
+            public TSource Current { get; private set; }
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                if (state == -2) return default;
+
+                completionSource.Reset();
+                MoveNext();
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            void MoveNext()
+            {
+                REPEAT:
+                try
+                {
+                    switch (state)
+                    {
+                        case -1: // init
+                            enumerator = source.GetAsyncEnumerator(cancellationToken);
+                            awaiter = enumerator.MoveNextAsync().GetAwaiter();
+                            if (awaiter.IsCompleted)
+                            {
+                                goto case -3;
+                            }
+                            else
+                            {
+                                state = -3;
+                                awaiter.UnsafeOnCompleted(moveNextAction);
+                                return;
+                            }
+                        case -3: // first
+                            if (awaiter.GetResult())
+                            {
+                                Current = enumerator.Current;
+                                goto CONTINUE;
+                            }
+                            else
+                            {
+                                goto DONE;
+                            }
+                        case 0: // normal
+                            awaiter = enumerator.MoveNextAsync().GetAwaiter();
+                            if (awaiter.IsCompleted)
+                            {
+                                goto case 1;
+                            }
+                            else
+                            {
+                                state = 1;
+                                awaiter.UnsafeOnCompleted(moveNextAction);
+                                return;
+                            }
+                        case 1:
+                            if (awaiter.GetResult())
+                            {
+                                enumeratorCurrent = enumerator.Current;
+                                awaiter2 = keySelector(enumeratorCurrent).GetAwaiter();
+                                if (awaiter2.IsCompleted)
+                                {
+                                    goto case 2;
+                                }
+                                else
+                                {
+                                    state = 2;
+                                    awaiter2.UnsafeOnCompleted(moveNextAction);
+                                    return;
+                                }
+                            }
+                            else
+                            {
+                                goto DONE;
+                            }
+                        case 2:
+                            var key = awaiter2.GetResult();
+                            if (!comparer.Equals(prev, key))
+                            {
+                                prev = key;
+                                Current = enumeratorCurrent;
+                                goto CONTINUE;
+                            }
+                            else
+                            {
+                                state = 0;
+                                goto REPEAT;
+                            }
+                        case -2:
+                        default:
+                            goto DONE;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    state = -2;
+                    completionSource.TrySetException(ex);
+                    return;
+                }
+
+                DONE:
+                state = -2;
+                completionSource.TrySetResult(false);
+                return;
+
+                CONTINUE:
+                state = 0;
+                completionSource.TrySetResult(true);
+                return;
+            }
+
+            public UniTask DisposeAsync()
+            {
+                return enumerator.DisposeAsync();
+            }
+        }
+    }
+
+    internal sealed class DistinctUntilChangedAwaitWithCancellation<TSource, TKey> : IUniTaskAsyncEnumerable<TSource>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+        readonly Func<TSource, CancellationToken, UniTask<TKey>> keySelector;
+        readonly IEqualityComparer<TKey> comparer;
+
+        public DistinctUntilChangedAwaitWithCancellation(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<TKey>> keySelector, IEqualityComparer<TKey> comparer)
+        {
+            this.source = source;
+            this.keySelector = keySelector;
+            this.comparer = comparer;
+        }
+
+        public IUniTaskAsyncEnumerator<TSource> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _DistinctUntilChangedAwaitWithCancellation(source, keySelector, comparer, cancellationToken);
+        }
+
+        sealed class _DistinctUntilChangedAwaitWithCancellation : MoveNextSource, IUniTaskAsyncEnumerator<TSource>
+        {
+            readonly IUniTaskAsyncEnumerable<TSource> source;
+            readonly Func<TSource, CancellationToken, UniTask<TKey>> keySelector;
+            readonly IEqualityComparer<TKey> comparer;
+            readonly CancellationToken cancellationToken;
+
+            int state = -1;
+            IUniTaskAsyncEnumerator<TSource> enumerator;
+            UniTask<bool>.Awaiter awaiter;
+            UniTask<TKey>.Awaiter awaiter2;
+            Action moveNextAction;
+            TSource enumeratorCurrent;
+            TKey prev;
+
+            public _DistinctUntilChangedAwaitWithCancellation(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<TKey>> keySelector, IEqualityComparer<TKey> comparer, CancellationToken cancellationToken)
+            {
+                this.source = source;
+                this.keySelector = keySelector;
+                this.comparer = comparer;
+                this.cancellationToken = cancellationToken;
+                this.moveNextAction = MoveNext;
+            }
+
+            public TSource Current { get; private set; }
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                if (state == -2) return default;
+
+                completionSource.Reset();
+                MoveNext();
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            void MoveNext()
+            {
+                REPEAT:
+                try
+                {
+                    switch (state)
+                    {
+                        case -1: // init
+                            enumerator = source.GetAsyncEnumerator(cancellationToken);
+                            awaiter = enumerator.MoveNextAsync().GetAwaiter();
+                            if (awaiter.IsCompleted)
+                            {
+                                goto case -3;
+                            }
+                            else
+                            {
+                                state = -3;
+                                awaiter.UnsafeOnCompleted(moveNextAction);
+                                return;
+                            }
+                        case -3: // first
+                            if (awaiter.GetResult())
+                            {
+                                Current = enumerator.Current;
+                                goto CONTINUE;
+                            }
+                            else
+                            {
+                                goto DONE;
+                            }
+                        case 0: // normal
+                            awaiter = enumerator.MoveNextAsync().GetAwaiter();
+                            if (awaiter.IsCompleted)
+                            {
+                                goto case 1;
+                            }
+                            else
+                            {
+                                state = 1;
+                                awaiter.UnsafeOnCompleted(moveNextAction);
+                                return;
+                            }
+                        case 1:
+                            if (awaiter.GetResult())
+                            {
+                                enumeratorCurrent = enumerator.Current;
+                                awaiter2 = keySelector(enumeratorCurrent, cancellationToken).GetAwaiter();
+                                if (awaiter2.IsCompleted)
+                                {
+                                    goto case 2;
+                                }
+                                else
+                                {
+                                    state = 2;
+                                    awaiter2.UnsafeOnCompleted(moveNextAction);
+                                    return;
+                                }
+                            }
+                            else
+                            {
+                                goto DONE;
+                            }
+                        case 2:
+                            var key = awaiter2.GetResult();
+                            if (!comparer.Equals(prev, key))
+                            {
+                                prev = key;
+                                Current = enumeratorCurrent;
+                                goto CONTINUE;
+                            }
+                            else
+                            {
+                                state = 0;
+                                goto REPEAT;
+                            }
+                        case -2:
+                        default:
+                            goto DONE;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    state = -2;
+                    completionSource.TrySetException(ex);
+                    return;
+                }
+
+                DONE:
+                state = -2;
+                completionSource.TrySetResult(false);
+                return;
+
+                CONTINUE:
+                state = 0;
+                completionSource.TrySetResult(true);
+                return;
+            }
+
+            public UniTask DisposeAsync()
+            {
+                return enumerator.DisposeAsync();
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/DistinctUntilChanged.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/DistinctUntilChanged.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0351f6767df7e644b935d4d599968162
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Do.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Do.cs
@@ -1,0 +1,258 @@
+﻿using Cysharp.Threading.Tasks;
+using Cysharp.Threading.Tasks.Internal;
+using Cysharp.Threading.Tasks.Linq;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static IUniTaskAsyncEnumerable<TSource> Do<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Action<TSource> onNext)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            return source.Do(onNext, null, null);
+        }
+
+        public static IUniTaskAsyncEnumerable<TSource> Do<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Action<TSource> onNext, Action<Exception> onError)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            return source.Do(onNext, onError, null);
+        }
+
+        public static IUniTaskAsyncEnumerable<TSource> Do<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Action<TSource> onNext, Action onCompleted)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            return source.Do(onNext, null, onCompleted);
+        }
+
+        public static IUniTaskAsyncEnumerable<TSource> Do<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Action<TSource> onNext, Action<Exception> onError, Action onCompleted)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            return new Do<TSource>(source, onNext, onError, onCompleted);
+        }
+
+        public static IUniTaskAsyncEnumerable<TSource> Do<TSource>(this IUniTaskAsyncEnumerable<TSource> source, IObserver<TSource> observer)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(observer, nameof(observer));
+
+            return source.Do(observer.OnNext, observer.OnError, observer.OnCompleted); // alloc delegate.
+        }
+
+        // not yet impl.
+
+        //public static IUniTaskAsyncEnumerable<TSource> DoAwait<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask> onNext)
+        //{
+        //    throw new NotImplementedException();
+        //}
+
+        //public static IUniTaskAsyncEnumerable<TSource> DoAwait<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask> onNext, Func<Exception, UniTask> onError)
+        //{
+        //    throw new NotImplementedException();
+        //}
+
+        //public static IUniTaskAsyncEnumerable<TSource> DoAwait<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask> onNext, Func<UniTask> onCompleted)
+        //{
+        //    throw new NotImplementedException();
+        //}
+
+        //public static IUniTaskAsyncEnumerable<TSource> DoAwait<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask> onNext, Func<Exception, UniTask> onError, Func<UniTask> onCompleted)
+        //{
+        //    throw new NotImplementedException();
+        //}
+
+        //public static IUniTaskAsyncEnumerable<TSource> DoAwaitWithCancellation<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask> onNext)
+        //{
+        //    throw new NotImplementedException();
+        //}
+
+        //public static IUniTaskAsyncEnumerable<TSource> DoAwaitWithCancellation<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask> onNext, Func<Exception, CancellationToken, UniTask> onError)
+        //{
+        //    throw new NotImplementedException();
+        //}
+
+        //public static IUniTaskAsyncEnumerable<TSource> DoAwaitWithCancellation<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask> onNext, Func<CancellationToken, UniTask> onCompleted)
+        //{
+        //    throw new NotImplementedException();
+        //}
+
+        //public static IUniTaskAsyncEnumerable<TSource> DoAwaitWithCancellation<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask> onNext, Func<Exception, CancellationToken, UniTask> onError, Func<CancellationToken, UniTask> onCompleted)
+        //{
+        //    throw new NotImplementedException();
+        //}
+    }
+
+    internal sealed class Do<TSource> : IUniTaskAsyncEnumerable<TSource>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+        readonly Action<TSource> onNext;
+        readonly Action<Exception> onError;
+        readonly Action onCompleted;
+
+        public Do(IUniTaskAsyncEnumerable<TSource> source, Action<TSource> onNext, Action<Exception> onError, Action onCompleted)
+        {
+            this.source = source;
+            this.onNext = onNext;
+            this.onError = onError;
+            this.onCompleted = onCompleted;
+        }
+
+        public IUniTaskAsyncEnumerator<TSource> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _Do(source, onNext, onError, onCompleted, cancellationToken);
+        }
+
+        sealed class _Do : MoveNextSource, IUniTaskAsyncEnumerator<TSource>
+        {
+            static readonly Action<object> MoveNextCoreDelegate = MoveNextCore;
+
+            readonly IUniTaskAsyncEnumerable<TSource> source;
+            readonly Action<TSource> onNext;
+            readonly Action<Exception> onError;
+            readonly Action onCompleted;
+            CancellationToken cancellationToken;
+
+            IUniTaskAsyncEnumerator<TSource> enumerator;
+            UniTask<bool>.Awaiter awaiter;
+
+            public _Do(IUniTaskAsyncEnumerable<TSource> source, Action<TSource> onNext, Action<Exception> onError, Action onCompleted, CancellationToken cancellationToken)
+            {
+                this.source = source;
+                this.onNext = onNext;
+                this.onError = onError;
+                this.onCompleted = onCompleted;
+                this.cancellationToken = cancellationToken;
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public TSource Current { get; private set; }
+
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                completionSource.Reset();
+
+                bool isCompleted = false;
+                try
+                {
+                    if (enumerator == null)
+                    {
+                        enumerator = source.GetAsyncEnumerator(cancellationToken);
+                    }
+
+                    awaiter = enumerator.MoveNextAsync().GetAwaiter();
+                    isCompleted = awaiter.IsCompleted;
+                }
+                catch (Exception ex)
+                {
+                    CallTrySetExceptionAfterNotification(ex);
+                    return new UniTask<bool>(this, completionSource.Version);
+                }
+
+                if (isCompleted)
+                {
+                    MoveNextCore(this);
+                }
+                else
+                {
+                    awaiter.SourceOnCompleted(MoveNextCoreDelegate, this);
+                }
+
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            void CallTrySetExceptionAfterNotification(Exception ex)
+            {
+                if (onError != null)
+                {
+                    try
+                    {
+                        onError(ex);
+                    }
+                    catch (Exception ex2)
+                    {
+                        completionSource.TrySetException(ex2);
+                        return;
+                    }
+                }
+
+                completionSource.TrySetException(ex);
+            }
+
+            bool TryGetResultWithNotification<T>(UniTask<T>.Awaiter awaiter, out T result)
+            {
+                try
+                {
+                    result = awaiter.GetResult();
+                    return true;
+                }
+                catch (Exception ex)
+                {
+                    CallTrySetExceptionAfterNotification(ex);
+                    result = default;
+                    return false;
+                }
+            }
+
+
+            static void MoveNextCore(object state)
+            {
+                var self = (_Do)state;
+
+                if (self.TryGetResultWithNotification(self.awaiter, out var result))
+                {
+                    if (result)
+                    {
+                        var v = self.enumerator.Current;
+
+                        if (self.onNext != null)
+                        {
+                            try
+                            {
+                                self.onNext(v);
+                            }
+                            catch (Exception ex)
+                            {
+                                self.CallTrySetExceptionAfterNotification(ex);
+                            }
+                        }
+
+                        self.Current = v;
+                        self.completionSource.TrySetResult(true);
+                    }
+                    else
+                    {
+                        if (self.onCompleted != null)
+                        {
+                            try
+                            {
+                                self.onCompleted();
+                            }
+                            catch (Exception ex)
+                            {
+                                self.CallTrySetExceptionAfterNotification(ex);
+                                return;
+                            }
+                        }
+
+                        self.completionSource.TrySetResult(false);
+                    }
+                }
+            }
+
+            public UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                if (enumerator != null)
+                {
+                    return enumerator.DisposeAsync();
+                }
+                return default;
+            }
+        }
+    }
+
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Do.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Do.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dd83c8e12dedf75409b829b93146d130
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/ElementAt.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/ElementAt.cs
@@ -1,0 +1,58 @@
+﻿using Cysharp.Threading.Tasks.Internal;
+using System;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static UniTask<TSource> ElementAtAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, int index, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return ElementAt.ElementAtAsync(source, index, cancellationToken, false);
+        }
+
+        public static UniTask<TSource> ElementAtOrDefaultAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, int index, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return ElementAt.ElementAtAsync(source, index, cancellationToken, true);
+        }
+    }
+
+    internal static class ElementAt
+    {
+        public static async UniTask<TSource> ElementAtAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, int index, CancellationToken cancellationToken, bool defaultIfEmpty)
+        {
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                int i = 0;
+                while (await e.MoveNextAsync())
+                {
+                    if (i++ == index)
+                    {
+                        return e.Current;
+                    }
+                }
+
+                if (defaultIfEmpty)
+                {
+                    return default;
+                }
+                else
+                {
+                    throw Error.ArgumentOutOfRange(nameof(index));
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/ElementAt.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/ElementAt.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c835bd2dd8555234c8919c7b8ef3b69a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Empty.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Empty.cs
@@ -1,0 +1,47 @@
+﻿using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static IUniTaskAsyncEnumerable<T> Empty<T>()
+        {
+            return Cysharp.Threading.Tasks.Linq.Empty<T>.Instance;
+        }
+    }
+
+    internal class Empty<T> : IUniTaskAsyncEnumerable<T>
+    {
+        public static readonly IUniTaskAsyncEnumerable<T> Instance = new Empty<T>();
+
+        Empty()
+        {
+        }
+
+        public IUniTaskAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return _Empty.Instance;
+        }
+
+        class _Empty : IUniTaskAsyncEnumerator<T>
+        {
+            public static readonly IUniTaskAsyncEnumerator<T> Instance = new _Empty();
+
+            _Empty()
+            {
+            }
+
+            public T Current => default;
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                return CompletedTasks.False;
+            }
+
+            public UniTask DisposeAsync()
+            {
+                return default;
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Empty.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Empty.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4fa123ad6258abb4184721b719a13810
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Except.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Except.cs
@@ -1,0 +1,116 @@
+﻿using Cysharp.Threading.Tasks.Internal;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static IUniTaskAsyncEnumerable<TSource> Except<TSource>(this IUniTaskAsyncEnumerable<TSource> first, IUniTaskAsyncEnumerable<TSource> second)
+        {
+            Error.ThrowArgumentNullException(first, nameof(first));
+            Error.ThrowArgumentNullException(second, nameof(second));
+
+            return new Except<TSource>(first, second, EqualityComparer<TSource>.Default);
+        }
+
+        public static IUniTaskAsyncEnumerable<TSource> Except<TSource>(this IUniTaskAsyncEnumerable<TSource> first, IUniTaskAsyncEnumerable<TSource> second, IEqualityComparer<TSource> comparer)
+        {
+            Error.ThrowArgumentNullException(first, nameof(first));
+            Error.ThrowArgumentNullException(second, nameof(second));
+            Error.ThrowArgumentNullException(comparer, nameof(comparer));
+
+            return new Except<TSource>(first, second, comparer);
+        }
+    }
+
+    internal sealed class Except<TSource> : IUniTaskAsyncEnumerable<TSource>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> first;
+        readonly IUniTaskAsyncEnumerable<TSource> second;
+        readonly IEqualityComparer<TSource> comparer;
+
+        public Except(IUniTaskAsyncEnumerable<TSource> first, IUniTaskAsyncEnumerable<TSource> second, IEqualityComparer<TSource> comparer)
+        {
+            this.first = first;
+            this.second = second;
+            this.comparer = comparer;
+        }
+
+        public IUniTaskAsyncEnumerator<TSource> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _Except(first, second, comparer, cancellationToken);
+        }
+
+        class _Except : AsyncEnumeratorBase<TSource, TSource>
+        {
+            static Action<object> HashSetAsyncCoreDelegate = HashSetAsyncCore;
+
+            readonly IEqualityComparer<TSource> comparer;
+            readonly IUniTaskAsyncEnumerable<TSource> second;
+
+            HashSet<TSource> set;
+            UniTask<HashSet<TSource>>.Awaiter awaiter;
+
+            public _Except(IUniTaskAsyncEnumerable<TSource> first, IUniTaskAsyncEnumerable<TSource> second, IEqualityComparer<TSource> comparer, CancellationToken cancellationToken)
+
+                : base(first, cancellationToken)
+            {
+                this.second = second;
+                this.comparer = comparer;
+            }
+
+            protected override bool OnFirstIteration()
+            {
+                if (set != null) return false;
+
+                awaiter = second.ToHashSetAsync(cancellationToken).GetAwaiter();
+                if (awaiter.IsCompleted)
+                {
+                    set = awaiter.GetResult();
+                    SourceMoveNext();
+                }
+                else
+                {
+                    awaiter.SourceOnCompleted(HashSetAsyncCoreDelegate, this);
+                }
+
+                return true;
+            }
+
+            static void HashSetAsyncCore(object state)
+            {
+                var self = (_Except)state;
+
+                if (self.TryGetResult(self.awaiter, out var result))
+                {
+                    self.set = result;
+                    self.SourceMoveNext();
+                }
+            }
+
+            protected override bool TryMoveNextCore(bool sourceHasCurrent, out bool result)
+            {
+                if (sourceHasCurrent)
+                {
+                    var v = SourceCurrent;
+                    if (set.Add(v))
+                    {
+                        Current = v;
+                        result = true;
+                        return true;
+                    }
+                    else
+                    {
+                        result = default;
+                        return false;
+                    }
+                }
+
+                result = false;
+                return true;
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Except.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Except.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 38c1c4129f59dcb49a5b864eaf4ec63c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/First.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/First.cs
@@ -1,0 +1,200 @@
+﻿using Cysharp.Threading.Tasks.Internal;
+using System;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static UniTask<TSource> FirstAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return First.FirstAsync(source, cancellationToken, false);
+        }
+
+        public static UniTask<TSource> FirstAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Boolean> predicate, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(predicate, nameof(predicate));
+
+            return First.FirstAsync(source, predicate, cancellationToken, false);
+        }
+
+        public static UniTask<TSource> FirstAwaitAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Boolean>> predicate, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(predicate, nameof(predicate));
+
+            return First.FirstAwaitAsync(source, predicate, cancellationToken, false);
+        }
+
+        public static UniTask<TSource> FirstAwaitWithCancellationAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Boolean>> predicate, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(predicate, nameof(predicate));
+
+            return First.FirstAwaitWithCancellationAsync(source, predicate, cancellationToken, false);
+        }
+
+        public static UniTask<TSource> FirstOrDefaultAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return First.FirstAsync(source, cancellationToken, true);
+        }
+
+        public static UniTask<TSource> FirstOrDefaultAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Boolean> predicate, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(predicate, nameof(predicate));
+
+            return First.FirstAsync(source, predicate, cancellationToken, true);
+        }
+
+        public static UniTask<TSource> FirstOrDefaultAwaitAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Boolean>> predicate, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(predicate, nameof(predicate));
+
+            return First.FirstAwaitAsync(source, predicate, cancellationToken, true);
+        }
+
+        public static UniTask<TSource> FirstOrDefaultAwaitWithCancellationAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Boolean>> predicate, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(predicate, nameof(predicate));
+
+            return First.FirstAwaitWithCancellationAsync(source, predicate, cancellationToken, true);
+        }
+    }
+
+    internal static class First
+    {
+        public static async UniTask<TSource> FirstAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, CancellationToken cancellationToken, bool defaultIfEmpty)
+        {
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                if (await e.MoveNextAsync())
+                {
+                    return e.Current;
+                }
+                else
+                {
+                    if (defaultIfEmpty)
+                    {
+                        return default;
+                    }
+                    else
+                    {
+                        throw Error.NoElements();
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+        }
+
+        public static async UniTask<TSource> FirstAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Boolean> predicate, CancellationToken cancellationToken, bool defaultIfEmpty)
+        {
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    var v = e.Current;
+                    if (predicate(v))
+                    {
+                        return v;
+                    }
+                }
+
+                if (defaultIfEmpty)
+                {
+                    return default;
+                }
+                else
+                {
+                    throw Error.NoElements();
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+        }
+
+        public static async UniTask<TSource> FirstAwaitAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Boolean>> predicate, CancellationToken cancellationToken, bool defaultIfEmpty)
+        {
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    var v = e.Current;
+                    if (await predicate(v))
+                    {
+                        return v;
+                    }
+                }
+
+                if (defaultIfEmpty)
+                {
+                    return default;
+                }
+                else
+                {
+                    throw Error.NoElements();
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+        }
+
+        public static async UniTask<TSource> FirstAwaitWithCancellationAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Boolean>> predicate, CancellationToken cancellationToken, bool defaultIfEmpty)
+        {
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    var v = e.Current;
+                    if (await predicate(v, cancellationToken))
+                    {
+                        return v;
+                    }
+                }
+
+                if (defaultIfEmpty)
+                {
+                    return default;
+                }
+                else
+                {
+                    throw Error.NoElements();
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/First.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/First.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 417946e97e9eed84db6f840f57037ca6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/ForEach.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/ForEach.cs
@@ -1,0 +1,193 @@
+﻿using Cysharp.Threading.Tasks.Internal;
+using System;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static UniTask ForEachAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Action<TSource> action, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(action, nameof(action));
+
+            return Cysharp.Threading.Tasks.Linq.ForEach.ForEachAsync(source, action, cancellationToken);
+        }
+
+        public static UniTask ForEachAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Action<TSource, Int32> action, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(action, nameof(action));
+
+            return Cysharp.Threading.Tasks.Linq.ForEach.ForEachAsync(source, action, cancellationToken);
+        }
+
+        /// <summary>Obsolete(Error), Use Use ForEachAwaitAsync instead.</summary>
+        [Obsolete("Use ForEachAwaitAsync instead.", true)]
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        public static UniTask ForEachAsync<T>(this IUniTaskAsyncEnumerable<T> source, Func<T, UniTask> action, CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException("Use ForEachAwaitAsync instead.");
+        }
+
+        /// <summary>Obsolete(Error), Use Use ForEachAwaitAsync instead.</summary>
+        [Obsolete("Use ForEachAwaitAsync instead.", true)]
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        public static UniTask ForEachAsync<T>(this IUniTaskAsyncEnumerable<T> source, Func<T, int, UniTask> action, CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException("Use ForEachAwaitAsync instead.");
+        }
+
+        public static UniTask ForEachAwaitAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask> action, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(action, nameof(action));
+
+            return Cysharp.Threading.Tasks.Linq.ForEach.ForEachAwaitAsync(source, action, cancellationToken);
+        }
+
+        public static UniTask ForEachAwaitAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Int32, UniTask> action, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(action, nameof(action));
+
+            return Cysharp.Threading.Tasks.Linq.ForEach.ForEachAwaitAsync(source, action, cancellationToken);
+        }
+
+        public static UniTask ForEachAwaitWithCancellationAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask> action, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(action, nameof(action));
+
+            return Cysharp.Threading.Tasks.Linq.ForEach.ForEachAwaitWithCancellationAsync(source, action, cancellationToken);
+        }
+
+        public static UniTask ForEachAwaitWithCancellationAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Int32, CancellationToken, UniTask> action, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(action, nameof(action));
+
+            return Cysharp.Threading.Tasks.Linq.ForEach.ForEachAwaitWithCancellationAsync(source, action, cancellationToken);
+        }
+    }
+
+    internal static class ForEach
+    {
+        public static async UniTask ForEachAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Action<TSource> action, CancellationToken cancellationToken)
+        {
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    action(e.Current);
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+        }
+
+        public static async UniTask ForEachAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Action<TSource, Int32> action, CancellationToken cancellationToken)
+        {
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                int index = 0;
+                while (await e.MoveNextAsync())
+                {
+                    action(e.Current, checked(index++));
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+        }
+
+        public static async UniTask ForEachAwaitAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask> action, CancellationToken cancellationToken)
+        {
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    await action(e.Current);
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+        }
+
+        public static async UniTask ForEachAwaitAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Int32, UniTask> action, CancellationToken cancellationToken)
+        {
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                int index = 0;
+                while (await e.MoveNextAsync())
+                {
+                    await action(e.Current, checked(index++));
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+        }
+
+        public static async UniTask ForEachAwaitWithCancellationAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask> action, CancellationToken cancellationToken)
+        {
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    await action(e.Current, cancellationToken);
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+        }
+
+        public static async UniTask ForEachAwaitWithCancellationAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Int32, CancellationToken, UniTask> action, CancellationToken cancellationToken)
+        {
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                int index = 0;
+                while (await e.MoveNextAsync())
+                {
+                    await action(e.Current, checked(index++), cancellationToken);
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/ForEach.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/ForEach.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ca8d7f8177ba16140920af405aea3fd4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/GroupBy.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/GroupBy.cs
@@ -1,0 +1,923 @@
+﻿using Cysharp.Threading.Tasks.Internal;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        // Ix-Async returns IGrouping but it is competely waste, use standard IGrouping.
+
+        public static IUniTaskAsyncEnumerable<IGrouping<TKey, TSource>> GroupBy<TSource, TKey>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            return new GroupBy<TSource, TKey, TSource>(source, keySelector, x => x, EqualityComparer<TKey>.Default);
+        }
+
+        public static IUniTaskAsyncEnumerable<IGrouping<TKey, TSource>> GroupBy<TSource, TKey>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            Error.ThrowArgumentNullException(comparer, nameof(comparer));
+            return new GroupBy<TSource, TKey, TSource>(source, keySelector, x => x, comparer);
+        }
+
+        public static IUniTaskAsyncEnumerable<IGrouping<TKey, TElement>> GroupBy<TSource, TKey, TElement>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            Error.ThrowArgumentNullException(elementSelector, nameof(elementSelector));
+            return new GroupBy<TSource, TKey, TElement>(source, keySelector, elementSelector, EqualityComparer<TKey>.Default);
+        }
+
+        public static IUniTaskAsyncEnumerable<IGrouping<TKey, TElement>> GroupBy<TSource, TKey, TElement>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            Error.ThrowArgumentNullException(elementSelector, nameof(elementSelector));
+            Error.ThrowArgumentNullException(comparer, nameof(comparer));
+            return new GroupBy<TSource, TKey, TElement>(source, keySelector, elementSelector, comparer);
+        }
+
+        public static IUniTaskAsyncEnumerable<TResult> GroupBy<TSource, TKey, TResult>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TKey, IEnumerable<TSource>, TResult> resultSelector)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            Error.ThrowArgumentNullException(resultSelector, nameof(resultSelector));
+            return new GroupBy<TSource, TKey, TSource, TResult>(source, keySelector, x => x, resultSelector, EqualityComparer<TKey>.Default);
+        }
+
+        public static IUniTaskAsyncEnumerable<TResult> GroupBy<TSource, TKey, TResult>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TKey, IEnumerable<TSource>, TResult> resultSelector, IEqualityComparer<TKey> comparer)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            Error.ThrowArgumentNullException(resultSelector, nameof(resultSelector));
+            Error.ThrowArgumentNullException(comparer, nameof(comparer));
+            return new GroupBy<TSource, TKey, TSource, TResult>(source, keySelector, x => x, resultSelector, comparer);
+        }
+
+        public static IUniTaskAsyncEnumerable<TResult> GroupBy<TSource, TKey, TElement, TResult>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, Func<TKey, IEnumerable<TElement>, TResult> resultSelector)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            Error.ThrowArgumentNullException(elementSelector, nameof(elementSelector));
+            Error.ThrowArgumentNullException(resultSelector, nameof(resultSelector));
+            return new GroupBy<TSource, TKey, TElement, TResult>(source, keySelector, elementSelector, resultSelector, EqualityComparer<TKey>.Default);
+        }
+        public static IUniTaskAsyncEnumerable<TResult> GroupBy<TSource, TKey, TElement, TResult>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, Func<TKey, IEnumerable<TElement>, TResult> resultSelector, IEqualityComparer<TKey> comparer)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            Error.ThrowArgumentNullException(elementSelector, nameof(elementSelector));
+            Error.ThrowArgumentNullException(resultSelector, nameof(resultSelector));
+            Error.ThrowArgumentNullException(comparer, nameof(comparer));
+            return new GroupBy<TSource, TKey, TElement, TResult>(source, keySelector, elementSelector, resultSelector, comparer);
+        }
+
+        // await
+
+        public static IUniTaskAsyncEnumerable<IGrouping<TKey, TSource>> GroupByAwait<TSource, TKey>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<TKey>> keySelector)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            return new GroupByAwait<TSource, TKey, TSource>(source, keySelector, x => UniTask.FromResult(x), EqualityComparer<TKey>.Default);
+        }
+
+        public static IUniTaskAsyncEnumerable<IGrouping<TKey, TSource>> GroupByAwait<TSource, TKey>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<TKey>> keySelector, IEqualityComparer<TKey> comparer)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            Error.ThrowArgumentNullException(comparer, nameof(comparer));
+            return new GroupByAwait<TSource, TKey, TSource>(source, keySelector, x => UniTask.FromResult(x), comparer);
+        }
+
+        public static IUniTaskAsyncEnumerable<IGrouping<TKey, TElement>> GroupByAwait<TSource, TKey, TElement>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<TKey>> keySelector, Func<TSource, UniTask<TElement>> elementSelector)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            Error.ThrowArgumentNullException(elementSelector, nameof(elementSelector));
+            return new GroupByAwait<TSource, TKey, TElement>(source, keySelector, elementSelector, EqualityComparer<TKey>.Default);
+        }
+
+        public static IUniTaskAsyncEnumerable<IGrouping<TKey, TElement>> GroupByAwait<TSource, TKey, TElement>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<TKey>> keySelector, Func<TSource, UniTask<TElement>> elementSelector, IEqualityComparer<TKey> comparer)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            Error.ThrowArgumentNullException(elementSelector, nameof(elementSelector));
+            Error.ThrowArgumentNullException(comparer, nameof(comparer));
+            return new GroupByAwait<TSource, TKey, TElement>(source, keySelector, elementSelector, comparer);
+        }
+
+        public static IUniTaskAsyncEnumerable<TResult> GroupByAwait<TSource, TKey, TResult>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<TKey>> keySelector, Func<TKey, IEnumerable<TSource>, UniTask<TResult>> resultSelector)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            Error.ThrowArgumentNullException(resultSelector, nameof(resultSelector));
+            return new GroupByAwait<TSource, TKey, TSource, TResult>(source, keySelector, x => UniTask.FromResult(x), resultSelector, EqualityComparer<TKey>.Default);
+        }
+
+        public static IUniTaskAsyncEnumerable<TResult> GroupByAwait<TSource, TKey, TElement, TResult>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<TKey>> keySelector, Func<TSource, UniTask<TElement>> elementSelector, Func<TKey, IEnumerable<TElement>, UniTask<TResult>> resultSelector)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            Error.ThrowArgumentNullException(elementSelector, nameof(elementSelector));
+            Error.ThrowArgumentNullException(resultSelector, nameof(resultSelector));
+            return new GroupByAwait<TSource, TKey, TElement, TResult>(source, keySelector, elementSelector, resultSelector, EqualityComparer<TKey>.Default);
+        }
+
+        public static IUniTaskAsyncEnumerable<TResult> GroupByAwait<TSource, TKey, TResult>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<TKey>> keySelector, Func<TKey, IEnumerable<TSource>, UniTask<TResult>> resultSelector, IEqualityComparer<TKey> comparer)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            Error.ThrowArgumentNullException(resultSelector, nameof(resultSelector));
+            Error.ThrowArgumentNullException(comparer, nameof(comparer));
+            return new GroupByAwait<TSource, TKey, TSource, TResult>(source, keySelector, x => UniTask.FromResult(x), resultSelector, comparer);
+        }
+
+        public static IUniTaskAsyncEnumerable<TResult> GroupByAwait<TSource, TKey, TElement, TResult>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<TKey>> keySelector, Func<TSource, UniTask<TElement>> elementSelector, Func<TKey, IEnumerable<TElement>, UniTask<TResult>> resultSelector, IEqualityComparer<TKey> comparer)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            Error.ThrowArgumentNullException(elementSelector, nameof(elementSelector));
+            Error.ThrowArgumentNullException(resultSelector, nameof(resultSelector));
+            Error.ThrowArgumentNullException(comparer, nameof(comparer));
+            return new GroupByAwait<TSource, TKey, TElement, TResult>(source, keySelector, elementSelector, resultSelector, comparer);
+        }
+
+        // with ct
+
+        public static IUniTaskAsyncEnumerable<IGrouping<TKey, TSource>> GroupByAwaitWithCancellation<TSource, TKey>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<TKey>> keySelector)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            return new GroupByAwaitWithCancellation<TSource, TKey, TSource>(source, keySelector, (x, _) => UniTask.FromResult(x), EqualityComparer<TKey>.Default);
+        }
+
+        public static IUniTaskAsyncEnumerable<IGrouping<TKey, TSource>> GroupByAwaitWithCancellation<TSource, TKey>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<TKey>> keySelector, IEqualityComparer<TKey> comparer)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            Error.ThrowArgumentNullException(comparer, nameof(comparer));
+            return new GroupByAwaitWithCancellation<TSource, TKey, TSource>(source, keySelector, (x, _) => UniTask.FromResult(x), comparer);
+        }
+
+        public static IUniTaskAsyncEnumerable<IGrouping<TKey, TElement>> GroupByAwaitWithCancellation<TSource, TKey, TElement>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<TKey>> keySelector, Func<TSource, CancellationToken, UniTask<TElement>> elementSelector)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            Error.ThrowArgumentNullException(elementSelector, nameof(elementSelector));
+            return new GroupByAwaitWithCancellation<TSource, TKey, TElement>(source, keySelector, elementSelector, EqualityComparer<TKey>.Default);
+        }
+
+        public static IUniTaskAsyncEnumerable<IGrouping<TKey, TElement>> GroupByAwaitWithCancellation<TSource, TKey, TElement>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<TKey>> keySelector, Func<TSource, CancellationToken, UniTask<TElement>> elementSelector, IEqualityComparer<TKey> comparer)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            Error.ThrowArgumentNullException(elementSelector, nameof(elementSelector));
+            Error.ThrowArgumentNullException(comparer, nameof(comparer));
+            return new GroupByAwaitWithCancellation<TSource, TKey, TElement>(source, keySelector, elementSelector, comparer);
+        }
+
+        public static IUniTaskAsyncEnumerable<TResult> GroupByAwaitWithCancellation<TSource, TKey, TResult>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<TKey>> keySelector, Func<TKey, IEnumerable<TSource>, CancellationToken, UniTask<TResult>> resultSelector)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            Error.ThrowArgumentNullException(resultSelector, nameof(resultSelector));
+            return new GroupByAwaitWithCancellation<TSource, TKey, TSource, TResult>(source, keySelector, (x, _) => UniTask.FromResult(x), resultSelector, EqualityComparer<TKey>.Default);
+        }
+
+        public static IUniTaskAsyncEnumerable<TResult> GroupByAwaitWithCancellation<TSource, TKey, TElement, TResult>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<TKey>> keySelector, Func<TSource, CancellationToken, UniTask<TElement>> elementSelector, Func<TKey, IEnumerable<TElement>, CancellationToken, UniTask<TResult>> resultSelector)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            Error.ThrowArgumentNullException(elementSelector, nameof(elementSelector));
+            Error.ThrowArgumentNullException(resultSelector, nameof(resultSelector));
+            return new GroupByAwaitWithCancellation<TSource, TKey, TElement, TResult>(source, keySelector, elementSelector, resultSelector, EqualityComparer<TKey>.Default);
+        }
+
+        public static IUniTaskAsyncEnumerable<TResult> GroupByAwaitWithCancellation<TSource, TKey, TResult>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<TKey>> keySelector, Func<TKey, IEnumerable<TSource>, CancellationToken, UniTask<TResult>> resultSelector, IEqualityComparer<TKey> comparer)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            Error.ThrowArgumentNullException(resultSelector, nameof(resultSelector));
+            Error.ThrowArgumentNullException(comparer, nameof(comparer));
+            return new GroupByAwaitWithCancellation<TSource, TKey, TSource, TResult>(source, keySelector, (x, _) => UniTask.FromResult(x), resultSelector, comparer);
+        }
+
+        public static IUniTaskAsyncEnumerable<TResult> GroupByAwaitWithCancellation<TSource, TKey, TElement, TResult>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<TKey>> keySelector, Func<TSource, CancellationToken, UniTask<TElement>> elementSelector, Func<TKey, IEnumerable<TElement>, CancellationToken, UniTask<TResult>> resultSelector, IEqualityComparer<TKey> comparer)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            Error.ThrowArgumentNullException(elementSelector, nameof(elementSelector));
+            Error.ThrowArgumentNullException(resultSelector, nameof(resultSelector));
+            Error.ThrowArgumentNullException(comparer, nameof(comparer));
+            return new GroupByAwaitWithCancellation<TSource, TKey, TElement, TResult>(source, keySelector, elementSelector, resultSelector, comparer);
+        }
+    }
+
+    internal sealed class GroupBy<TSource, TKey, TElement> : IUniTaskAsyncEnumerable<IGrouping<TKey, TElement>>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+        readonly Func<TSource, TKey> keySelector;
+        readonly Func<TSource, TElement> elementSelector;
+        readonly IEqualityComparer<TKey> comparer;
+
+        public GroupBy(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer)
+        {
+            this.source = source;
+            this.keySelector = keySelector;
+            this.elementSelector = elementSelector;
+            this.comparer = comparer;
+        }
+
+        public IUniTaskAsyncEnumerator<IGrouping<TKey, TElement>> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _GroupBy(source, keySelector, elementSelector, comparer, cancellationToken);
+        }
+
+        sealed class _GroupBy : MoveNextSource, IUniTaskAsyncEnumerator<IGrouping<TKey, TElement>>
+        {
+            readonly IUniTaskAsyncEnumerable<TSource> source;
+            readonly Func<TSource, TKey> keySelector;
+            readonly Func<TSource, TElement> elementSelector;
+            readonly IEqualityComparer<TKey> comparer;
+            CancellationToken cancellationToken;
+
+            IEnumerator<IGrouping<TKey, TElement>> groupEnumerator;
+
+            public _GroupBy(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer, CancellationToken cancellationToken)
+            {
+                this.source = source;
+                this.keySelector = keySelector;
+                this.elementSelector = elementSelector;
+                this.comparer = comparer;
+                this.cancellationToken = cancellationToken;
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public IGrouping<TKey, TElement> Current { get; private set; }
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                completionSource.Reset();
+
+                if (groupEnumerator == null)
+                {
+                    CreateLookup().Forget();
+                }
+                else
+                {
+                    SourceMoveNext();
+                }
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            async UniTaskVoid CreateLookup()
+            {
+                try
+                {
+                    var lookup = await source.ToLookupAsync(keySelector, elementSelector, comparer, cancellationToken);
+                    groupEnumerator = lookup.GetEnumerator();
+                }
+                catch (Exception ex)
+                {
+                    completionSource.TrySetException(ex);
+                    return;
+                }
+                SourceMoveNext();
+            }
+
+            void SourceMoveNext()
+            {
+                try
+                {
+                    if (groupEnumerator.MoveNext())
+                    {
+                        Current = groupEnumerator.Current as IGrouping<TKey, TElement>;
+                        completionSource.TrySetResult(true);
+                    }
+                    else
+                    {
+                        completionSource.TrySetResult(false);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    completionSource.TrySetException(ex);
+                    return;
+                }
+            }
+
+            public UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                if (groupEnumerator != null)
+                {
+                    groupEnumerator.Dispose();
+                }
+
+                return default;
+            }
+        }
+    }
+
+    internal sealed class GroupBy<TSource, TKey, TElement, TResult> : IUniTaskAsyncEnumerable<TResult>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+        readonly Func<TSource, TKey> keySelector;
+        readonly Func<TSource, TElement> elementSelector;
+        readonly Func<TKey, IEnumerable<TElement>, TResult> resultSelector;
+        readonly IEqualityComparer<TKey> comparer;
+
+        public GroupBy(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, Func<TKey, IEnumerable<TElement>, TResult> resultSelector, IEqualityComparer<TKey> comparer)
+        {
+            this.source = source;
+            this.keySelector = keySelector;
+            this.elementSelector = elementSelector;
+            this.resultSelector = resultSelector;
+            this.comparer = comparer;
+        }
+
+        public IUniTaskAsyncEnumerator<TResult> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _GroupBy(source, keySelector, elementSelector, resultSelector, comparer, cancellationToken);
+        }
+
+        sealed class _GroupBy : MoveNextSource, IUniTaskAsyncEnumerator<TResult>
+        {
+            readonly IUniTaskAsyncEnumerable<TSource> source;
+            readonly Func<TSource, TKey> keySelector;
+            readonly Func<TSource, TElement> elementSelector;
+            readonly Func<TKey, IEnumerable<TElement>, TResult> resultSelector;
+            readonly IEqualityComparer<TKey> comparer;
+            CancellationToken cancellationToken;
+
+            IEnumerator<IGrouping<TKey, TElement>> groupEnumerator;
+
+            public _GroupBy(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, Func<TKey, IEnumerable<TElement>, TResult> resultSelector, IEqualityComparer<TKey> comparer, CancellationToken cancellationToken)
+            {
+                this.source = source;
+                this.keySelector = keySelector;
+                this.elementSelector = elementSelector;
+                this.resultSelector = resultSelector;
+                this.comparer = comparer;
+                this.cancellationToken = cancellationToken;
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public TResult Current { get; private set; }
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                completionSource.Reset();
+
+                if (groupEnumerator == null)
+                {
+                    CreateLookup().Forget();
+                }
+                else
+                {
+                    SourceMoveNext();
+                }
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            async UniTaskVoid CreateLookup()
+            {
+                try
+                {
+                    var lookup = await source.ToLookupAsync(keySelector, elementSelector, comparer, cancellationToken);
+                    groupEnumerator = lookup.GetEnumerator();
+                }
+                catch (Exception ex)
+                {
+                    completionSource.TrySetException(ex);
+                    return;
+                }
+                SourceMoveNext();
+            }
+
+            void SourceMoveNext()
+            {
+                try
+                {
+                    if (groupEnumerator.MoveNext())
+                    {
+                        var current = groupEnumerator.Current;
+                        Current = resultSelector(current.Key, current);
+                        completionSource.TrySetResult(true);
+                    }
+                    else
+                    {
+                        completionSource.TrySetResult(false);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    completionSource.TrySetException(ex);
+                    return;
+                }
+            }
+
+            public UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                if (groupEnumerator != null)
+                {
+                    groupEnumerator.Dispose();
+                }
+
+                return default;
+            }
+        }
+    }
+
+    internal sealed class GroupByAwait<TSource, TKey, TElement> : IUniTaskAsyncEnumerable<IGrouping<TKey, TElement>>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+        readonly Func<TSource, UniTask<TKey>> keySelector;
+        readonly Func<TSource, UniTask<TElement>> elementSelector;
+        readonly IEqualityComparer<TKey> comparer;
+
+        public GroupByAwait(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<TKey>> keySelector, Func<TSource, UniTask<TElement>> elementSelector, IEqualityComparer<TKey> comparer)
+        {
+            this.source = source;
+            this.keySelector = keySelector;
+            this.elementSelector = elementSelector;
+            this.comparer = comparer;
+        }
+
+        public IUniTaskAsyncEnumerator<IGrouping<TKey, TElement>> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _GroupByAwait(source, keySelector, elementSelector, comparer, cancellationToken);
+        }
+
+        sealed class _GroupByAwait : MoveNextSource, IUniTaskAsyncEnumerator<IGrouping<TKey, TElement>>
+        {
+            readonly IUniTaskAsyncEnumerable<TSource> source;
+            readonly Func<TSource, UniTask<TKey>> keySelector;
+            readonly Func<TSource, UniTask<TElement>> elementSelector;
+            readonly IEqualityComparer<TKey> comparer;
+            CancellationToken cancellationToken;
+
+            IEnumerator<IGrouping<TKey, TElement>> groupEnumerator;
+
+            public _GroupByAwait(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<TKey>> keySelector, Func<TSource, UniTask<TElement>> elementSelector, IEqualityComparer<TKey> comparer, CancellationToken cancellationToken)
+            {
+                this.source = source;
+                this.keySelector = keySelector;
+                this.elementSelector = elementSelector;
+                this.comparer = comparer;
+                this.cancellationToken = cancellationToken;
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public IGrouping<TKey, TElement> Current { get; private set; }
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                completionSource.Reset();
+
+                if (groupEnumerator == null)
+                {
+                    CreateLookup().Forget();
+                }
+                else
+                {
+                    SourceMoveNext();
+                }
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            async UniTaskVoid CreateLookup()
+            {
+                try
+                {
+                    var lookup = await source.ToLookupAwaitAsync(keySelector, elementSelector, comparer, cancellationToken);
+                    groupEnumerator = lookup.GetEnumerator();
+                }
+                catch (Exception ex)
+                {
+                    completionSource.TrySetException(ex);
+                    return;
+                }
+                SourceMoveNext();
+            }
+
+            void SourceMoveNext()
+            {
+                try
+                {
+                    if (groupEnumerator.MoveNext())
+                    {
+                        Current = groupEnumerator.Current as IGrouping<TKey, TElement>;
+                        completionSource.TrySetResult(true);
+                    }
+                    else
+                    {
+                        completionSource.TrySetResult(false);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    completionSource.TrySetException(ex);
+                    return;
+                }
+            }
+
+            public UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                if (groupEnumerator != null)
+                {
+                    groupEnumerator.Dispose();
+                }
+
+                return default;
+            }
+        }
+    }
+
+    internal sealed class GroupByAwait<TSource, TKey, TElement, TResult> : IUniTaskAsyncEnumerable<TResult>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+        readonly Func<TSource, UniTask<TKey>> keySelector;
+        readonly Func<TSource, UniTask<TElement>> elementSelector;
+        readonly Func<TKey, IEnumerable<TElement>, UniTask<TResult>> resultSelector;
+        readonly IEqualityComparer<TKey> comparer;
+
+        public GroupByAwait(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<TKey>> keySelector, Func<TSource, UniTask<TElement>> elementSelector, Func<TKey, IEnumerable<TElement>, UniTask<TResult>> resultSelector, IEqualityComparer<TKey> comparer)
+        {
+            this.source = source;
+            this.keySelector = keySelector;
+            this.elementSelector = elementSelector;
+            this.resultSelector = resultSelector;
+            this.comparer = comparer;
+        }
+
+        public IUniTaskAsyncEnumerator<TResult> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _GroupByAwait(source, keySelector, elementSelector, resultSelector, comparer, cancellationToken);
+        }
+
+        sealed class _GroupByAwait : MoveNextSource, IUniTaskAsyncEnumerator<TResult>
+        {
+            readonly static Action<object> ResultSelectCoreDelegate = ResultSelectCore;
+
+            readonly IUniTaskAsyncEnumerable<TSource> source;
+            readonly Func<TSource, UniTask<TKey>> keySelector;
+            readonly Func<TSource, UniTask<TElement>> elementSelector;
+            readonly Func<TKey, IEnumerable<TElement>, UniTask<TResult>> resultSelector;
+            readonly IEqualityComparer<TKey> comparer;
+            CancellationToken cancellationToken;
+
+            IEnumerator<IGrouping<TKey, TElement>> groupEnumerator;
+            UniTask<TResult>.Awaiter awaiter;
+
+            public _GroupByAwait(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<TKey>> keySelector, Func<TSource, UniTask<TElement>> elementSelector, Func<TKey, IEnumerable<TElement>, UniTask<TResult>> resultSelector, IEqualityComparer<TKey> comparer, CancellationToken cancellationToken)
+            {
+                this.source = source;
+                this.keySelector = keySelector;
+                this.elementSelector = elementSelector;
+                this.resultSelector = resultSelector;
+                this.comparer = comparer;
+                this.cancellationToken = cancellationToken;
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public TResult Current { get; private set; }
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                completionSource.Reset();
+
+                if (groupEnumerator == null)
+                {
+                    CreateLookup().Forget();
+                }
+                else
+                {
+                    SourceMoveNext();
+                }
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            async UniTaskVoid CreateLookup()
+            {
+                try
+                {
+                    var lookup = await source.ToLookupAwaitAsync(keySelector, elementSelector, comparer, cancellationToken);
+                    groupEnumerator = lookup.GetEnumerator();
+                }
+                catch (Exception ex)
+                {
+                    completionSource.TrySetException(ex);
+                    return;
+                }
+                SourceMoveNext();
+            }
+
+            void SourceMoveNext()
+            {
+                try
+                {
+                    if (groupEnumerator.MoveNext())
+                    {
+                        var current = groupEnumerator.Current;
+
+                        awaiter = resultSelector(current.Key, current).GetAwaiter();
+                        if (awaiter.IsCompleted)
+                        {
+                            ResultSelectCore(this);
+                        }
+                        else
+                        {
+                            awaiter.SourceOnCompleted(ResultSelectCoreDelegate, this);
+                        }
+                        return;
+                    }
+                    else
+                    {
+                        completionSource.TrySetResult(false);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    completionSource.TrySetException(ex);
+                    return;
+                }
+            }
+
+            static void ResultSelectCore(object state)
+            {
+                var self = (_GroupByAwait)state;
+
+                if (self.TryGetResult(self.awaiter, out var result))
+                {
+                    self.Current = result;
+                    self.completionSource.TrySetResult(true);
+                }
+            }
+
+            public UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                if (groupEnumerator != null)
+                {
+                    groupEnumerator.Dispose();
+                }
+
+                return default;
+            }
+        }
+    }
+
+    internal sealed class GroupByAwaitWithCancellation<TSource, TKey, TElement> : IUniTaskAsyncEnumerable<IGrouping<TKey, TElement>>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+        readonly Func<TSource, CancellationToken, UniTask<TKey>> keySelector;
+        readonly Func<TSource, CancellationToken, UniTask<TElement>> elementSelector;
+        readonly IEqualityComparer<TKey> comparer;
+
+        public GroupByAwaitWithCancellation(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<TKey>> keySelector, Func<TSource, CancellationToken, UniTask<TElement>> elementSelector, IEqualityComparer<TKey> comparer)
+        {
+            this.source = source;
+            this.keySelector = keySelector;
+            this.elementSelector = elementSelector;
+            this.comparer = comparer;
+        }
+
+        public IUniTaskAsyncEnumerator<IGrouping<TKey, TElement>> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _GroupByAwaitWithCancellation(source, keySelector, elementSelector, comparer, cancellationToken);
+        }
+
+        sealed class _GroupByAwaitWithCancellation : MoveNextSource, IUniTaskAsyncEnumerator<IGrouping<TKey, TElement>>
+        {
+            readonly IUniTaskAsyncEnumerable<TSource> source;
+            readonly Func<TSource, CancellationToken, UniTask<TKey>> keySelector;
+            readonly Func<TSource, CancellationToken, UniTask<TElement>> elementSelector;
+            readonly IEqualityComparer<TKey> comparer;
+            CancellationToken cancellationToken;
+
+            IEnumerator<IGrouping<TKey, TElement>> groupEnumerator;
+
+            public _GroupByAwaitWithCancellation(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<TKey>> keySelector, Func<TSource, CancellationToken, UniTask<TElement>> elementSelector, IEqualityComparer<TKey> comparer, CancellationToken cancellationToken)
+            {
+                this.source = source;
+                this.keySelector = keySelector;
+                this.elementSelector = elementSelector;
+                this.comparer = comparer;
+                this.cancellationToken = cancellationToken;
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public IGrouping<TKey, TElement> Current { get; private set; }
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                completionSource.Reset();
+
+                if (groupEnumerator == null)
+                {
+                    CreateLookup().Forget();
+                }
+                else
+                {
+                    SourceMoveNext();
+                }
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            async UniTaskVoid CreateLookup()
+            {
+                try
+                {
+                    var lookup = await source.ToLookupAwaitWithCancellationAsync(keySelector, elementSelector, comparer, cancellationToken);
+                    groupEnumerator = lookup.GetEnumerator();
+                }
+                catch (Exception ex)
+                {
+                    completionSource.TrySetException(ex);
+                    return;
+                }
+                SourceMoveNext();
+            }
+
+            void SourceMoveNext()
+            {
+                try
+                {
+                    if (groupEnumerator.MoveNext())
+                    {
+                        Current = groupEnumerator.Current as IGrouping<TKey, TElement>;
+                        completionSource.TrySetResult(true);
+                    }
+                    else
+                    {
+                        completionSource.TrySetResult(false);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    completionSource.TrySetException(ex);
+                    return;
+                }
+            }
+
+            public UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                if (groupEnumerator != null)
+                {
+                    groupEnumerator.Dispose();
+                }
+
+                return default;
+            }
+        }
+    }
+
+    internal sealed class GroupByAwaitWithCancellation<TSource, TKey, TElement, TResult> : IUniTaskAsyncEnumerable<TResult>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+        readonly Func<TSource, CancellationToken, UniTask<TKey>> keySelector;
+        readonly Func<TSource, CancellationToken, UniTask<TElement>> elementSelector;
+        readonly Func<TKey, IEnumerable<TElement>, CancellationToken, UniTask<TResult>> resultSelector;
+        readonly IEqualityComparer<TKey> comparer;
+
+        public GroupByAwaitWithCancellation(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<TKey>> keySelector, Func<TSource, CancellationToken, UniTask<TElement>> elementSelector, Func<TKey, IEnumerable<TElement>, CancellationToken, UniTask<TResult>> resultSelector, IEqualityComparer<TKey> comparer)
+        {
+            this.source = source;
+            this.keySelector = keySelector;
+            this.elementSelector = elementSelector;
+            this.resultSelector = resultSelector;
+            this.comparer = comparer;
+        }
+
+        public IUniTaskAsyncEnumerator<TResult> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _GroupByAwaitWithCancellation(source, keySelector, elementSelector, resultSelector, comparer, cancellationToken);
+        }
+
+        sealed class _GroupByAwaitWithCancellation : MoveNextSource, IUniTaskAsyncEnumerator<TResult>
+        {
+            readonly static Action<object> ResultSelectCoreDelegate = ResultSelectCore;
+
+            readonly IUniTaskAsyncEnumerable<TSource> source;
+            readonly Func<TSource, CancellationToken, UniTask<TKey>> keySelector;
+            readonly Func<TSource, CancellationToken, UniTask<TElement>> elementSelector;
+            readonly Func<TKey, IEnumerable<TElement>, CancellationToken, UniTask<TResult>> resultSelector;
+            readonly IEqualityComparer<TKey> comparer;
+            CancellationToken cancellationToken;
+
+            IEnumerator<IGrouping<TKey, TElement>> groupEnumerator;
+            UniTask<TResult>.Awaiter awaiter;
+
+            public _GroupByAwaitWithCancellation(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<TKey>> keySelector, Func<TSource, CancellationToken, UniTask<TElement>> elementSelector, Func<TKey, IEnumerable<TElement>, CancellationToken, UniTask<TResult>> resultSelector, IEqualityComparer<TKey> comparer, CancellationToken cancellationToken)
+            {
+                this.source = source;
+                this.keySelector = keySelector;
+                this.elementSelector = elementSelector;
+                this.resultSelector = resultSelector;
+                this.comparer = comparer;
+                this.cancellationToken = cancellationToken;
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public TResult Current { get; private set; }
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                completionSource.Reset();
+
+                if (groupEnumerator == null)
+                {
+                    CreateLookup().Forget();
+                }
+                else
+                {
+                    SourceMoveNext();
+                }
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            async UniTaskVoid CreateLookup()
+            {
+                try
+                {
+                    var lookup = await source.ToLookupAwaitWithCancellationAsync(keySelector, elementSelector, comparer, cancellationToken);
+                    groupEnumerator = lookup.GetEnumerator();
+                }
+                catch (Exception ex)
+                {
+                    completionSource.TrySetException(ex);
+                    return;
+                }
+                SourceMoveNext();
+            }
+
+            void SourceMoveNext()
+            {
+                try
+                {
+                    if (groupEnumerator.MoveNext())
+                    {
+                        var current = groupEnumerator.Current;
+
+                        awaiter = resultSelector(current.Key, current, cancellationToken).GetAwaiter();
+                        if (awaiter.IsCompleted)
+                        {
+                            ResultSelectCore(this);
+                        }
+                        else
+                        {
+                            awaiter.SourceOnCompleted(ResultSelectCoreDelegate, this);
+                        }
+                        return;
+                    }
+                    else
+                    {
+                        completionSource.TrySetResult(false);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    completionSource.TrySetException(ex);
+                    return;
+                }
+            }
+
+            static void ResultSelectCore(object state)
+            {
+                var self = (_GroupByAwaitWithCancellation)state;
+
+                if (self.TryGetResult(self.awaiter, out var result))
+                {
+                    self.Current = result;
+                    self.completionSource.TrySetResult(true);
+                }
+            }
+
+            public UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                if (groupEnumerator != null)
+                {
+                    groupEnumerator.Dispose();
+                }
+
+                return default;
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/GroupBy.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/GroupBy.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a2de80df1cc8a1240ab0ee7badd334d0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/GroupJoin.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/GroupJoin.cs
@@ -1,0 +1,612 @@
+﻿using Cysharp.Threading.Tasks.Internal;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static IUniTaskAsyncEnumerable<TResult> GroupJoin<TOuter, TInner, TKey, TResult>(this IUniTaskAsyncEnumerable<TOuter> outer, IUniTaskAsyncEnumerable<TInner> inner, Func<TOuter, TKey> outerKeySelector, Func<TInner, TKey> innerKeySelector, Func<TOuter, IEnumerable<TInner>, TResult> resultSelector)
+        {
+            Error.ThrowArgumentNullException(outer, nameof(outer));
+            Error.ThrowArgumentNullException(inner, nameof(inner));
+            Error.ThrowArgumentNullException(outerKeySelector, nameof(outerKeySelector));
+            Error.ThrowArgumentNullException(innerKeySelector, nameof(innerKeySelector));
+            Error.ThrowArgumentNullException(resultSelector, nameof(resultSelector));
+
+            return new GroupJoin<TOuter, TInner, TKey, TResult>(outer, inner, outerKeySelector, innerKeySelector, resultSelector, EqualityComparer<TKey>.Default);
+        }
+
+        public static IUniTaskAsyncEnumerable<TResult> GroupJoin<TOuter, TInner, TKey, TResult>(this IUniTaskAsyncEnumerable<TOuter> outer, IUniTaskAsyncEnumerable<TInner> inner, Func<TOuter, TKey> outerKeySelector, Func<TInner, TKey> innerKeySelector, Func<TOuter, IEnumerable<TInner>, TResult> resultSelector, IEqualityComparer<TKey> comparer)
+        {
+            Error.ThrowArgumentNullException(outer, nameof(outer));
+            Error.ThrowArgumentNullException(inner, nameof(inner));
+            Error.ThrowArgumentNullException(outerKeySelector, nameof(outerKeySelector));
+            Error.ThrowArgumentNullException(innerKeySelector, nameof(innerKeySelector));
+            Error.ThrowArgumentNullException(resultSelector, nameof(resultSelector));
+            Error.ThrowArgumentNullException(comparer, nameof(comparer));
+
+            return new GroupJoin<TOuter, TInner, TKey, TResult>(outer, inner, outerKeySelector, innerKeySelector, resultSelector, comparer);
+        }
+
+        public static IUniTaskAsyncEnumerable<TResult> GroupJoinAwait<TOuter, TInner, TKey, TResult>(this IUniTaskAsyncEnumerable<TOuter> outer, IUniTaskAsyncEnumerable<TInner> inner, Func<TOuter, UniTask<TKey>> outerKeySelector, Func<TInner, UniTask<TKey>> innerKeySelector, Func<TOuter, IEnumerable<TInner>, UniTask<TResult>> resultSelector)
+        {
+            Error.ThrowArgumentNullException(outer, nameof(outer));
+            Error.ThrowArgumentNullException(inner, nameof(inner));
+            Error.ThrowArgumentNullException(outerKeySelector, nameof(outerKeySelector));
+            Error.ThrowArgumentNullException(innerKeySelector, nameof(innerKeySelector));
+            Error.ThrowArgumentNullException(resultSelector, nameof(resultSelector));
+
+            return new GroupJoinAwait<TOuter, TInner, TKey, TResult>(outer, inner, outerKeySelector, innerKeySelector, resultSelector, EqualityComparer<TKey>.Default);
+        }
+
+        public static IUniTaskAsyncEnumerable<TResult> GroupJoinAwait<TOuter, TInner, TKey, TResult>(this IUniTaskAsyncEnumerable<TOuter> outer, IUniTaskAsyncEnumerable<TInner> inner, Func<TOuter, UniTask<TKey>> outerKeySelector, Func<TInner, UniTask<TKey>> innerKeySelector, Func<TOuter, IEnumerable<TInner>, UniTask<TResult>> resultSelector, IEqualityComparer<TKey> comparer)
+        {
+            Error.ThrowArgumentNullException(outer, nameof(outer));
+            Error.ThrowArgumentNullException(inner, nameof(inner));
+            Error.ThrowArgumentNullException(outerKeySelector, nameof(outerKeySelector));
+            Error.ThrowArgumentNullException(innerKeySelector, nameof(innerKeySelector));
+            Error.ThrowArgumentNullException(resultSelector, nameof(resultSelector));
+            Error.ThrowArgumentNullException(comparer, nameof(comparer));
+
+            return new GroupJoinAwait<TOuter, TInner, TKey, TResult>(outer, inner, outerKeySelector, innerKeySelector, resultSelector, comparer);
+        }
+
+        public static IUniTaskAsyncEnumerable<TResult> GroupJoinAwaitWithCancellation<TOuter, TInner, TKey, TResult>(this IUniTaskAsyncEnumerable<TOuter> outer, IUniTaskAsyncEnumerable<TInner> inner, Func<TOuter, CancellationToken, UniTask<TKey>> outerKeySelector, Func<TInner, CancellationToken, UniTask<TKey>> innerKeySelector, Func<TOuter, IEnumerable<TInner>, CancellationToken, UniTask<TResult>> resultSelector)
+        {
+            Error.ThrowArgumentNullException(outer, nameof(outer));
+            Error.ThrowArgumentNullException(inner, nameof(inner));
+            Error.ThrowArgumentNullException(outerKeySelector, nameof(outerKeySelector));
+            Error.ThrowArgumentNullException(innerKeySelector, nameof(innerKeySelector));
+            Error.ThrowArgumentNullException(resultSelector, nameof(resultSelector));
+
+            return new GroupJoinAwaitWithCancellation<TOuter, TInner, TKey, TResult>(outer, inner, outerKeySelector, innerKeySelector, resultSelector, EqualityComparer<TKey>.Default);
+        }
+
+        public static IUniTaskAsyncEnumerable<TResult> GroupJoinAwaitWithCancellation<TOuter, TInner, TKey, TResult>(this IUniTaskAsyncEnumerable<TOuter> outer, IUniTaskAsyncEnumerable<TInner> inner, Func<TOuter, CancellationToken, UniTask<TKey>> outerKeySelector, Func<TInner, CancellationToken, UniTask<TKey>> innerKeySelector, Func<TOuter, IEnumerable<TInner>, CancellationToken, UniTask<TResult>> resultSelector, IEqualityComparer<TKey> comparer)
+        {
+            Error.ThrowArgumentNullException(outer, nameof(outer));
+            Error.ThrowArgumentNullException(inner, nameof(inner));
+            Error.ThrowArgumentNullException(outerKeySelector, nameof(outerKeySelector));
+            Error.ThrowArgumentNullException(innerKeySelector, nameof(innerKeySelector));
+            Error.ThrowArgumentNullException(resultSelector, nameof(resultSelector));
+            Error.ThrowArgumentNullException(comparer, nameof(comparer));
+
+            return new GroupJoinAwaitWithCancellation<TOuter, TInner, TKey, TResult>(outer, inner, outerKeySelector, innerKeySelector, resultSelector, comparer);
+        }
+
+    }
+
+    internal sealed class GroupJoin<TOuter, TInner, TKey, TResult> : IUniTaskAsyncEnumerable<TResult>
+    {
+        readonly IUniTaskAsyncEnumerable<TOuter> outer;
+        readonly IUniTaskAsyncEnumerable<TInner> inner;
+        readonly Func<TOuter, TKey> outerKeySelector;
+        readonly Func<TInner, TKey> innerKeySelector;
+        readonly Func<TOuter, IEnumerable<TInner>, TResult> resultSelector;
+        readonly IEqualityComparer<TKey> comparer;
+
+        public GroupJoin(IUniTaskAsyncEnumerable<TOuter> outer, IUniTaskAsyncEnumerable<TInner> inner, Func<TOuter, TKey> outerKeySelector, Func<TInner, TKey> innerKeySelector, Func<TOuter, IEnumerable<TInner>, TResult> resultSelector, IEqualityComparer<TKey> comparer)
+        {
+            this.outer = outer;
+            this.inner = inner;
+            this.outerKeySelector = outerKeySelector;
+            this.innerKeySelector = innerKeySelector;
+            this.resultSelector = resultSelector;
+            this.comparer = comparer;
+        }
+
+        public IUniTaskAsyncEnumerator<TResult> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _GroupJoin(outer, inner, outerKeySelector, innerKeySelector, resultSelector, comparer, cancellationToken);
+        }
+
+        sealed class _GroupJoin : MoveNextSource, IUniTaskAsyncEnumerator<TResult>
+        {
+            static readonly Action<object> MoveNextCoreDelegate = MoveNextCore;
+
+            readonly IUniTaskAsyncEnumerable<TOuter> outer;
+            readonly IUniTaskAsyncEnumerable<TInner> inner;
+            readonly Func<TOuter, TKey> outerKeySelector;
+            readonly Func<TInner, TKey> innerKeySelector;
+            readonly Func<TOuter, IEnumerable<TInner>, TResult> resultSelector;
+            readonly IEqualityComparer<TKey> comparer;
+            CancellationToken cancellationToken;
+
+            ILookup<TKey, TInner> lookup;
+            IUniTaskAsyncEnumerator<TOuter> enumerator;
+            UniTask<bool>.Awaiter awaiter;
+
+
+            public _GroupJoin(IUniTaskAsyncEnumerable<TOuter> outer, IUniTaskAsyncEnumerable<TInner> inner, Func<TOuter, TKey> outerKeySelector, Func<TInner, TKey> innerKeySelector, Func<TOuter, IEnumerable<TInner>, TResult> resultSelector, IEqualityComparer<TKey> comparer, CancellationToken cancellationToken)
+            {
+                this.outer = outer;
+                this.inner = inner;
+                this.outerKeySelector = outerKeySelector;
+                this.innerKeySelector = innerKeySelector;
+                this.resultSelector = resultSelector;
+                this.comparer = comparer;
+                this.cancellationToken = cancellationToken;
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public TResult Current { get; private set; }
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                completionSource.Reset();
+
+                if (lookup == null)
+                {
+                    CreateLookup().Forget();
+                }
+                else
+                {
+                    SourceMoveNext();
+                }
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            async UniTaskVoid CreateLookup()
+            {
+                try
+                {
+                    lookup = await inner.ToLookupAsync(innerKeySelector, comparer, cancellationToken);
+                    enumerator = outer.GetAsyncEnumerator(cancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    completionSource.TrySetException(ex);
+                    return;
+                }
+                SourceMoveNext();
+            }
+
+            void SourceMoveNext()
+            {
+                try
+                {
+                    awaiter = enumerator.MoveNextAsync().GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        MoveNextCore(this);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(MoveNextCoreDelegate, this);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    completionSource.TrySetException(ex);
+                }
+            }
+
+            static void MoveNextCore(object state)
+            {
+                var self = (_GroupJoin)state;
+
+                if (self.TryGetResult(self.awaiter, out var result))
+                {
+                    if (result)
+                    {
+                        var outer = self.enumerator.Current;
+                        var key = self.outerKeySelector(outer);
+                        var values = self.lookup[key];
+
+                        self.Current = self.resultSelector(outer, values);
+                        self.completionSource.TrySetResult(true);
+                    }
+                    else
+                    {
+                        self.completionSource.TrySetResult(false);
+                    }
+                }
+            }
+
+            public UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                if (enumerator != null)
+                {
+                    return enumerator.DisposeAsync();
+                }
+
+                return default;
+            }
+        }
+    }
+
+    internal sealed class GroupJoinAwait<TOuter, TInner, TKey, TResult> : IUniTaskAsyncEnumerable<TResult>
+    {
+        readonly IUniTaskAsyncEnumerable<TOuter> outer;
+        readonly IUniTaskAsyncEnumerable<TInner> inner;
+        readonly Func<TOuter, UniTask<TKey>> outerKeySelector;
+        readonly Func<TInner, UniTask<TKey>> innerKeySelector;
+        readonly Func<TOuter, IEnumerable<TInner>, UniTask<TResult>> resultSelector;
+        readonly IEqualityComparer<TKey> comparer;
+
+        public GroupJoinAwait(IUniTaskAsyncEnumerable<TOuter> outer, IUniTaskAsyncEnumerable<TInner> inner, Func<TOuter, UniTask<TKey>> outerKeySelector, Func<TInner, UniTask<TKey>> innerKeySelector, Func<TOuter, IEnumerable<TInner>, UniTask<TResult>> resultSelector, IEqualityComparer<TKey> comparer)
+        {
+            this.outer = outer;
+            this.inner = inner;
+            this.outerKeySelector = outerKeySelector;
+            this.innerKeySelector = innerKeySelector;
+            this.resultSelector = resultSelector;
+            this.comparer = comparer;
+        }
+
+        public IUniTaskAsyncEnumerator<TResult> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _GroupJoinAwait(outer, inner, outerKeySelector, innerKeySelector, resultSelector, comparer, cancellationToken);
+        }
+
+        sealed class _GroupJoinAwait : MoveNextSource, IUniTaskAsyncEnumerator<TResult>
+        {
+            static readonly Action<object> MoveNextCoreDelegate = MoveNextCore;
+            readonly static Action<object> ResultSelectCoreDelegate = ResultSelectCore;
+            readonly static Action<object> OuterKeySelectCoreDelegate = OuterKeySelectCore;
+
+            readonly IUniTaskAsyncEnumerable<TOuter> outer;
+            readonly IUniTaskAsyncEnumerable<TInner> inner;
+            readonly Func<TOuter, UniTask<TKey>> outerKeySelector;
+            readonly Func<TInner, UniTask<TKey>> innerKeySelector;
+            readonly Func<TOuter, IEnumerable<TInner>, UniTask<TResult>> resultSelector;
+            readonly IEqualityComparer<TKey> comparer;
+            CancellationToken cancellationToken;
+
+            ILookup<TKey, TInner> lookup;
+            IUniTaskAsyncEnumerator<TOuter> enumerator;
+            TOuter outerValue;
+            UniTask<bool>.Awaiter awaiter;
+            UniTask<TKey>.Awaiter outerKeyAwaiter;
+            UniTask<TResult>.Awaiter resultAwaiter;
+
+
+            public _GroupJoinAwait(IUniTaskAsyncEnumerable<TOuter> outer, IUniTaskAsyncEnumerable<TInner> inner, Func<TOuter, UniTask<TKey>> outerKeySelector, Func<TInner, UniTask<TKey>> innerKeySelector, Func<TOuter, IEnumerable<TInner>, UniTask<TResult>> resultSelector, IEqualityComparer<TKey> comparer, CancellationToken cancellationToken)
+            {
+                this.outer = outer;
+                this.inner = inner;
+                this.outerKeySelector = outerKeySelector;
+                this.innerKeySelector = innerKeySelector;
+                this.resultSelector = resultSelector;
+                this.comparer = comparer;
+                this.cancellationToken = cancellationToken;
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public TResult Current { get; private set; }
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                completionSource.Reset();
+
+                if (lookup == null)
+                {
+                    CreateLookup().Forget();
+                }
+                else
+                {
+                    SourceMoveNext();
+                }
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            async UniTaskVoid CreateLookup()
+            {
+                try
+                {
+                    lookup = await inner.ToLookupAwaitAsync(innerKeySelector, comparer, cancellationToken);
+                    enumerator = outer.GetAsyncEnumerator(cancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    completionSource.TrySetException(ex);
+                    return;
+                }
+                SourceMoveNext();
+            }
+
+            void SourceMoveNext()
+            {
+                try
+                {
+                    awaiter = enumerator.MoveNextAsync().GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        MoveNextCore(this);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(MoveNextCoreDelegate, this);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    completionSource.TrySetException(ex);
+                }
+            }
+
+            static void MoveNextCore(object state)
+            {
+                var self = (_GroupJoinAwait)state;
+
+                if (self.TryGetResult(self.awaiter, out var result))
+                {
+                    if (result)
+                    {
+                        try
+                        {
+
+                            self.outerValue = self.enumerator.Current;
+                            self.outerKeyAwaiter = self.outerKeySelector(self.outerValue).GetAwaiter();
+                            if (self.outerKeyAwaiter.IsCompleted)
+                            {
+                                OuterKeySelectCore(self);
+                            }
+                            else
+                            {
+                                self.outerKeyAwaiter.SourceOnCompleted(OuterKeySelectCoreDelegate, self);
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            self.completionSource.TrySetException(ex);
+                        }
+                    }
+                    else
+                    {
+                        self.completionSource.TrySetResult(false);
+                    }
+                }
+            }
+
+            static void OuterKeySelectCore(object state)
+            {
+                var self = (_GroupJoinAwait)state;
+
+                if (self.TryGetResult(self.outerKeyAwaiter, out var result))
+                {
+                    try
+                    {
+                        var values = self.lookup[result];
+                        self.resultAwaiter = self.resultSelector(self.outerValue, values).GetAwaiter();
+                        if (self.resultAwaiter.IsCompleted)
+                        {
+                            ResultSelectCore(self);
+                        }
+                        else
+                        {
+                            self.resultAwaiter.SourceOnCompleted(ResultSelectCoreDelegate, self);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completionSource.TrySetException(ex);
+                    }
+                }
+            }
+
+            static void ResultSelectCore(object state)
+            {
+                var self = (_GroupJoinAwait)state;
+
+                if (self.TryGetResult(self.resultAwaiter, out var result))
+                {
+                    self.Current = result;
+                    self.completionSource.TrySetResult(true);
+                }
+            }
+
+            public UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                if (enumerator != null)
+                {
+                    return enumerator.DisposeAsync();
+                }
+
+                return default;
+            }
+        }
+    }
+
+    internal sealed class GroupJoinAwaitWithCancellation<TOuter, TInner, TKey, TResult> : IUniTaskAsyncEnumerable<TResult>
+    {
+        readonly IUniTaskAsyncEnumerable<TOuter> outer;
+        readonly IUniTaskAsyncEnumerable<TInner> inner;
+        readonly Func<TOuter, CancellationToken, UniTask<TKey>> outerKeySelector;
+        readonly Func<TInner, CancellationToken, UniTask<TKey>> innerKeySelector;
+        readonly Func<TOuter, IEnumerable<TInner>, CancellationToken, UniTask<TResult>> resultSelector;
+        readonly IEqualityComparer<TKey> comparer;
+
+        public GroupJoinAwaitWithCancellation(IUniTaskAsyncEnumerable<TOuter> outer, IUniTaskAsyncEnumerable<TInner> inner, Func<TOuter, CancellationToken, UniTask<TKey>> outerKeySelector, Func<TInner, CancellationToken, UniTask<TKey>> innerKeySelector, Func<TOuter, IEnumerable<TInner>, CancellationToken, UniTask<TResult>> resultSelector, IEqualityComparer<TKey> comparer)
+        {
+            this.outer = outer;
+            this.inner = inner;
+            this.outerKeySelector = outerKeySelector;
+            this.innerKeySelector = innerKeySelector;
+            this.resultSelector = resultSelector;
+            this.comparer = comparer;
+        }
+
+        public IUniTaskAsyncEnumerator<TResult> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _GroupJoinAwaitWithCancellation(outer, inner, outerKeySelector, innerKeySelector, resultSelector, comparer, cancellationToken);
+        }
+
+        sealed class _GroupJoinAwaitWithCancellation : MoveNextSource, IUniTaskAsyncEnumerator<TResult>
+        {
+            static readonly Action<object> MoveNextCoreDelegate = MoveNextCore;
+            readonly static Action<object> ResultSelectCoreDelegate = ResultSelectCore;
+            readonly static Action<object> OuterKeySelectCoreDelegate = OuterKeySelectCore;
+
+            readonly IUniTaskAsyncEnumerable<TOuter> outer;
+            readonly IUniTaskAsyncEnumerable<TInner> inner;
+            readonly Func<TOuter, CancellationToken, UniTask<TKey>> outerKeySelector;
+            readonly Func<TInner, CancellationToken, UniTask<TKey>> innerKeySelector;
+            readonly Func<TOuter, IEnumerable<TInner>, CancellationToken, UniTask<TResult>> resultSelector;
+            readonly IEqualityComparer<TKey> comparer;
+            CancellationToken cancellationToken;
+
+            ILookup<TKey, TInner> lookup;
+            IUniTaskAsyncEnumerator<TOuter> enumerator;
+            TOuter outerValue;
+            UniTask<bool>.Awaiter awaiter;
+            UniTask<TKey>.Awaiter outerKeyAwaiter;
+            UniTask<TResult>.Awaiter resultAwaiter;
+
+
+            public _GroupJoinAwaitWithCancellation(IUniTaskAsyncEnumerable<TOuter> outer, IUniTaskAsyncEnumerable<TInner> inner, Func<TOuter, CancellationToken, UniTask<TKey>> outerKeySelector, Func<TInner, CancellationToken, UniTask<TKey>> innerKeySelector, Func<TOuter, IEnumerable<TInner>, CancellationToken, UniTask<TResult>> resultSelector, IEqualityComparer<TKey> comparer, CancellationToken cancellationToken)
+            {
+                this.outer = outer;
+                this.inner = inner;
+                this.outerKeySelector = outerKeySelector;
+                this.innerKeySelector = innerKeySelector;
+                this.resultSelector = resultSelector;
+                this.comparer = comparer;
+                this.cancellationToken = cancellationToken;
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public TResult Current { get; private set; }
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                completionSource.Reset();
+
+                if (lookup == null)
+                {
+                    CreateLookup().Forget();
+                }
+                else
+                {
+                    SourceMoveNext();
+                }
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            async UniTaskVoid CreateLookup()
+            {
+                try
+                {
+                    lookup = await inner.ToLookupAwaitWithCancellationAsync(innerKeySelector, comparer, cancellationToken);
+                    enumerator = outer.GetAsyncEnumerator(cancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    completionSource.TrySetException(ex);
+                    return;
+                }
+                SourceMoveNext();
+            }
+
+            void SourceMoveNext()
+            {
+                try
+                {
+                    awaiter = enumerator.MoveNextAsync().GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        MoveNextCore(this);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(MoveNextCoreDelegate, this);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    completionSource.TrySetException(ex);
+                }
+            }
+
+            static void MoveNextCore(object state)
+            {
+                var self = (_GroupJoinAwaitWithCancellation)state;
+
+                if (self.TryGetResult(self.awaiter, out var result))
+                {
+                    if (result)
+                    {
+                        try
+                        {
+
+                            self.outerValue = self.enumerator.Current;
+                            self.outerKeyAwaiter = self.outerKeySelector(self.outerValue, self.cancellationToken).GetAwaiter();
+                            if (self.outerKeyAwaiter.IsCompleted)
+                            {
+                                OuterKeySelectCore(self);
+                            }
+                            else
+                            {
+                                self.outerKeyAwaiter.SourceOnCompleted(OuterKeySelectCoreDelegate, self);
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            self.completionSource.TrySetException(ex);
+                        }
+                    }
+                    else
+                    {
+                        self.completionSource.TrySetResult(false);
+                    }
+                }
+            }
+
+            static void OuterKeySelectCore(object state)
+            {
+                var self = (_GroupJoinAwaitWithCancellation)state;
+
+                if (self.TryGetResult(self.outerKeyAwaiter, out var result))
+                {
+                    try
+                    {
+                        var values = self.lookup[result];
+                        self.resultAwaiter = self.resultSelector(self.outerValue, values, self.cancellationToken).GetAwaiter();
+                        if (self.resultAwaiter.IsCompleted)
+                        {
+                            ResultSelectCore(self);
+                        }
+                        else
+                        {
+                            self.resultAwaiter.SourceOnCompleted(ResultSelectCoreDelegate, self);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        self.completionSource.TrySetException(ex);
+                    }
+                }
+            }
+
+            static void ResultSelectCore(object state)
+            {
+                var self = (_GroupJoinAwaitWithCancellation)state;
+
+                if (self.TryGetResult(self.resultAwaiter, out var result))
+                {
+                    self.Current = result;
+                    self.completionSource.TrySetResult(true);
+                }
+            }
+
+            public UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                if (enumerator != null)
+                {
+                    return enumerator.DisposeAsync();
+                }
+
+                return default;
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/GroupJoin.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/GroupJoin.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7bf7759d03bf3f64190d3ae83b182c2c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Intersect.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Intersect.cs
@@ -1,0 +1,117 @@
+﻿using Cysharp.Threading.Tasks.Internal;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static IUniTaskAsyncEnumerable<TSource> Intersect<TSource>(this IUniTaskAsyncEnumerable<TSource> first, IUniTaskAsyncEnumerable<TSource> second)
+        {
+            Error.ThrowArgumentNullException(first, nameof(first));
+            Error.ThrowArgumentNullException(second, nameof(second));
+
+            return new Intersect<TSource>(first, second, EqualityComparer<TSource>.Default);
+        }
+
+        public static IUniTaskAsyncEnumerable<TSource> Intersect<TSource>(this IUniTaskAsyncEnumerable<TSource> first, IUniTaskAsyncEnumerable<TSource> second, IEqualityComparer<TSource> comparer)
+        {
+            Error.ThrowArgumentNullException(first, nameof(first));
+            Error.ThrowArgumentNullException(second, nameof(second));
+            Error.ThrowArgumentNullException(comparer, nameof(comparer));
+
+            return new Intersect<TSource>(first, second, comparer);
+        }
+    }
+
+    internal sealed class Intersect<TSource> : IUniTaskAsyncEnumerable<TSource>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> first;
+        readonly IUniTaskAsyncEnumerable<TSource> second;
+        readonly IEqualityComparer<TSource> comparer;
+
+        public Intersect(IUniTaskAsyncEnumerable<TSource> first, IUniTaskAsyncEnumerable<TSource> second, IEqualityComparer<TSource> comparer)
+        {
+            this.first = first;
+            this.second = second;
+            this.comparer = comparer;
+        }
+
+        public IUniTaskAsyncEnumerator<TSource> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _Intersect(first, second, comparer, cancellationToken);
+        }
+
+        class _Intersect : AsyncEnumeratorBase<TSource, TSource>
+        {
+            static Action<object> HashSetAsyncCoreDelegate = HashSetAsyncCore;
+
+            readonly IEqualityComparer<TSource> comparer;
+            readonly IUniTaskAsyncEnumerable<TSource> second;
+
+            HashSet<TSource> set;
+            UniTask<HashSet<TSource>>.Awaiter awaiter;
+
+            public _Intersect(IUniTaskAsyncEnumerable<TSource> first, IUniTaskAsyncEnumerable<TSource> second, IEqualityComparer<TSource> comparer, CancellationToken cancellationToken)
+
+                : base(first, cancellationToken)
+            {
+                this.second = second;
+                this.comparer = comparer;
+            }
+
+            protected override bool OnFirstIteration()
+            {
+                if (set != null) return false;
+
+                awaiter = second.ToHashSetAsync(cancellationToken).GetAwaiter();
+                if (awaiter.IsCompleted)
+                {
+                    set = awaiter.GetResult();
+                    SourceMoveNext();
+                }
+                else
+                {
+                    awaiter.SourceOnCompleted(HashSetAsyncCoreDelegate, this);
+                }
+
+                return true;
+            }
+
+            static void HashSetAsyncCore(object state)
+            {
+                var self = (_Intersect)state;
+
+                if (self.TryGetResult(self.awaiter, out var result))
+                {
+                    self.set = result;
+                    self.SourceMoveNext();
+                }
+            }
+
+            protected override bool TryMoveNextCore(bool sourceHasCurrent, out bool result)
+            {
+                if (sourceHasCurrent)
+                {
+                    var v = SourceCurrent;
+
+                    if (set.Remove(v))
+                    {
+                        Current = v;
+                        result = true;
+                        return true;
+                    }
+                    else
+                    {
+                        result = default;
+                        return false;
+                    }
+                }
+
+                result = false;
+                return true;
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Intersect.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Intersect.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 93999a70f5d57134bbe971f3e988c4f2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Join.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Join.cs
@@ -1,0 +1,728 @@
+﻿using Cysharp.Threading.Tasks.Internal;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static IUniTaskAsyncEnumerable<TResult> Join<TOuter, TInner, TKey, TResult>(this IUniTaskAsyncEnumerable<TOuter> outer, IUniTaskAsyncEnumerable<TInner> inner, Func<TOuter, TKey> outerKeySelector, Func<TInner, TKey> innerKeySelector, Func<TOuter, TInner, TResult> resultSelector)
+        {
+            Error.ThrowArgumentNullException(outer, nameof(outer));
+            Error.ThrowArgumentNullException(inner, nameof(inner));
+            Error.ThrowArgumentNullException(outerKeySelector, nameof(outerKeySelector));
+            Error.ThrowArgumentNullException(innerKeySelector, nameof(innerKeySelector));
+            Error.ThrowArgumentNullException(resultSelector, nameof(resultSelector));
+
+            return new Join<TOuter, TInner, TKey, TResult>(outer, inner, outerKeySelector, innerKeySelector, resultSelector, EqualityComparer<TKey>.Default);
+        }
+
+        public static IUniTaskAsyncEnumerable<TResult> Join<TOuter, TInner, TKey, TResult>(this IUniTaskAsyncEnumerable<TOuter> outer, IUniTaskAsyncEnumerable<TInner> inner, Func<TOuter, TKey> outerKeySelector, Func<TInner, TKey> innerKeySelector, Func<TOuter, TInner, TResult> resultSelector, IEqualityComparer<TKey> comparer)
+        {
+            Error.ThrowArgumentNullException(outer, nameof(outer));
+            Error.ThrowArgumentNullException(inner, nameof(inner));
+            Error.ThrowArgumentNullException(outerKeySelector, nameof(outerKeySelector));
+            Error.ThrowArgumentNullException(innerKeySelector, nameof(innerKeySelector));
+            Error.ThrowArgumentNullException(resultSelector, nameof(resultSelector));
+            Error.ThrowArgumentNullException(comparer, nameof(comparer));
+
+            return new Join<TOuter, TInner, TKey, TResult>(outer, inner, outerKeySelector, innerKeySelector, resultSelector, comparer);
+        }
+
+        public static IUniTaskAsyncEnumerable<TResult> JoinAwait<TOuter, TInner, TKey, TResult>(this IUniTaskAsyncEnumerable<TOuter> outer, IUniTaskAsyncEnumerable<TInner> inner, Func<TOuter, UniTask<TKey>> outerKeySelector, Func<TInner, UniTask<TKey>> innerKeySelector, Func<TOuter, TInner, UniTask<TResult>> resultSelector)
+        {
+            Error.ThrowArgumentNullException(outer, nameof(outer));
+            Error.ThrowArgumentNullException(inner, nameof(inner));
+            Error.ThrowArgumentNullException(outerKeySelector, nameof(outerKeySelector));
+            Error.ThrowArgumentNullException(innerKeySelector, nameof(innerKeySelector));
+            Error.ThrowArgumentNullException(resultSelector, nameof(resultSelector));
+
+            return new JoinAwait<TOuter, TInner, TKey, TResult>(outer, inner, outerKeySelector, innerKeySelector, resultSelector, EqualityComparer<TKey>.Default);
+        }
+
+        public static IUniTaskAsyncEnumerable<TResult> JoinAwait<TOuter, TInner, TKey, TResult>(this IUniTaskAsyncEnumerable<TOuter> outer, IUniTaskAsyncEnumerable<TInner> inner, Func<TOuter, UniTask<TKey>> outerKeySelector, Func<TInner, UniTask<TKey>> innerKeySelector, Func<TOuter, TInner, UniTask<TResult>> resultSelector, IEqualityComparer<TKey> comparer)
+        {
+            Error.ThrowArgumentNullException(outer, nameof(outer));
+            Error.ThrowArgumentNullException(inner, nameof(inner));
+            Error.ThrowArgumentNullException(outerKeySelector, nameof(outerKeySelector));
+            Error.ThrowArgumentNullException(innerKeySelector, nameof(innerKeySelector));
+            Error.ThrowArgumentNullException(resultSelector, nameof(resultSelector));
+            Error.ThrowArgumentNullException(comparer, nameof(comparer));
+
+            return new JoinAwait<TOuter, TInner, TKey, TResult>(outer, inner, outerKeySelector, innerKeySelector, resultSelector, comparer);
+        }
+
+        public static IUniTaskAsyncEnumerable<TResult> JoinAwaitWithCancellation<TOuter, TInner, TKey, TResult>(this IUniTaskAsyncEnumerable<TOuter> outer, IUniTaskAsyncEnumerable<TInner> inner, Func<TOuter, CancellationToken, UniTask<TKey>> outerKeySelector, Func<TInner, CancellationToken, UniTask<TKey>> innerKeySelector, Func<TOuter, TInner, CancellationToken, UniTask<TResult>> resultSelector)
+        {
+            Error.ThrowArgumentNullException(outer, nameof(outer));
+            Error.ThrowArgumentNullException(inner, nameof(inner));
+            Error.ThrowArgumentNullException(outerKeySelector, nameof(outerKeySelector));
+            Error.ThrowArgumentNullException(innerKeySelector, nameof(innerKeySelector));
+            Error.ThrowArgumentNullException(resultSelector, nameof(resultSelector));
+
+            return new JoinAwaitWithCancellation<TOuter, TInner, TKey, TResult>(outer, inner, outerKeySelector, innerKeySelector, resultSelector, EqualityComparer<TKey>.Default);
+        }
+
+        public static IUniTaskAsyncEnumerable<TResult> JoinAwaitWithCancellation<TOuter, TInner, TKey, TResult>(this IUniTaskAsyncEnumerable<TOuter> outer, IUniTaskAsyncEnumerable<TInner> inner, Func<TOuter, CancellationToken, UniTask<TKey>> outerKeySelector, Func<TInner, CancellationToken, UniTask<TKey>> innerKeySelector, Func<TOuter, TInner, CancellationToken, UniTask<TResult>> resultSelector, IEqualityComparer<TKey> comparer)
+        {
+            Error.ThrowArgumentNullException(outer, nameof(outer));
+            Error.ThrowArgumentNullException(inner, nameof(inner));
+            Error.ThrowArgumentNullException(outerKeySelector, nameof(outerKeySelector));
+            Error.ThrowArgumentNullException(innerKeySelector, nameof(innerKeySelector));
+            Error.ThrowArgumentNullException(resultSelector, nameof(resultSelector));
+            Error.ThrowArgumentNullException(comparer, nameof(comparer));
+
+            return new JoinAwaitWithCancellation<TOuter, TInner, TKey, TResult>(outer, inner, outerKeySelector, innerKeySelector, resultSelector, comparer);
+        }
+    }
+
+    internal sealed class Join<TOuter, TInner, TKey, TResult> : IUniTaskAsyncEnumerable<TResult>
+    {
+        readonly IUniTaskAsyncEnumerable<TOuter> outer;
+        readonly IUniTaskAsyncEnumerable<TInner> inner;
+        readonly Func<TOuter, TKey> outerKeySelector;
+        readonly Func<TInner, TKey> innerKeySelector;
+        readonly Func<TOuter, TInner, TResult> resultSelector;
+        readonly IEqualityComparer<TKey> comparer;
+
+        public Join(IUniTaskAsyncEnumerable<TOuter> outer, IUniTaskAsyncEnumerable<TInner> inner, Func<TOuter, TKey> outerKeySelector, Func<TInner, TKey> innerKeySelector, Func<TOuter, TInner, TResult> resultSelector, IEqualityComparer<TKey> comparer)
+        {
+            this.outer = outer;
+            this.inner = inner;
+            this.outerKeySelector = outerKeySelector;
+            this.innerKeySelector = innerKeySelector;
+            this.resultSelector = resultSelector;
+            this.comparer = comparer;
+        }
+
+        public IUniTaskAsyncEnumerator<TResult> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _Join(outer, inner, outerKeySelector, innerKeySelector, resultSelector, comparer, cancellationToken);
+        }
+
+        sealed class _Join : MoveNextSource, IUniTaskAsyncEnumerator<TResult>
+        {
+            static readonly Action<object> MoveNextCoreDelegate = MoveNextCore;
+
+            readonly IUniTaskAsyncEnumerable<TOuter> outer;
+            readonly IUniTaskAsyncEnumerable<TInner> inner;
+            readonly Func<TOuter, TKey> outerKeySelector;
+            readonly Func<TInner, TKey> innerKeySelector;
+            readonly Func<TOuter, TInner, TResult> resultSelector;
+            readonly IEqualityComparer<TKey> comparer;
+            CancellationToken cancellationToken;
+
+            ILookup<TKey, TInner> lookup;
+            IUniTaskAsyncEnumerator<TOuter> enumerator;
+            UniTask<bool>.Awaiter awaiter;
+            TOuter currentOuterValue;
+            IEnumerator<TInner> valueEnumerator;
+
+            bool continueNext;
+
+            public _Join(IUniTaskAsyncEnumerable<TOuter> outer, IUniTaskAsyncEnumerable<TInner> inner, Func<TOuter, TKey> outerKeySelector, Func<TInner, TKey> innerKeySelector, Func<TOuter, TInner, TResult> resultSelector, IEqualityComparer<TKey> comparer, CancellationToken cancellationToken)
+            {
+                this.outer = outer;
+                this.inner = inner;
+                this.outerKeySelector = outerKeySelector;
+                this.innerKeySelector = innerKeySelector;
+                this.resultSelector = resultSelector;
+                this.comparer = comparer;
+                this.cancellationToken = cancellationToken;
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public TResult Current { get; private set; }
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                completionSource.Reset();
+
+                if (lookup == null)
+                {
+                    CreateInnerHashSet().Forget();
+                }
+                else
+                {
+                    SourceMoveNext();
+                }
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            async UniTaskVoid CreateInnerHashSet()
+            {
+                try
+                {
+                    lookup = await inner.ToLookupAsync(innerKeySelector, comparer, cancellationToken);
+                    enumerator = outer.GetAsyncEnumerator(cancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    completionSource.TrySetException(ex);
+                    return;
+                }
+                SourceMoveNext();
+            }
+
+            void SourceMoveNext()
+            {
+                try
+                {
+                    LOOP:
+                    if (valueEnumerator != null)
+                    {
+                        if (valueEnumerator.MoveNext())
+                        {
+                            Current = resultSelector(currentOuterValue, valueEnumerator.Current);
+                            goto TRY_SET_RESULT_TRUE;
+                        }
+                        else
+                        {
+                            valueEnumerator.Dispose();
+                            valueEnumerator = null;
+                        }
+                    }
+
+                    awaiter = enumerator.MoveNextAsync().GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        continueNext = true;
+                        MoveNextCore(this);
+                        if (continueNext)
+                        {
+                            continueNext = false;
+                            goto LOOP; // avoid recursive
+                        }
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(MoveNextCoreDelegate, this);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    completionSource.TrySetException(ex);
+                }
+
+                return;
+
+                TRY_SET_RESULT_TRUE:
+                completionSource.TrySetResult(true);
+            }
+
+
+            static void MoveNextCore(object state)
+            {
+                var self = (_Join)state;
+
+                if (self.TryGetResult(self.awaiter, out var result))
+                {
+                    if (result)
+                    {
+                        self.currentOuterValue = self.enumerator.Current;
+                        var key = self.outerKeySelector(self.currentOuterValue);
+                        self.valueEnumerator = self.lookup[key].GetEnumerator();
+
+                        if (self.continueNext)
+                        {
+                            return;
+                        }
+                        else
+                        {
+                            self.SourceMoveNext();
+                        }
+                    }
+                    else
+                    {
+                        self.continueNext = false;
+                        self.completionSource.TrySetResult(false);
+                    }
+                }
+                else
+                {
+                    self.continueNext = false;
+                }
+            }
+
+            public UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                if (valueEnumerator != null)
+                {
+                    valueEnumerator.Dispose();
+                }
+
+                if (enumerator != null)
+                {
+                    return enumerator.DisposeAsync();
+                }
+
+                return default;
+            }
+        }
+    }
+
+    internal sealed class JoinAwait<TOuter, TInner, TKey, TResult> : IUniTaskAsyncEnumerable<TResult>
+    {
+        readonly IUniTaskAsyncEnumerable<TOuter> outer;
+        readonly IUniTaskAsyncEnumerable<TInner> inner;
+        readonly Func<TOuter, UniTask<TKey>> outerKeySelector;
+        readonly Func<TInner, UniTask<TKey>> innerKeySelector;
+        readonly Func<TOuter, TInner, UniTask<TResult>> resultSelector;
+        readonly IEqualityComparer<TKey> comparer;
+
+        public JoinAwait(IUniTaskAsyncEnumerable<TOuter> outer, IUniTaskAsyncEnumerable<TInner> inner, Func<TOuter, UniTask<TKey>> outerKeySelector, Func<TInner, UniTask<TKey>> innerKeySelector, Func<TOuter, TInner, UniTask<TResult>> resultSelector, IEqualityComparer<TKey> comparer)
+        {
+            this.outer = outer;
+            this.inner = inner;
+            this.outerKeySelector = outerKeySelector;
+            this.innerKeySelector = innerKeySelector;
+            this.resultSelector = resultSelector;
+            this.comparer = comparer;
+        }
+
+        public IUniTaskAsyncEnumerator<TResult> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _JoinAwait(outer, inner, outerKeySelector, innerKeySelector, resultSelector, comparer, cancellationToken);
+        }
+
+        sealed class _JoinAwait : MoveNextSource, IUniTaskAsyncEnumerator<TResult>
+        {
+            static readonly Action<object> MoveNextCoreDelegate = MoveNextCore;
+            static readonly Action<object> OuterSelectCoreDelegate = OuterSelectCore;
+            static readonly Action<object> ResultSelectCoreDelegate = ResultSelectCore;
+
+            readonly IUniTaskAsyncEnumerable<TOuter> outer;
+            readonly IUniTaskAsyncEnumerable<TInner> inner;
+            readonly Func<TOuter, UniTask<TKey>> outerKeySelector;
+            readonly Func<TInner, UniTask<TKey>> innerKeySelector;
+            readonly Func<TOuter, TInner, UniTask<TResult>> resultSelector;
+            readonly IEqualityComparer<TKey> comparer;
+            CancellationToken cancellationToken;
+
+            ILookup<TKey, TInner> lookup;
+            IUniTaskAsyncEnumerator<TOuter> enumerator;
+            UniTask<bool>.Awaiter awaiter;
+            TOuter currentOuterValue;
+            IEnumerator<TInner> valueEnumerator;
+
+            UniTask<TResult>.Awaiter resultAwaiter;
+            UniTask<TKey>.Awaiter outerKeyAwaiter;
+
+            bool continueNext;
+
+            public _JoinAwait(IUniTaskAsyncEnumerable<TOuter> outer, IUniTaskAsyncEnumerable<TInner> inner, Func<TOuter, UniTask<TKey>> outerKeySelector, Func<TInner, UniTask<TKey>> innerKeySelector, Func<TOuter, TInner, UniTask<TResult>> resultSelector, IEqualityComparer<TKey> comparer, CancellationToken cancellationToken)
+            {
+                this.outer = outer;
+                this.inner = inner;
+                this.outerKeySelector = outerKeySelector;
+                this.innerKeySelector = innerKeySelector;
+                this.resultSelector = resultSelector;
+                this.comparer = comparer;
+                this.cancellationToken = cancellationToken;
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public TResult Current { get; private set; }
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                completionSource.Reset();
+
+                if (lookup == null)
+                {
+                    CreateInnerHashSet().Forget();
+                }
+                else
+                {
+                    SourceMoveNext();
+                }
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            async UniTaskVoid CreateInnerHashSet()
+            {
+                try
+                {
+                    lookup = await inner.ToLookupAwaitAsync(innerKeySelector, comparer, cancellationToken);
+                    enumerator = outer.GetAsyncEnumerator(cancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    completionSource.TrySetException(ex);
+                    return;
+                }
+                SourceMoveNext();
+            }
+
+            void SourceMoveNext()
+            {
+                try
+                {
+                    LOOP:
+                    if (valueEnumerator != null)
+                    {
+                        if (valueEnumerator.MoveNext())
+                        {
+                            resultAwaiter = resultSelector(currentOuterValue, valueEnumerator.Current).GetAwaiter();
+                            if (resultAwaiter.IsCompleted)
+                            {
+                                ResultSelectCore(this);
+                            }
+                            else
+                            {
+                                resultAwaiter.SourceOnCompleted(ResultSelectCoreDelegate, this);
+                            }
+                            return;
+                        }
+                        else
+                        {
+                            valueEnumerator.Dispose();
+                            valueEnumerator = null;
+                        }
+                    }
+
+                    awaiter = enumerator.MoveNextAsync().GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        continueNext = true;
+                        MoveNextCore(this);
+                        if (continueNext)
+                        {
+                            continueNext = false;
+                            goto LOOP; // avoid recursive
+                        }
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(MoveNextCoreDelegate, this);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    completionSource.TrySetException(ex);
+                }
+            }
+
+
+            static void MoveNextCore(object state)
+            {
+                var self = (_JoinAwait)state;
+
+                if (self.TryGetResult(self.awaiter, out var result))
+                {
+                    if (result)
+                    {
+                        self.currentOuterValue = self.enumerator.Current;
+
+                        self.outerKeyAwaiter = self.outerKeySelector(self.currentOuterValue).GetAwaiter();
+
+                        if (self.outerKeyAwaiter.IsCompleted)
+                        {
+                            OuterSelectCore(self);
+                        }
+                        else
+                        {
+                            self.continueNext = false;
+                            self.outerKeyAwaiter.SourceOnCompleted(OuterSelectCoreDelegate, self);
+                        }
+                    }
+                    else
+                    {
+                        self.continueNext = false;
+                        self.completionSource.TrySetResult(false);
+                    }
+                }
+                else
+                {
+                    self.continueNext = false;
+                }
+            }
+
+            static void OuterSelectCore(object state)
+            {
+                var self = (_JoinAwait)state;
+
+                if (self.TryGetResult(self.outerKeyAwaiter, out var key))
+                {
+                    self.valueEnumerator = self.lookup[key].GetEnumerator();
+
+                    if (self.continueNext)
+                    {
+                        return;
+                    }
+                    else
+                    {
+                        self.SourceMoveNext();
+                    }
+                }
+                else
+                {
+                    self.continueNext = false;
+                }
+            }
+
+            static void ResultSelectCore(object state)
+            {
+                var self = (_JoinAwait)state;
+
+                if (self.TryGetResult(self.resultAwaiter, out var result))
+                {
+                    self.Current = result;
+                    self.completionSource.TrySetResult(true);
+                }
+            }
+
+            public UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                if (valueEnumerator != null)
+                {
+                    valueEnumerator.Dispose();
+                }
+
+                if (enumerator != null)
+                {
+                    return enumerator.DisposeAsync();
+                }
+
+                return default;
+            }
+        }
+    }
+
+    internal sealed class JoinAwaitWithCancellation<TOuter, TInner, TKey, TResult> : IUniTaskAsyncEnumerable<TResult>
+    {
+        readonly IUniTaskAsyncEnumerable<TOuter> outer;
+        readonly IUniTaskAsyncEnumerable<TInner> inner;
+        readonly Func<TOuter, CancellationToken, UniTask<TKey>> outerKeySelector;
+        readonly Func<TInner, CancellationToken, UniTask<TKey>> innerKeySelector;
+        readonly Func<TOuter, TInner, CancellationToken, UniTask<TResult>> resultSelector;
+        readonly IEqualityComparer<TKey> comparer;
+
+        public JoinAwaitWithCancellation(IUniTaskAsyncEnumerable<TOuter> outer, IUniTaskAsyncEnumerable<TInner> inner, Func<TOuter, CancellationToken, UniTask<TKey>> outerKeySelector, Func<TInner, CancellationToken, UniTask<TKey>> innerKeySelector, Func<TOuter, TInner, CancellationToken, UniTask<TResult>> resultSelector, IEqualityComparer<TKey> comparer)
+        {
+            this.outer = outer;
+            this.inner = inner;
+            this.outerKeySelector = outerKeySelector;
+            this.innerKeySelector = innerKeySelector;
+            this.resultSelector = resultSelector;
+            this.comparer = comparer;
+        }
+
+        public IUniTaskAsyncEnumerator<TResult> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _JoinAwaitWithCancellation(outer, inner, outerKeySelector, innerKeySelector, resultSelector, comparer, cancellationToken);
+        }
+
+        sealed class _JoinAwaitWithCancellation : MoveNextSource, IUniTaskAsyncEnumerator<TResult>
+        {
+            static readonly Action<object> MoveNextCoreDelegate = MoveNextCore;
+            static readonly Action<object> OuterSelectCoreDelegate = OuterSelectCore;
+            static readonly Action<object> ResultSelectCoreDelegate = ResultSelectCore;
+
+            readonly IUniTaskAsyncEnumerable<TOuter> outer;
+            readonly IUniTaskAsyncEnumerable<TInner> inner;
+            readonly Func<TOuter, CancellationToken, UniTask<TKey>> outerKeySelector;
+            readonly Func<TInner, CancellationToken, UniTask<TKey>> innerKeySelector;
+            readonly Func<TOuter, TInner, CancellationToken, UniTask<TResult>> resultSelector;
+            readonly IEqualityComparer<TKey> comparer;
+            CancellationToken cancellationToken;
+
+            ILookup<TKey, TInner> lookup;
+            IUniTaskAsyncEnumerator<TOuter> enumerator;
+            UniTask<bool>.Awaiter awaiter;
+            TOuter currentOuterValue;
+            IEnumerator<TInner> valueEnumerator;
+
+            UniTask<TResult>.Awaiter resultAwaiter;
+            UniTask<TKey>.Awaiter outerKeyAwaiter;
+
+            bool continueNext;
+
+            public _JoinAwaitWithCancellation(IUniTaskAsyncEnumerable<TOuter> outer, IUniTaskAsyncEnumerable<TInner> inner, Func<TOuter, CancellationToken, UniTask<TKey>> outerKeySelector, Func<TInner, CancellationToken, UniTask<TKey>> innerKeySelector, Func<TOuter, TInner, CancellationToken, UniTask<TResult>> resultSelector, IEqualityComparer<TKey> comparer, CancellationToken cancellationToken)
+            {
+                this.outer = outer;
+                this.inner = inner;
+                this.outerKeySelector = outerKeySelector;
+                this.innerKeySelector = innerKeySelector;
+                this.resultSelector = resultSelector;
+                this.comparer = comparer;
+                this.cancellationToken = cancellationToken;
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public TResult Current { get; private set; }
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                completionSource.Reset();
+
+                if (lookup == null)
+                {
+                    CreateInnerHashSet().Forget();
+                }
+                else
+                {
+                    SourceMoveNext();
+                }
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            async UniTaskVoid CreateInnerHashSet()
+            {
+                try
+                {
+                    lookup = await inner.ToLookupAwaitWithCancellationAsync(innerKeySelector, comparer, cancellationToken: cancellationToken);
+                    enumerator = outer.GetAsyncEnumerator(cancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    completionSource.TrySetException(ex);
+                    return;
+                }
+                SourceMoveNext();
+            }
+
+            void SourceMoveNext()
+            {
+                try
+                {
+                    LOOP:
+                    if (valueEnumerator != null)
+                    {
+                        if (valueEnumerator.MoveNext())
+                        {
+                            resultAwaiter = resultSelector(currentOuterValue, valueEnumerator.Current, cancellationToken).GetAwaiter();
+                            if (resultAwaiter.IsCompleted)
+                            {
+                                ResultSelectCore(this);
+                            }
+                            else
+                            {
+                                resultAwaiter.SourceOnCompleted(ResultSelectCoreDelegate, this);
+                            }
+                            return;
+                        }
+                        else
+                        {
+                            valueEnumerator.Dispose();
+                            valueEnumerator = null;
+                        }
+                    }
+
+                    awaiter = enumerator.MoveNextAsync().GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        continueNext = true;
+                        MoveNextCore(this);
+                        if (continueNext)
+                        {
+                            continueNext = false;
+                            goto LOOP; // avoid recursive
+                        }
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(MoveNextCoreDelegate, this);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    completionSource.TrySetException(ex);
+                }
+            }
+
+
+            static void MoveNextCore(object state)
+            {
+                var self = (_JoinAwaitWithCancellation)state;
+
+                if (self.TryGetResult(self.awaiter, out var result))
+                {
+                    if (result)
+                    {
+                        self.currentOuterValue = self.enumerator.Current;
+
+                        self.outerKeyAwaiter = self.outerKeySelector(self.currentOuterValue, self.cancellationToken).GetAwaiter();
+
+                        if (self.outerKeyAwaiter.IsCompleted)
+                        {
+                            OuterSelectCore(self);
+                        }
+                        else
+                        {
+                            self.continueNext = false;
+                            self.outerKeyAwaiter.SourceOnCompleted(OuterSelectCoreDelegate, self);
+                        }
+                    }
+                    else
+                    {
+                        self.continueNext = false;
+                        self.completionSource.TrySetResult(false);
+                    }
+                }
+                else
+                {
+                    self.continueNext = false;
+                }
+            }
+
+            static void OuterSelectCore(object state)
+            {
+                var self = (_JoinAwaitWithCancellation)state;
+
+                if (self.TryGetResult(self.outerKeyAwaiter, out var key))
+                {
+                    self.valueEnumerator = self.lookup[key].GetEnumerator();
+
+                    if (self.continueNext)
+                    {
+                        return;
+                    }
+                    else
+                    {
+                        self.SourceMoveNext();
+                    }
+                }
+                else
+                {
+                    self.continueNext = false;
+                }
+            }
+
+            static void ResultSelectCore(object state)
+            {
+                var self = (_JoinAwaitWithCancellation)state;
+
+                if (self.TryGetResult(self.resultAwaiter, out var result))
+                {
+                    self.Current = result;
+                    self.completionSource.TrySetResult(true);
+                }
+            }
+
+            public UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                if (valueEnumerator != null)
+                {
+                    valueEnumerator.Dispose();
+                }
+
+                if (enumerator != null)
+                {
+                    return enumerator.DisposeAsync();
+                }
+
+                return default;
+            }
+        }
+    }
+
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Join.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Join.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dc4ff8cb6d7c9a64896f2f082124d6b3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Last.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Last.cs
@@ -1,0 +1,240 @@
+﻿using Cysharp.Threading.Tasks.Internal;
+using System;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static UniTask<TSource> LastAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return Last.LastAsync(source, cancellationToken, false);
+        }
+
+        public static UniTask<TSource> LastAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Boolean> predicate, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(predicate, nameof(predicate));
+
+            return Last.LastAsync(source, predicate, cancellationToken, false);
+        }
+
+        public static UniTask<TSource> LastAwaitAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Boolean>> predicate, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(predicate, nameof(predicate));
+
+            return Last.LastAwaitAsync(source, predicate, cancellationToken, false);
+        }
+
+        public static UniTask<TSource> LastAwaitWithCancellationAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Boolean>> predicate, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(predicate, nameof(predicate));
+
+            return Last.LastAwaitWithCancellationAsync(source, predicate, cancellationToken, false);
+        }
+
+        public static UniTask<TSource> LastOrDefaultAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return Last.LastAsync(source, cancellationToken, true);
+        }
+
+        public static UniTask<TSource> LastOrDefaultAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Boolean> predicate, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(predicate, nameof(predicate));
+
+            return Last.LastAsync(source, predicate, cancellationToken, true);
+        }
+
+        public static UniTask<TSource> LastOrDefaultAwaitAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Boolean>> predicate, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(predicate, nameof(predicate));
+
+            return Last.LastAwaitAsync(source, predicate, cancellationToken, true);
+        }
+
+        public static UniTask<TSource> LastOrDefaultAwaitWithCancellationAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Boolean>> predicate, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(predicate, nameof(predicate));
+
+            return Last.LastAwaitWithCancellationAsync(source, predicate, cancellationToken, true);
+        }
+    }
+
+    internal static class Last
+    {
+        public static async UniTask<TSource> LastAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, CancellationToken cancellationToken, bool defaultIfEmpty)
+        {
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                TSource value = default;
+                if (await e.MoveNextAsync())
+                {
+                    value = e.Current;
+                }
+                else
+                {
+                    if (defaultIfEmpty)
+                    {
+                        return value;
+                    }
+                    else
+                    {
+                        throw Error.NoElements();
+                    }
+                }
+
+                while (await e.MoveNextAsync())
+                {
+                    value = e.Current;
+                }
+                return value;
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+        }
+
+        public static async UniTask<TSource> LastAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Boolean> predicate, CancellationToken cancellationToken, bool defaultIfEmpty)
+        {
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                TSource value = default;
+
+                bool found = false;
+                while (await e.MoveNextAsync())
+                {
+                    var v = e.Current;
+                    if (predicate(v))
+                    {
+                        found = true;
+                        value = v;
+                    }
+                }
+
+                if (defaultIfEmpty)
+                {
+                    return value;
+                }
+                else
+                {
+                    if (found)
+                    {
+                        return value;
+                    }
+                    else
+                    {
+                        throw Error.NoElements();
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+        }
+
+        public static async UniTask<TSource> LastAwaitAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Boolean>> predicate, CancellationToken cancellationToken, bool defaultIfEmpty)
+        {
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                TSource value = default;
+
+                bool found = false;
+                while (await e.MoveNextAsync())
+                {
+                    var v = e.Current;
+                    if (await predicate(v))
+                    {
+                        found = true;
+                        value = v;
+                    }
+                }
+
+                if (defaultIfEmpty)
+                {
+                    return value;
+                }
+                else
+                {
+                    if (found)
+                    {
+                        return value;
+                    }
+                    else
+                    {
+                        throw Error.NoElements();
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+        }
+
+        public static async UniTask<TSource> LastAwaitWithCancellationAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Boolean>> predicate, CancellationToken cancellationToken, bool defaultIfEmpty)
+        {
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                TSource value = default;
+
+                bool found = false;
+                while (await e.MoveNextAsync())
+                {
+                    var v = e.Current;
+                    if (await predicate(v, cancellationToken))
+                    {
+                        found = true;
+                        value = v;
+                    }
+                }
+
+                if (defaultIfEmpty)
+                {
+                    return value;
+                }
+                else
+                {
+                    if (found)
+                    {
+                        return value;
+                    }
+                    else
+                    {
+                        throw Error.NoElements();
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Last.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Last.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a0ccc93be1387fa4a975f06310127c11
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/LongCount.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/LongCount.cs
@@ -1,0 +1,144 @@
+﻿using Cysharp.Threading.Tasks.Internal;
+using System;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static UniTask<long> LongCountAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return LongCount.LongCountAsync(source, cancellationToken);
+        }
+
+        public static UniTask<long> LongCountAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Boolean> predicate, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(predicate, nameof(predicate));
+
+            return LongCount.LongCountAsync(source, predicate, cancellationToken);
+        }
+
+        public static UniTask<long> LongCountAwaitAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Boolean>> predicate, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(predicate, nameof(predicate));
+
+            return LongCount.LongCountAwaitAsync(source, predicate, cancellationToken);
+        }
+
+        public static UniTask<long> LongCountAwaitWithCancellationAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Boolean>> predicate, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(predicate, nameof(predicate));
+
+            return LongCount.LongCountAwaitWithCancellationAsync(source, predicate, cancellationToken);
+        }
+    }
+
+    internal static class LongCount
+    {
+        internal static async UniTask<long> LongCountAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, CancellationToken cancellationToken)
+        {
+            long count = 0;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    checked { count++; }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return count;
+        }
+
+        internal static async UniTask<long> LongCountAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Boolean> predicate, CancellationToken cancellationToken)
+        {
+            long count = 0;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    if (predicate(e.Current))
+                    {
+                        checked { count++; }
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return count;
+        }
+
+        internal static async UniTask<long> LongCountAwaitAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Boolean>> predicate, CancellationToken cancellationToken)
+        {
+            long count = 0;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    if (await predicate(e.Current))
+                    {
+                        checked { count++; }
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return count;
+        }
+
+        internal static async UniTask<long> LongCountAwaitWithCancellationAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Boolean>> predicate, CancellationToken cancellationToken)
+        {
+            long count = 0;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    if (await predicate(e.Current, cancellationToken))
+                    {
+                        checked { count++; }
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return count;
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/LongCount.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/LongCount.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 198b39e58ced3ab4f97ccbe0916787d5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Max.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Max.cs
@@ -1,0 +1,200 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using Cysharp.Threading.Tasks.Internal;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static UniTask<TSource> MaxAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return Max.MaxAsync(source, cancellationToken);
+        }
+
+        public static UniTask<TResult> MaxAsync<TSource, TResult>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, TResult> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Max.MaxAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<TResult> MaxAwaitAsync<TSource, TResult>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<TResult>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Max.MaxAwaitAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<TResult> MaxAwaitWithCancellationAsync<TSource, TResult>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<TResult>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Max.MaxAwaitWithCancellationAsync(source, selector, cancellationToken);
+        }
+    }
+
+    internal static partial class Max
+    {
+        public static async UniTask<TSource> MaxAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, CancellationToken cancellationToken)
+        {
+            TSource value = default;
+            var comparer = Comparer<TSource>.Default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = e.Current;
+
+                    goto NEXT_LOOP;
+                }
+
+                return value;
+
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = e.Current;
+                    if (comparer.Compare(value, x) < 0)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<TResult> MaxAsync<TSource, TResult>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, TResult> selector, CancellationToken cancellationToken)
+        {
+            TResult value = default;
+            var comparer = Comparer<TResult>.Default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = selector(e.Current);
+
+                    goto NEXT_LOOP;
+                }
+
+                return value;
+
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = selector(e.Current);
+                    if (comparer.Compare(value, x) < 0)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<TResult> MaxAwaitAsync<TSource, TResult>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<TResult>> selector, CancellationToken cancellationToken)
+        {
+            TResult value = default;
+            var comparer = Comparer<TResult>.Default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = await selector(e.Current);
+
+                    goto NEXT_LOOP;
+                }
+
+                return value;
+
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = await selector(e.Current);
+                    if (comparer.Compare(value, x) < 0)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<TResult> MaxAwaitWithCancellationAsync<TSource, TResult>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<TResult>> selector, CancellationToken cancellationToken)
+        {
+            TResult value = default;
+            var comparer = Comparer<TResult>.Default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = await selector(e.Current, cancellationToken);
+
+                    goto NEXT_LOOP;
+                }
+
+                return value;
+
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = await selector(e.Current, cancellationToken);
+                    if (comparer.Compare(value, x) < 0)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Max.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Max.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5c8a118a6b664c441820b8a87d7f6e28
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Min.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Min.cs
@@ -1,0 +1,200 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using Cysharp.Threading.Tasks.Internal;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static UniTask<TSource> MinAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return Min.MinAsync(source, cancellationToken);
+        }
+
+        public static UniTask<TResult> MinAsync<TSource, TResult>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, TResult> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Min.MinAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<TResult> MinAwaitAsync<TSource, TResult>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<TResult>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Min.MinAwaitAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<TResult> MinAwaitWithCancellationAsync<TSource, TResult>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<TResult>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Min.MinAwaitWithCancellationAsync(source, selector, cancellationToken);
+        }
+    }
+
+    internal static partial class Min
+    {
+        public static async UniTask<TSource> MinAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, CancellationToken cancellationToken)
+        {
+            TSource value = default;
+            var comparer = Comparer<TSource>.Default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = e.Current;
+
+                    goto NEXT_LOOP;
+                }
+
+                return value;
+
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = e.Current;
+                    if (comparer.Compare(value, x) > 0)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<TResult> MinAsync<TSource, TResult>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, TResult> selector, CancellationToken cancellationToken)
+        {
+            TResult value = default;
+            var comparer = Comparer<TResult>.Default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = selector(e.Current);
+
+                    goto NEXT_LOOP;
+                }
+
+                return value;
+
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = selector(e.Current);
+                    if (comparer.Compare(value, x) > 0)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<TResult> MinAwaitAsync<TSource, TResult>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<TResult>> selector, CancellationToken cancellationToken)
+        {
+            TResult value = default;
+            var comparer = Comparer<TResult>.Default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = await selector(e.Current);
+
+                    goto NEXT_LOOP;
+                }
+
+                return value;
+
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = await selector(e.Current);
+                    if (comparer.Compare(value, x) > 0)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<TResult> MinAwaitWithCancellationAsync<TSource, TResult>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<TResult>> selector, CancellationToken cancellationToken)
+        {
+            TResult value = default;
+            var comparer = Comparer<TResult>.Default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = await selector(e.Current, cancellationToken);
+
+                    goto NEXT_LOOP;
+                }
+
+                return value;
+
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = await selector(e.Current, cancellationToken);
+                    if (comparer.Compare(value, x) > 0)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Min.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Min.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 57ac9da21d3457849a8e45548290a508
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/MinMax.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/MinMax.cs
@@ -1,0 +1,3763 @@
+﻿using System;
+using System.Threading;
+using Cysharp.Threading.Tasks.Internal;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static UniTask<Int32> MinAsync(this IUniTaskAsyncEnumerable<Int32> source, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return Min.MinAsync(source, cancellationToken);
+        }
+
+        public static UniTask<Int32> MinAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Int32> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Min.MinAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Int32> MinAwaitAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Int32>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Min.MinAwaitAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Int32> MinAwaitWithCancellationAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Int32>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Min.MinAwaitWithCancellationAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Int64> MinAsync(this IUniTaskAsyncEnumerable<Int64> source, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return Min.MinAsync(source, cancellationToken);
+        }
+
+        public static UniTask<Int64> MinAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Int64> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Min.MinAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Int64> MinAwaitAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Int64>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Min.MinAwaitAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Int64> MinAwaitWithCancellationAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Int64>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Min.MinAwaitWithCancellationAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Single> MinAsync(this IUniTaskAsyncEnumerable<Single> source, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return Min.MinAsync(source, cancellationToken);
+        }
+
+        public static UniTask<Single> MinAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Single> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Min.MinAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Single> MinAwaitAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Single>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Min.MinAwaitAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Single> MinAwaitWithCancellationAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Single>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Min.MinAwaitWithCancellationAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Double> MinAsync(this IUniTaskAsyncEnumerable<Double> source, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return Min.MinAsync(source, cancellationToken);
+        }
+
+        public static UniTask<Double> MinAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Double> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Min.MinAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Double> MinAwaitAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Double>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Min.MinAwaitAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Double> MinAwaitWithCancellationAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Double>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Min.MinAwaitWithCancellationAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Decimal> MinAsync(this IUniTaskAsyncEnumerable<Decimal> source, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return Min.MinAsync(source, cancellationToken);
+        }
+
+        public static UniTask<Decimal> MinAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Decimal> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Min.MinAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Decimal> MinAwaitAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Decimal>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Min.MinAwaitAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Decimal> MinAwaitWithCancellationAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Decimal>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Min.MinAwaitWithCancellationAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Int32?> MinAsync(this IUniTaskAsyncEnumerable<Int32?> source, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return Min.MinAsync(source, cancellationToken);
+        }
+
+        public static UniTask<Int32?> MinAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Int32?> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Min.MinAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Int32?> MinAwaitAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Int32?>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Min.MinAwaitAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Int32?> MinAwaitWithCancellationAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Int32?>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Min.MinAwaitWithCancellationAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Int64?> MinAsync(this IUniTaskAsyncEnumerable<Int64?> source, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return Min.MinAsync(source, cancellationToken);
+        }
+
+        public static UniTask<Int64?> MinAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Int64?> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Min.MinAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Int64?> MinAwaitAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Int64?>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Min.MinAwaitAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Int64?> MinAwaitWithCancellationAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Int64?>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Min.MinAwaitWithCancellationAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Single?> MinAsync(this IUniTaskAsyncEnumerable<Single?> source, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return Min.MinAsync(source, cancellationToken);
+        }
+
+        public static UniTask<Single?> MinAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Single?> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Min.MinAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Single?> MinAwaitAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Single?>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Min.MinAwaitAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Single?> MinAwaitWithCancellationAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Single?>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Min.MinAwaitWithCancellationAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Double?> MinAsync(this IUniTaskAsyncEnumerable<Double?> source, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return Min.MinAsync(source, cancellationToken);
+        }
+
+        public static UniTask<Double?> MinAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Double?> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Min.MinAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Double?> MinAwaitAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Double?>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Min.MinAwaitAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Double?> MinAwaitWithCancellationAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Double?>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Min.MinAwaitWithCancellationAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Decimal?> MinAsync(this IUniTaskAsyncEnumerable<Decimal?> source, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return Min.MinAsync(source, cancellationToken);
+        }
+
+        public static UniTask<Decimal?> MinAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Decimal?> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Min.MinAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Decimal?> MinAwaitAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Decimal?>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Min.MinAwaitAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Decimal?> MinAwaitWithCancellationAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Decimal?>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Min.MinAwaitWithCancellationAsync(source, selector, cancellationToken);
+        }
+
+    }
+
+    internal static partial class Min
+    {
+        public static async UniTask<Int32> MinAsync(IUniTaskAsyncEnumerable<Int32> source, CancellationToken cancellationToken)
+        {
+            Int32 value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = e.Current;
+                
+                    goto NEXT_LOOP;
+                }
+
+                throw Error.NoElements();
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = e.Current;
+                    if (value > x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Int32> MinAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Int32> selector, CancellationToken cancellationToken)
+        {
+            Int32 value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = selector(e.Current);
+                
+                    goto NEXT_LOOP;
+                }
+
+                throw Error.NoElements();
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = selector(e.Current);
+                    if (value > x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Int32> MinAwaitAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Int32>> selector, CancellationToken cancellationToken)
+        {
+            Int32 value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = await selector(e.Current);
+                
+                    goto NEXT_LOOP;
+                }
+
+                throw Error.NoElements();
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = await selector(e.Current);
+                    if (value > x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Int32> MinAwaitWithCancellationAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Int32>> selector, CancellationToken cancellationToken)
+        {
+            Int32 value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = await selector(e.Current, cancellationToken);
+                
+                    goto NEXT_LOOP;
+                }
+
+                throw Error.NoElements();
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = await selector(e.Current, cancellationToken);
+                    if (value > x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Int64> MinAsync(IUniTaskAsyncEnumerable<Int64> source, CancellationToken cancellationToken)
+        {
+            Int64 value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = e.Current;
+                
+                    goto NEXT_LOOP;
+                }
+
+                throw Error.NoElements();
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = e.Current;
+                    if (value > x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Int64> MinAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Int64> selector, CancellationToken cancellationToken)
+        {
+            Int64 value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = selector(e.Current);
+                
+                    goto NEXT_LOOP;
+                }
+
+                throw Error.NoElements();
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = selector(e.Current);
+                    if (value > x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Int64> MinAwaitAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Int64>> selector, CancellationToken cancellationToken)
+        {
+            Int64 value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = await selector(e.Current);
+                
+                    goto NEXT_LOOP;
+                }
+
+                throw Error.NoElements();
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = await selector(e.Current);
+                    if (value > x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Int64> MinAwaitWithCancellationAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Int64>> selector, CancellationToken cancellationToken)
+        {
+            Int64 value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = await selector(e.Current, cancellationToken);
+                
+                    goto NEXT_LOOP;
+                }
+
+                throw Error.NoElements();
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = await selector(e.Current, cancellationToken);
+                    if (value > x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Single> MinAsync(IUniTaskAsyncEnumerable<Single> source, CancellationToken cancellationToken)
+        {
+            Single value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = e.Current;
+                
+                    goto NEXT_LOOP;
+                }
+
+                throw Error.NoElements();
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = e.Current;
+                    if (value > x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Single> MinAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Single> selector, CancellationToken cancellationToken)
+        {
+            Single value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = selector(e.Current);
+                
+                    goto NEXT_LOOP;
+                }
+
+                throw Error.NoElements();
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = selector(e.Current);
+                    if (value > x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Single> MinAwaitAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Single>> selector, CancellationToken cancellationToken)
+        {
+            Single value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = await selector(e.Current);
+                
+                    goto NEXT_LOOP;
+                }
+
+                throw Error.NoElements();
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = await selector(e.Current);
+                    if (value > x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Single> MinAwaitWithCancellationAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Single>> selector, CancellationToken cancellationToken)
+        {
+            Single value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = await selector(e.Current, cancellationToken);
+                
+                    goto NEXT_LOOP;
+                }
+
+                throw Error.NoElements();
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = await selector(e.Current, cancellationToken);
+                    if (value > x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Double> MinAsync(IUniTaskAsyncEnumerable<Double> source, CancellationToken cancellationToken)
+        {
+            Double value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = e.Current;
+                
+                    goto NEXT_LOOP;
+                }
+
+                throw Error.NoElements();
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = e.Current;
+                    if (value > x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Double> MinAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Double> selector, CancellationToken cancellationToken)
+        {
+            Double value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = selector(e.Current);
+                
+                    goto NEXT_LOOP;
+                }
+
+                throw Error.NoElements();
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = selector(e.Current);
+                    if (value > x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Double> MinAwaitAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Double>> selector, CancellationToken cancellationToken)
+        {
+            Double value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = await selector(e.Current);
+                
+                    goto NEXT_LOOP;
+                }
+
+                throw Error.NoElements();
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = await selector(e.Current);
+                    if (value > x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Double> MinAwaitWithCancellationAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Double>> selector, CancellationToken cancellationToken)
+        {
+            Double value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = await selector(e.Current, cancellationToken);
+                
+                    goto NEXT_LOOP;
+                }
+
+                throw Error.NoElements();
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = await selector(e.Current, cancellationToken);
+                    if (value > x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Decimal> MinAsync(IUniTaskAsyncEnumerable<Decimal> source, CancellationToken cancellationToken)
+        {
+            Decimal value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = e.Current;
+                
+                    goto NEXT_LOOP;
+                }
+
+                throw Error.NoElements();
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = e.Current;
+                    if (value > x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Decimal> MinAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Decimal> selector, CancellationToken cancellationToken)
+        {
+            Decimal value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = selector(e.Current);
+                
+                    goto NEXT_LOOP;
+                }
+
+                throw Error.NoElements();
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = selector(e.Current);
+                    if (value > x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Decimal> MinAwaitAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Decimal>> selector, CancellationToken cancellationToken)
+        {
+            Decimal value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = await selector(e.Current);
+                
+                    goto NEXT_LOOP;
+                }
+
+                throw Error.NoElements();
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = await selector(e.Current);
+                    if (value > x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Decimal> MinAwaitWithCancellationAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Decimal>> selector, CancellationToken cancellationToken)
+        {
+            Decimal value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = await selector(e.Current, cancellationToken);
+                
+                    goto NEXT_LOOP;
+                }
+
+                throw Error.NoElements();
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = await selector(e.Current, cancellationToken);
+                    if (value > x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Int32?> MinAsync(IUniTaskAsyncEnumerable<Int32?> source, CancellationToken cancellationToken)
+        {
+            Int32? value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = e.Current;
+                    if(value == null) continue;
+                
+                    goto NEXT_LOOP;
+                }
+
+                return default;
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = e.Current;
+                    if( x == null) continue;
+                    if (value > x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Int32?> MinAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Int32?> selector, CancellationToken cancellationToken)
+        {
+            Int32? value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = selector(e.Current);
+                    if(value == null) continue;
+                
+                    goto NEXT_LOOP;
+                }
+
+                return default;
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = selector(e.Current);
+                    if( x == null) continue;
+                    if (value > x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Int32?> MinAwaitAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Int32?>> selector, CancellationToken cancellationToken)
+        {
+            Int32? value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = await selector(e.Current);
+                    if(value == null) continue;
+                
+                    goto NEXT_LOOP;
+                }
+
+                return default;
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = await selector(e.Current);
+                    if( x == null) continue;
+                    if (value > x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Int32?> MinAwaitWithCancellationAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Int32?>> selector, CancellationToken cancellationToken)
+        {
+            Int32? value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = await selector(e.Current, cancellationToken);
+                    if(value == null) continue;
+                
+                    goto NEXT_LOOP;
+                }
+
+                return default;
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = await selector(e.Current, cancellationToken);
+                    if( x == null) continue;
+                    if (value > x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Int64?> MinAsync(IUniTaskAsyncEnumerable<Int64?> source, CancellationToken cancellationToken)
+        {
+            Int64? value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = e.Current;
+                    if(value == null) continue;
+                
+                    goto NEXT_LOOP;
+                }
+
+                return default;
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = e.Current;
+                    if( x == null) continue;
+                    if (value > x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Int64?> MinAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Int64?> selector, CancellationToken cancellationToken)
+        {
+            Int64? value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = selector(e.Current);
+                    if(value == null) continue;
+                
+                    goto NEXT_LOOP;
+                }
+
+                return default;
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = selector(e.Current);
+                    if( x == null) continue;
+                    if (value > x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Int64?> MinAwaitAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Int64?>> selector, CancellationToken cancellationToken)
+        {
+            Int64? value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = await selector(e.Current);
+                    if(value == null) continue;
+                
+                    goto NEXT_LOOP;
+                }
+
+                return default;
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = await selector(e.Current);
+                    if( x == null) continue;
+                    if (value > x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Int64?> MinAwaitWithCancellationAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Int64?>> selector, CancellationToken cancellationToken)
+        {
+            Int64? value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = await selector(e.Current, cancellationToken);
+                    if(value == null) continue;
+                
+                    goto NEXT_LOOP;
+                }
+
+                return default;
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = await selector(e.Current, cancellationToken);
+                    if( x == null) continue;
+                    if (value > x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Single?> MinAsync(IUniTaskAsyncEnumerable<Single?> source, CancellationToken cancellationToken)
+        {
+            Single? value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = e.Current;
+                    if(value == null) continue;
+                
+                    goto NEXT_LOOP;
+                }
+
+                return default;
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = e.Current;
+                    if( x == null) continue;
+                    if (value > x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Single?> MinAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Single?> selector, CancellationToken cancellationToken)
+        {
+            Single? value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = selector(e.Current);
+                    if(value == null) continue;
+                
+                    goto NEXT_LOOP;
+                }
+
+                return default;
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = selector(e.Current);
+                    if( x == null) continue;
+                    if (value > x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Single?> MinAwaitAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Single?>> selector, CancellationToken cancellationToken)
+        {
+            Single? value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = await selector(e.Current);
+                    if(value == null) continue;
+                
+                    goto NEXT_LOOP;
+                }
+
+                return default;
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = await selector(e.Current);
+                    if( x == null) continue;
+                    if (value > x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Single?> MinAwaitWithCancellationAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Single?>> selector, CancellationToken cancellationToken)
+        {
+            Single? value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = await selector(e.Current, cancellationToken);
+                    if(value == null) continue;
+                
+                    goto NEXT_LOOP;
+                }
+
+                return default;
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = await selector(e.Current, cancellationToken);
+                    if( x == null) continue;
+                    if (value > x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Double?> MinAsync(IUniTaskAsyncEnumerable<Double?> source, CancellationToken cancellationToken)
+        {
+            Double? value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = e.Current;
+                    if(value == null) continue;
+                
+                    goto NEXT_LOOP;
+                }
+
+                return default;
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = e.Current;
+                    if( x == null) continue;
+                    if (value > x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Double?> MinAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Double?> selector, CancellationToken cancellationToken)
+        {
+            Double? value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = selector(e.Current);
+                    if(value == null) continue;
+                
+                    goto NEXT_LOOP;
+                }
+
+                return default;
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = selector(e.Current);
+                    if( x == null) continue;
+                    if (value > x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Double?> MinAwaitAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Double?>> selector, CancellationToken cancellationToken)
+        {
+            Double? value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = await selector(e.Current);
+                    if(value == null) continue;
+                
+                    goto NEXT_LOOP;
+                }
+
+                return default;
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = await selector(e.Current);
+                    if( x == null) continue;
+                    if (value > x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Double?> MinAwaitWithCancellationAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Double?>> selector, CancellationToken cancellationToken)
+        {
+            Double? value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = await selector(e.Current, cancellationToken);
+                    if(value == null) continue;
+                
+                    goto NEXT_LOOP;
+                }
+
+                return default;
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = await selector(e.Current, cancellationToken);
+                    if( x == null) continue;
+                    if (value > x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Decimal?> MinAsync(IUniTaskAsyncEnumerable<Decimal?> source, CancellationToken cancellationToken)
+        {
+            Decimal? value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = e.Current;
+                    if(value == null) continue;
+                
+                    goto NEXT_LOOP;
+                }
+
+                return default;
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = e.Current;
+                    if( x == null) continue;
+                    if (value > x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Decimal?> MinAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Decimal?> selector, CancellationToken cancellationToken)
+        {
+            Decimal? value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = selector(e.Current);
+                    if(value == null) continue;
+                
+                    goto NEXT_LOOP;
+                }
+
+                return default;
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = selector(e.Current);
+                    if( x == null) continue;
+                    if (value > x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Decimal?> MinAwaitAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Decimal?>> selector, CancellationToken cancellationToken)
+        {
+            Decimal? value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = await selector(e.Current);
+                    if(value == null) continue;
+                
+                    goto NEXT_LOOP;
+                }
+
+                return default;
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = await selector(e.Current);
+                    if( x == null) continue;
+                    if (value > x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Decimal?> MinAwaitWithCancellationAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Decimal?>> selector, CancellationToken cancellationToken)
+        {
+            Decimal? value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = await selector(e.Current, cancellationToken);
+                    if(value == null) continue;
+                
+                    goto NEXT_LOOP;
+                }
+
+                return default;
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = await selector(e.Current, cancellationToken);
+                    if( x == null) continue;
+                    if (value > x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+    }
+
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static UniTask<Int32> MaxAsync(this IUniTaskAsyncEnumerable<Int32> source, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return Max.MaxAsync(source, cancellationToken);
+        }
+
+        public static UniTask<Int32> MaxAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Int32> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Max.MaxAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Int32> MaxAwaitAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Int32>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Max.MaxAwaitAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Int32> MaxAwaitWithCancellationAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Int32>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Max.MaxAwaitWithCancellationAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Int64> MaxAsync(this IUniTaskAsyncEnumerable<Int64> source, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return Max.MaxAsync(source, cancellationToken);
+        }
+
+        public static UniTask<Int64> MaxAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Int64> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Max.MaxAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Int64> MaxAwaitAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Int64>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Max.MaxAwaitAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Int64> MaxAwaitWithCancellationAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Int64>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Max.MaxAwaitWithCancellationAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Single> MaxAsync(this IUniTaskAsyncEnumerable<Single> source, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return Max.MaxAsync(source, cancellationToken);
+        }
+
+        public static UniTask<Single> MaxAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Single> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Max.MaxAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Single> MaxAwaitAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Single>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Max.MaxAwaitAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Single> MaxAwaitWithCancellationAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Single>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Max.MaxAwaitWithCancellationAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Double> MaxAsync(this IUniTaskAsyncEnumerable<Double> source, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return Max.MaxAsync(source, cancellationToken);
+        }
+
+        public static UniTask<Double> MaxAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Double> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Max.MaxAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Double> MaxAwaitAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Double>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Max.MaxAwaitAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Double> MaxAwaitWithCancellationAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Double>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Max.MaxAwaitWithCancellationAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Decimal> MaxAsync(this IUniTaskAsyncEnumerable<Decimal> source, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return Max.MaxAsync(source, cancellationToken);
+        }
+
+        public static UniTask<Decimal> MaxAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Decimal> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Max.MaxAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Decimal> MaxAwaitAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Decimal>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Max.MaxAwaitAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Decimal> MaxAwaitWithCancellationAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Decimal>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Max.MaxAwaitWithCancellationAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Int32?> MaxAsync(this IUniTaskAsyncEnumerable<Int32?> source, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return Max.MaxAsync(source, cancellationToken);
+        }
+
+        public static UniTask<Int32?> MaxAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Int32?> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Max.MaxAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Int32?> MaxAwaitAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Int32?>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Max.MaxAwaitAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Int32?> MaxAwaitWithCancellationAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Int32?>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Max.MaxAwaitWithCancellationAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Int64?> MaxAsync(this IUniTaskAsyncEnumerable<Int64?> source, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return Max.MaxAsync(source, cancellationToken);
+        }
+
+        public static UniTask<Int64?> MaxAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Int64?> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Max.MaxAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Int64?> MaxAwaitAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Int64?>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Max.MaxAwaitAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Int64?> MaxAwaitWithCancellationAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Int64?>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Max.MaxAwaitWithCancellationAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Single?> MaxAsync(this IUniTaskAsyncEnumerable<Single?> source, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return Max.MaxAsync(source, cancellationToken);
+        }
+
+        public static UniTask<Single?> MaxAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Single?> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Max.MaxAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Single?> MaxAwaitAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Single?>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Max.MaxAwaitAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Single?> MaxAwaitWithCancellationAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Single?>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Max.MaxAwaitWithCancellationAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Double?> MaxAsync(this IUniTaskAsyncEnumerable<Double?> source, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return Max.MaxAsync(source, cancellationToken);
+        }
+
+        public static UniTask<Double?> MaxAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Double?> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Max.MaxAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Double?> MaxAwaitAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Double?>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Max.MaxAwaitAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Double?> MaxAwaitWithCancellationAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Double?>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Max.MaxAwaitWithCancellationAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Decimal?> MaxAsync(this IUniTaskAsyncEnumerable<Decimal?> source, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return Max.MaxAsync(source, cancellationToken);
+        }
+
+        public static UniTask<Decimal?> MaxAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Decimal?> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Max.MaxAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Decimal?> MaxAwaitAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Decimal?>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Max.MaxAwaitAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Decimal?> MaxAwaitWithCancellationAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Decimal?>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Max.MaxAwaitWithCancellationAsync(source, selector, cancellationToken);
+        }
+
+    }
+
+    internal static partial class Max
+    {
+        public static async UniTask<Int32> MaxAsync(IUniTaskAsyncEnumerable<Int32> source, CancellationToken cancellationToken)
+        {
+            Int32 value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = e.Current;
+                
+                    goto NEXT_LOOP;
+                }
+
+                throw Error.NoElements();
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = e.Current;
+                    if (value < x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Int32> MaxAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Int32> selector, CancellationToken cancellationToken)
+        {
+            Int32 value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = selector(e.Current);
+                
+                    goto NEXT_LOOP;
+                }
+
+                throw Error.NoElements();
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = selector(e.Current);
+                    if (value < x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Int32> MaxAwaitAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Int32>> selector, CancellationToken cancellationToken)
+        {
+            Int32 value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = await selector(e.Current);
+                
+                    goto NEXT_LOOP;
+                }
+
+                throw Error.NoElements();
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = await selector(e.Current);
+                    if (value < x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Int32> MaxAwaitWithCancellationAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Int32>> selector, CancellationToken cancellationToken)
+        {
+            Int32 value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = await selector(e.Current, cancellationToken);
+                
+                    goto NEXT_LOOP;
+                }
+
+                throw Error.NoElements();
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = await selector(e.Current, cancellationToken);
+                    if (value < x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Int64> MaxAsync(IUniTaskAsyncEnumerable<Int64> source, CancellationToken cancellationToken)
+        {
+            Int64 value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = e.Current;
+                
+                    goto NEXT_LOOP;
+                }
+
+                throw Error.NoElements();
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = e.Current;
+                    if (value < x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Int64> MaxAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Int64> selector, CancellationToken cancellationToken)
+        {
+            Int64 value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = selector(e.Current);
+                
+                    goto NEXT_LOOP;
+                }
+
+                throw Error.NoElements();
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = selector(e.Current);
+                    if (value < x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Int64> MaxAwaitAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Int64>> selector, CancellationToken cancellationToken)
+        {
+            Int64 value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = await selector(e.Current);
+                
+                    goto NEXT_LOOP;
+                }
+
+                throw Error.NoElements();
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = await selector(e.Current);
+                    if (value < x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Int64> MaxAwaitWithCancellationAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Int64>> selector, CancellationToken cancellationToken)
+        {
+            Int64 value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = await selector(e.Current, cancellationToken);
+                
+                    goto NEXT_LOOP;
+                }
+
+                throw Error.NoElements();
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = await selector(e.Current, cancellationToken);
+                    if (value < x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Single> MaxAsync(IUniTaskAsyncEnumerable<Single> source, CancellationToken cancellationToken)
+        {
+            Single value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = e.Current;
+                
+                    goto NEXT_LOOP;
+                }
+
+                throw Error.NoElements();
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = e.Current;
+                    if (value < x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Single> MaxAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Single> selector, CancellationToken cancellationToken)
+        {
+            Single value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = selector(e.Current);
+                
+                    goto NEXT_LOOP;
+                }
+
+                throw Error.NoElements();
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = selector(e.Current);
+                    if (value < x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Single> MaxAwaitAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Single>> selector, CancellationToken cancellationToken)
+        {
+            Single value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = await selector(e.Current);
+                
+                    goto NEXT_LOOP;
+                }
+
+                throw Error.NoElements();
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = await selector(e.Current);
+                    if (value < x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Single> MaxAwaitWithCancellationAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Single>> selector, CancellationToken cancellationToken)
+        {
+            Single value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = await selector(e.Current, cancellationToken);
+                
+                    goto NEXT_LOOP;
+                }
+
+                throw Error.NoElements();
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = await selector(e.Current, cancellationToken);
+                    if (value < x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Double> MaxAsync(IUniTaskAsyncEnumerable<Double> source, CancellationToken cancellationToken)
+        {
+            Double value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = e.Current;
+                
+                    goto NEXT_LOOP;
+                }
+
+                throw Error.NoElements();
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = e.Current;
+                    if (value < x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Double> MaxAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Double> selector, CancellationToken cancellationToken)
+        {
+            Double value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = selector(e.Current);
+                
+                    goto NEXT_LOOP;
+                }
+
+                throw Error.NoElements();
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = selector(e.Current);
+                    if (value < x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Double> MaxAwaitAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Double>> selector, CancellationToken cancellationToken)
+        {
+            Double value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = await selector(e.Current);
+                
+                    goto NEXT_LOOP;
+                }
+
+                throw Error.NoElements();
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = await selector(e.Current);
+                    if (value < x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Double> MaxAwaitWithCancellationAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Double>> selector, CancellationToken cancellationToken)
+        {
+            Double value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = await selector(e.Current, cancellationToken);
+                
+                    goto NEXT_LOOP;
+                }
+
+                throw Error.NoElements();
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = await selector(e.Current, cancellationToken);
+                    if (value < x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Decimal> MaxAsync(IUniTaskAsyncEnumerable<Decimal> source, CancellationToken cancellationToken)
+        {
+            Decimal value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = e.Current;
+                
+                    goto NEXT_LOOP;
+                }
+
+                throw Error.NoElements();
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = e.Current;
+                    if (value < x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Decimal> MaxAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Decimal> selector, CancellationToken cancellationToken)
+        {
+            Decimal value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = selector(e.Current);
+                
+                    goto NEXT_LOOP;
+                }
+
+                throw Error.NoElements();
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = selector(e.Current);
+                    if (value < x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Decimal> MaxAwaitAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Decimal>> selector, CancellationToken cancellationToken)
+        {
+            Decimal value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = await selector(e.Current);
+                
+                    goto NEXT_LOOP;
+                }
+
+                throw Error.NoElements();
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = await selector(e.Current);
+                    if (value < x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Decimal> MaxAwaitWithCancellationAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Decimal>> selector, CancellationToken cancellationToken)
+        {
+            Decimal value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = await selector(e.Current, cancellationToken);
+                
+                    goto NEXT_LOOP;
+                }
+
+                throw Error.NoElements();
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = await selector(e.Current, cancellationToken);
+                    if (value < x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Int32?> MaxAsync(IUniTaskAsyncEnumerable<Int32?> source, CancellationToken cancellationToken)
+        {
+            Int32? value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = e.Current;
+                    if(value == null) continue;
+                
+                    goto NEXT_LOOP;
+                }
+
+                return default;
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = e.Current;
+                    if( x == null) continue;
+                    if (value < x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Int32?> MaxAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Int32?> selector, CancellationToken cancellationToken)
+        {
+            Int32? value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = selector(e.Current);
+                    if(value == null) continue;
+                
+                    goto NEXT_LOOP;
+                }
+
+                return default;
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = selector(e.Current);
+                    if( x == null) continue;
+                    if (value < x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Int32?> MaxAwaitAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Int32?>> selector, CancellationToken cancellationToken)
+        {
+            Int32? value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = await selector(e.Current);
+                    if(value == null) continue;
+                
+                    goto NEXT_LOOP;
+                }
+
+                return default;
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = await selector(e.Current);
+                    if( x == null) continue;
+                    if (value < x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Int32?> MaxAwaitWithCancellationAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Int32?>> selector, CancellationToken cancellationToken)
+        {
+            Int32? value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = await selector(e.Current, cancellationToken);
+                    if(value == null) continue;
+                
+                    goto NEXT_LOOP;
+                }
+
+                return default;
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = await selector(e.Current, cancellationToken);
+                    if( x == null) continue;
+                    if (value < x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Int64?> MaxAsync(IUniTaskAsyncEnumerable<Int64?> source, CancellationToken cancellationToken)
+        {
+            Int64? value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = e.Current;
+                    if(value == null) continue;
+                
+                    goto NEXT_LOOP;
+                }
+
+                return default;
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = e.Current;
+                    if( x == null) continue;
+                    if (value < x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Int64?> MaxAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Int64?> selector, CancellationToken cancellationToken)
+        {
+            Int64? value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = selector(e.Current);
+                    if(value == null) continue;
+                
+                    goto NEXT_LOOP;
+                }
+
+                return default;
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = selector(e.Current);
+                    if( x == null) continue;
+                    if (value < x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Int64?> MaxAwaitAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Int64?>> selector, CancellationToken cancellationToken)
+        {
+            Int64? value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = await selector(e.Current);
+                    if(value == null) continue;
+                
+                    goto NEXT_LOOP;
+                }
+
+                return default;
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = await selector(e.Current);
+                    if( x == null) continue;
+                    if (value < x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Int64?> MaxAwaitWithCancellationAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Int64?>> selector, CancellationToken cancellationToken)
+        {
+            Int64? value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = await selector(e.Current, cancellationToken);
+                    if(value == null) continue;
+                
+                    goto NEXT_LOOP;
+                }
+
+                return default;
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = await selector(e.Current, cancellationToken);
+                    if( x == null) continue;
+                    if (value < x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Single?> MaxAsync(IUniTaskAsyncEnumerable<Single?> source, CancellationToken cancellationToken)
+        {
+            Single? value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = e.Current;
+                    if(value == null) continue;
+                
+                    goto NEXT_LOOP;
+                }
+
+                return default;
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = e.Current;
+                    if( x == null) continue;
+                    if (value < x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Single?> MaxAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Single?> selector, CancellationToken cancellationToken)
+        {
+            Single? value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = selector(e.Current);
+                    if(value == null) continue;
+                
+                    goto NEXT_LOOP;
+                }
+
+                return default;
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = selector(e.Current);
+                    if( x == null) continue;
+                    if (value < x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Single?> MaxAwaitAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Single?>> selector, CancellationToken cancellationToken)
+        {
+            Single? value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = await selector(e.Current);
+                    if(value == null) continue;
+                
+                    goto NEXT_LOOP;
+                }
+
+                return default;
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = await selector(e.Current);
+                    if( x == null) continue;
+                    if (value < x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Single?> MaxAwaitWithCancellationAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Single?>> selector, CancellationToken cancellationToken)
+        {
+            Single? value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = await selector(e.Current, cancellationToken);
+                    if(value == null) continue;
+                
+                    goto NEXT_LOOP;
+                }
+
+                return default;
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = await selector(e.Current, cancellationToken);
+                    if( x == null) continue;
+                    if (value < x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Double?> MaxAsync(IUniTaskAsyncEnumerable<Double?> source, CancellationToken cancellationToken)
+        {
+            Double? value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = e.Current;
+                    if(value == null) continue;
+                
+                    goto NEXT_LOOP;
+                }
+
+                return default;
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = e.Current;
+                    if( x == null) continue;
+                    if (value < x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Double?> MaxAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Double?> selector, CancellationToken cancellationToken)
+        {
+            Double? value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = selector(e.Current);
+                    if(value == null) continue;
+                
+                    goto NEXT_LOOP;
+                }
+
+                return default;
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = selector(e.Current);
+                    if( x == null) continue;
+                    if (value < x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Double?> MaxAwaitAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Double?>> selector, CancellationToken cancellationToken)
+        {
+            Double? value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = await selector(e.Current);
+                    if(value == null) continue;
+                
+                    goto NEXT_LOOP;
+                }
+
+                return default;
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = await selector(e.Current);
+                    if( x == null) continue;
+                    if (value < x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Double?> MaxAwaitWithCancellationAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Double?>> selector, CancellationToken cancellationToken)
+        {
+            Double? value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = await selector(e.Current, cancellationToken);
+                    if(value == null) continue;
+                
+                    goto NEXT_LOOP;
+                }
+
+                return default;
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = await selector(e.Current, cancellationToken);
+                    if( x == null) continue;
+                    if (value < x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Decimal?> MaxAsync(IUniTaskAsyncEnumerable<Decimal?> source, CancellationToken cancellationToken)
+        {
+            Decimal? value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = e.Current;
+                    if(value == null) continue;
+                
+                    goto NEXT_LOOP;
+                }
+
+                return default;
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = e.Current;
+                    if( x == null) continue;
+                    if (value < x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Decimal?> MaxAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Decimal?> selector, CancellationToken cancellationToken)
+        {
+            Decimal? value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = selector(e.Current);
+                    if(value == null) continue;
+                
+                    goto NEXT_LOOP;
+                }
+
+                return default;
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = selector(e.Current);
+                    if( x == null) continue;
+                    if (value < x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Decimal?> MaxAwaitAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Decimal?>> selector, CancellationToken cancellationToken)
+        {
+            Decimal? value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = await selector(e.Current);
+                    if(value == null) continue;
+                
+                    goto NEXT_LOOP;
+                }
+
+                return default;
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = await selector(e.Current);
+                    if( x == null) continue;
+                    if (value < x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+        public static async UniTask<Decimal?> MaxAwaitWithCancellationAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Decimal?>> selector, CancellationToken cancellationToken)
+        {
+            Decimal? value = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    value = await selector(e.Current, cancellationToken);
+                    if(value == null) continue;
+                
+                    goto NEXT_LOOP;
+                }
+
+                return default;
+                
+                NEXT_LOOP:
+
+                while (await e.MoveNextAsync())
+                {
+                    var x = await selector(e.Current, cancellationToken);
+                    if( x == null) continue;
+                    if (value < x)
+                    {
+                        value = x;
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return value;
+        }
+
+    }
+
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/MinMax.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/MinMax.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2d6da02d9ab970e4999daf7147d98e36
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Never.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Never.cs
@@ -1,0 +1,56 @@
+﻿using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static IUniTaskAsyncEnumerable<T> Never<T>()
+        {
+            return Cysharp.Threading.Tasks.Linq.Never<T>.Instance;
+        }
+    }
+
+    internal class Never<T> : IUniTaskAsyncEnumerable<T>
+    {
+        public static readonly IUniTaskAsyncEnumerable<T> Instance = new Never<T>();
+
+        Never()
+        {
+        }
+
+        public IUniTaskAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _Never(cancellationToken);
+        }
+
+        class _Never : IUniTaskAsyncEnumerator<T>
+        {
+            CancellationToken cancellationToken;
+
+            public _Never(CancellationToken cancellationToken)
+            {
+                this.cancellationToken = cancellationToken;
+            }
+
+            public T Current => default;
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                var tcs = new UniTaskCompletionSource<bool>();
+
+                cancellationToken.Register(state =>
+                {
+                    var task = (UniTaskCompletionSource<bool>)state;
+                    task.TrySetCanceled(cancellationToken);
+                }, tcs);
+
+                return tcs.Task;
+            }
+
+            public UniTask DisposeAsync()
+            {
+                return default;
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Never.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Never.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8b307c3d3be71a94da251564bcdefa3d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/OfType.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/OfType.cs
@@ -1,0 +1,61 @@
+﻿using Cysharp.Threading.Tasks.Internal;
+using System;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static IUniTaskAsyncEnumerable<TResult> OfType<TResult>(this IUniTaskAsyncEnumerable<Object> source)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return new OfType<TResult>(source);
+        }
+    }
+
+    internal sealed class OfType<TResult> : IUniTaskAsyncEnumerable<TResult>
+    {
+        readonly IUniTaskAsyncEnumerable<object> source;
+
+        public OfType(IUniTaskAsyncEnumerable<object> source)
+        {
+            this.source = source;
+        }
+
+        public IUniTaskAsyncEnumerator<TResult> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _OfType(source, cancellationToken);
+        }
+
+        class _OfType : AsyncEnumeratorBase<object, TResult>
+        {
+            public _OfType(IUniTaskAsyncEnumerable<object> source, CancellationToken cancellationToken)
+
+                : base(source, cancellationToken)
+            {
+            }
+
+            protected override bool TryMoveNextCore(bool sourceHasCurrent, out bool result)
+            {
+                if (sourceHasCurrent)
+                {
+                    if (SourceCurrent is TResult castCurent)
+                    {
+                        Current = castCurent;
+                        result = true;
+                        return true;
+                    }
+                    else
+                    {
+                        result = default;
+                        return false;
+                    }
+                }
+
+                result = false;
+                return true;
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/OfType.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/OfType.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 111ffe87a7d700442a9ef5af554b252c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/OrderBy.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/OrderBy.cs
@@ -1,0 +1,558 @@
+﻿using Cysharp.Threading.Tasks;
+using Cysharp.Threading.Tasks.Internal;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        #region OrderBy_OrderByDescending
+
+        public static IUniTaskOrderedAsyncEnumerable<TSource> OrderBy<TSource, TKey>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+
+            return new OrderedAsyncEnumerable<TSource, TKey>(source, keySelector, Comparer<TKey>.Default, false, null);
+        }
+
+        public static IUniTaskOrderedAsyncEnumerable<TSource> OrderBy<TSource, TKey>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, IComparer<TKey> comparer)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            Error.ThrowArgumentNullException(comparer, nameof(comparer));
+
+            return new OrderedAsyncEnumerable<TSource, TKey>(source, keySelector, comparer, false, null);
+        }
+
+        public static IUniTaskOrderedAsyncEnumerable<TSource> OrderByAwait<TSource, TKey>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<TKey>> keySelector)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+
+            return new OrderedAsyncEnumerableAwait<TSource, TKey>(source, keySelector, Comparer<TKey>.Default, false, null);
+        }
+
+        public static IUniTaskOrderedAsyncEnumerable<TSource> OrderByAwait<TSource, TKey>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<TKey>> keySelector, IComparer<TKey> comparer)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            Error.ThrowArgumentNullException(comparer, nameof(comparer));
+
+            return new OrderedAsyncEnumerableAwait<TSource, TKey>(source, keySelector, comparer, false, null);
+        }
+
+        public static IUniTaskOrderedAsyncEnumerable<TSource> OrderByAwaitWithCancellation<TSource, TKey>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<TKey>> keySelector)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+
+            return new OrderedAsyncEnumerableAwaitWithCancellation<TSource, TKey>(source, keySelector, Comparer<TKey>.Default, false, null);
+        }
+
+        public static IUniTaskOrderedAsyncEnumerable<TSource> OrderByAwaitWithCancellation<TSource, TKey>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<TKey>> keySelector, IComparer<TKey> comparer)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            Error.ThrowArgumentNullException(comparer, nameof(comparer));
+
+            return new OrderedAsyncEnumerableAwaitWithCancellation<TSource, TKey>(source, keySelector, comparer, false, null);
+        }
+
+        public static IUniTaskOrderedAsyncEnumerable<TSource> OrderByDescending<TSource, TKey>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+
+            return new OrderedAsyncEnumerable<TSource, TKey>(source, keySelector, Comparer<TKey>.Default, true, null);
+        }
+
+        public static IUniTaskOrderedAsyncEnumerable<TSource> OrderByDescending<TSource, TKey>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, IComparer<TKey> comparer)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            Error.ThrowArgumentNullException(comparer, nameof(comparer));
+
+            return new OrderedAsyncEnumerable<TSource, TKey>(source, keySelector, comparer, true, null);
+        }
+
+        public static IUniTaskOrderedAsyncEnumerable<TSource> OrderByDescendingAwait<TSource, TKey>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<TKey>> keySelector)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+
+            return new OrderedAsyncEnumerableAwait<TSource, TKey>(source, keySelector, Comparer<TKey>.Default, true, null);
+        }
+
+        public static IUniTaskOrderedAsyncEnumerable<TSource> OrderByDescendingAwait<TSource, TKey>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<TKey>> keySelector, IComparer<TKey> comparer)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            Error.ThrowArgumentNullException(comparer, nameof(comparer));
+
+            return new OrderedAsyncEnumerableAwait<TSource, TKey>(source, keySelector, comparer, true, null);
+        }
+
+        public static IUniTaskOrderedAsyncEnumerable<TSource> OrderByDescendingAwaitWithCancellation<TSource, TKey>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<TKey>> keySelector)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+
+            return new OrderedAsyncEnumerableAwaitWithCancellation<TSource, TKey>(source, keySelector, Comparer<TKey>.Default, true, null);
+        }
+
+        public static IUniTaskOrderedAsyncEnumerable<TSource> OrderByDescendingAwaitWithCancellation<TSource, TKey>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<TKey>> keySelector, IComparer<TKey> comparer)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            Error.ThrowArgumentNullException(comparer, nameof(comparer));
+
+            return new OrderedAsyncEnumerableAwaitWithCancellation<TSource, TKey>(source, keySelector, comparer, true, null);
+        }
+
+        #endregion
+
+        #region ThenBy_ThenByDescending
+
+        public static IUniTaskOrderedAsyncEnumerable<TSource> ThenBy<TSource, TKey>(this IUniTaskOrderedAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+
+            return source.CreateOrderedEnumerable(keySelector, Comparer<TKey>.Default, false);
+        }
+
+        public static IUniTaskOrderedAsyncEnumerable<TSource> ThenBy<TSource, TKey>(this IUniTaskOrderedAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, IComparer<TKey> comparer)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            Error.ThrowArgumentNullException(comparer, nameof(comparer));
+
+            return source.CreateOrderedEnumerable(keySelector, comparer, false);
+        }
+
+        public static IUniTaskOrderedAsyncEnumerable<TSource> ThenByAwait<TSource, TKey>(this IUniTaskOrderedAsyncEnumerable<TSource> source, Func<TSource, UniTask<TKey>> keySelector)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+
+            return source.CreateOrderedEnumerable(keySelector, Comparer<TKey>.Default, false);
+        }
+
+        public static IUniTaskOrderedAsyncEnumerable<TSource> ThenByAwait<TSource, TKey>(this IUniTaskOrderedAsyncEnumerable<TSource> source, Func<TSource, UniTask<TKey>> keySelector, IComparer<TKey> comparer)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            Error.ThrowArgumentNullException(comparer, nameof(comparer));
+
+            return source.CreateOrderedEnumerable(keySelector, comparer, false);
+        }
+
+        public static IUniTaskOrderedAsyncEnumerable<TSource> ThenByAwaitWithCancellation<TSource, TKey>(this IUniTaskOrderedAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<TKey>> keySelector)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+
+            return source.CreateOrderedEnumerable(keySelector, Comparer<TKey>.Default, false);
+        }
+
+        public static IUniTaskOrderedAsyncEnumerable<TSource> ThenByAwaitWithCancellation<TSource, TKey>(this IUniTaskOrderedAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<TKey>> keySelector, IComparer<TKey> comparer)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            Error.ThrowArgumentNullException(comparer, nameof(comparer));
+
+            return source.CreateOrderedEnumerable(keySelector, comparer, false);
+        }
+
+        public static IUniTaskOrderedAsyncEnumerable<TSource> ThenByDescending<TSource, TKey>(this IUniTaskOrderedAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+
+            return source.CreateOrderedEnumerable(keySelector, Comparer<TKey>.Default, true);
+        }
+
+        public static IUniTaskOrderedAsyncEnumerable<TSource> ThenByDescending<TSource, TKey>(this IUniTaskOrderedAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, IComparer<TKey> comparer)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            Error.ThrowArgumentNullException(comparer, nameof(comparer));
+
+            return source.CreateOrderedEnumerable(keySelector, comparer, true);
+        }
+
+        public static IUniTaskOrderedAsyncEnumerable<TSource> ThenByDescendingAwait<TSource, TKey>(this IUniTaskOrderedAsyncEnumerable<TSource> source, Func<TSource, UniTask<TKey>> keySelector)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+
+            return source.CreateOrderedEnumerable(keySelector, Comparer<TKey>.Default, true);
+        }
+
+        public static IUniTaskOrderedAsyncEnumerable<TSource> ThenByDescendingAwait<TSource, TKey>(this IUniTaskOrderedAsyncEnumerable<TSource> source, Func<TSource, UniTask<TKey>> keySelector, IComparer<TKey> comparer)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            Error.ThrowArgumentNullException(comparer, nameof(comparer));
+
+            return source.CreateOrderedEnumerable(keySelector, comparer, true);
+        }
+
+        public static IUniTaskOrderedAsyncEnumerable<TSource> ThenByDescendingAwaitWithCancellation<TSource, TKey>(this IUniTaskOrderedAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<TKey>> keySelector)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+
+            return source.CreateOrderedEnumerable(keySelector, Comparer<TKey>.Default, true);
+        }
+
+        public static IUniTaskOrderedAsyncEnumerable<TSource> ThenByDescendingAwaitWithCancellation<TSource, TKey>(this IUniTaskOrderedAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<TKey>> keySelector, IComparer<TKey> comparer)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            Error.ThrowArgumentNullException(comparer, nameof(comparer));
+
+            return source.CreateOrderedEnumerable(keySelector, comparer, true);
+        }
+
+        #endregion
+    }
+
+    internal abstract class AsyncEnumerableSorter<TElement>
+    {
+        internal abstract UniTask ComputeKeysAsync(TElement[] elements, int count);
+
+        internal abstract int CompareKeys(int index1, int index2);
+
+        internal async UniTask<int[]> SortAsync(TElement[] elements, int count)
+        {
+            await ComputeKeysAsync(elements, count);
+
+            int[] map = new int[count];
+            for (int i = 0; i < count; i++) map[i] = i;
+            QuickSort(map, 0, count - 1);
+            return map;
+        }
+
+        void QuickSort(int[] map, int left, int right)
+        {
+            do
+            {
+                int i = left;
+                int j = right;
+                int x = map[i + ((j - i) >> 1)];
+                do
+                {
+                    while (i < map.Length && CompareKeys(x, map[i]) > 0) i++;
+                    while (j >= 0 && CompareKeys(x, map[j]) < 0) j--;
+                    if (i > j) break;
+                    if (i < j)
+                    {
+                        int temp = map[i];
+                        map[i] = map[j];
+                        map[j] = temp;
+                    }
+                    i++;
+                    j--;
+                } while (i <= j);
+                if (j - left <= right - i)
+                {
+                    if (left < j) QuickSort(map, left, j);
+                    left = i;
+                }
+                else
+                {
+                    if (i < right) QuickSort(map, i, right);
+                    right = j;
+                }
+            } while (left < right);
+        }
+    }
+
+    internal class SyncSelectorAsyncEnumerableSorter<TElement, TKey> : AsyncEnumerableSorter<TElement>
+    {
+        readonly Func<TElement, TKey> keySelector;
+        readonly IComparer<TKey> comparer;
+        readonly bool descending;
+        readonly AsyncEnumerableSorter<TElement> next;
+        TKey[] keys;
+
+        internal SyncSelectorAsyncEnumerableSorter(Func<TElement, TKey> keySelector, IComparer<TKey> comparer, bool descending, AsyncEnumerableSorter<TElement> next)
+        {
+            this.keySelector = keySelector;
+            this.comparer = comparer;
+            this.descending = descending;
+            this.next = next;
+        }
+
+        internal override async UniTask ComputeKeysAsync(TElement[] elements, int count)
+        {
+            keys = new TKey[count];
+            for (int i = 0; i < count; i++) keys[i] = keySelector(elements[i]);
+            if (next != null) await next.ComputeKeysAsync(elements, count);
+        }
+
+        internal override int CompareKeys(int index1, int index2)
+        {
+            int c = comparer.Compare(keys[index1], keys[index2]);
+            if (c == 0)
+            {
+                if (next == null) return index1 - index2;
+                return next.CompareKeys(index1, index2);
+            }
+            return descending ? -c : c;
+        }
+    }
+
+    internal class AsyncSelectorEnumerableSorter<TElement, TKey> : AsyncEnumerableSorter<TElement>
+    {
+        readonly Func<TElement, UniTask<TKey>> keySelector;
+        readonly IComparer<TKey> comparer;
+        readonly bool descending;
+        readonly AsyncEnumerableSorter<TElement> next;
+        TKey[] keys;
+
+        internal AsyncSelectorEnumerableSorter(Func<TElement, UniTask<TKey>> keySelector, IComparer<TKey> comparer, bool descending, AsyncEnumerableSorter<TElement> next)
+        {
+            this.keySelector = keySelector;
+            this.comparer = comparer;
+            this.descending = descending;
+            this.next = next;
+        }
+
+        internal override async UniTask ComputeKeysAsync(TElement[] elements, int count)
+        {
+            keys = new TKey[count];
+            for (int i = 0; i < count; i++) keys[i] = await keySelector(elements[i]);
+            if (next != null) await next.ComputeKeysAsync(elements, count);
+        }
+
+        internal override int CompareKeys(int index1, int index2)
+        {
+            int c = comparer.Compare(keys[index1], keys[index2]);
+            if (c == 0)
+            {
+                if (next == null) return index1 - index2;
+                return next.CompareKeys(index1, index2);
+            }
+            return descending ? -c : c;
+        }
+    }
+
+    internal class AsyncSelectorWithCancellationEnumerableSorter<TElement, TKey> : AsyncEnumerableSorter<TElement>
+    {
+        readonly Func<TElement, CancellationToken, UniTask<TKey>> keySelector;
+        readonly IComparer<TKey> comparer;
+        readonly bool descending;
+        readonly AsyncEnumerableSorter<TElement> next;
+        CancellationToken cancellationToken;
+        TKey[] keys;
+
+        internal AsyncSelectorWithCancellationEnumerableSorter(Func<TElement, CancellationToken, UniTask<TKey>> keySelector, IComparer<TKey> comparer, bool descending, AsyncEnumerableSorter<TElement> next, CancellationToken cancellationToken)
+        {
+            this.keySelector = keySelector;
+            this.comparer = comparer;
+            this.descending = descending;
+            this.next = next;
+            this.cancellationToken = cancellationToken;
+        }
+
+        internal override async UniTask ComputeKeysAsync(TElement[] elements, int count)
+        {
+            keys = new TKey[count];
+            for (int i = 0; i < count; i++) keys[i] = await keySelector(elements[i], cancellationToken);
+            if (next != null) await next.ComputeKeysAsync(elements, count);
+        }
+
+        internal override int CompareKeys(int index1, int index2)
+        {
+            int c = comparer.Compare(keys[index1], keys[index2]);
+            if (c == 0)
+            {
+                if (next == null) return index1 - index2;
+                return next.CompareKeys(index1, index2);
+            }
+            return descending ? -c : c;
+        }
+    }
+
+    internal abstract class OrderedAsyncEnumerable<TElement> : IUniTaskOrderedAsyncEnumerable<TElement>
+    {
+        protected readonly IUniTaskAsyncEnumerable<TElement> source;
+
+        public OrderedAsyncEnumerable(IUniTaskAsyncEnumerable<TElement> source)
+        {
+            this.source = source;
+        }
+
+        public IUniTaskOrderedAsyncEnumerable<TElement> CreateOrderedEnumerable<TKey>(Func<TElement, TKey> keySelector, IComparer<TKey> comparer, bool descending)
+        {
+            return new OrderedAsyncEnumerable<TElement, TKey>(source, keySelector, comparer, descending, this);
+        }
+
+        public IUniTaskOrderedAsyncEnumerable<TElement> CreateOrderedEnumerable<TKey>(Func<TElement, UniTask<TKey>> keySelector, IComparer<TKey> comparer, bool descending)
+        {
+            return new OrderedAsyncEnumerableAwait<TElement, TKey>(source, keySelector, comparer, descending, this);
+        }
+
+        public IUniTaskOrderedAsyncEnumerable<TElement> CreateOrderedEnumerable<TKey>(Func<TElement, CancellationToken, UniTask<TKey>> keySelector, IComparer<TKey> comparer, bool descending)
+        {
+            return new OrderedAsyncEnumerableAwaitWithCancellation<TElement, TKey>(source, keySelector, comparer, descending, this);
+        }
+
+        internal abstract AsyncEnumerableSorter<TElement> GetAsyncEnumerableSorter(AsyncEnumerableSorter<TElement> next, CancellationToken cancellationToken);
+
+        public IUniTaskAsyncEnumerator<TElement> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _OrderedAsyncEnumerator(this, cancellationToken);
+        }
+
+        class _OrderedAsyncEnumerator : MoveNextSource, IUniTaskAsyncEnumerator<TElement>
+        {
+            protected readonly OrderedAsyncEnumerable<TElement> parent;
+            CancellationToken cancellationToken;
+            TElement[] buffer;
+            int[] map;
+            int index;
+
+            public _OrderedAsyncEnumerator(OrderedAsyncEnumerable<TElement> parent, CancellationToken cancellationToken)
+            {
+                this.parent = parent;
+                this.cancellationToken = cancellationToken;
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public TElement Current { get; private set; }
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (map == null)
+                {
+                    completionSource.Reset();
+                    CreateSortSource().Forget();
+                    return new UniTask<bool>(this, completionSource.Version);
+                }
+
+                if (index < buffer.Length)
+                {
+                    Current = buffer[map[index++]];
+                    return CompletedTasks.True;
+                }
+                else
+                {
+                    return CompletedTasks.False;
+                }
+            }
+
+            async UniTaskVoid CreateSortSource()
+            {
+                try
+                {
+                    buffer = await parent.source.ToArrayAsync();
+                    if (buffer.Length == 0)
+                    {
+                        completionSource.TrySetResult(false);
+                        return;
+                    }
+
+                    var sorter = parent.GetAsyncEnumerableSorter(null, cancellationToken);
+                    map = await sorter.SortAsync(buffer, buffer.Length);
+                    sorter = null;
+
+                    // set first value
+                    Current = buffer[map[index++]];
+                }
+                catch (Exception ex)
+                {
+                    completionSource.TrySetException(ex);
+                    return;
+                }
+
+                completionSource.TrySetResult(true);
+            }
+
+            public UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                return default;
+            }
+        }
+    }
+
+    internal class OrderedAsyncEnumerable<TElement, TKey> : OrderedAsyncEnumerable<TElement>
+    {
+        readonly Func<TElement, TKey> keySelector;
+        readonly IComparer<TKey> comparer;
+        readonly bool descending;
+        readonly OrderedAsyncEnumerable<TElement> parent;
+
+        public OrderedAsyncEnumerable(IUniTaskAsyncEnumerable<TElement> source, Func<TElement, TKey> keySelector, IComparer<TKey> comparer, bool descending, OrderedAsyncEnumerable<TElement> parent)
+            : base(source)
+        {
+            this.keySelector = keySelector;
+            this.comparer = comparer;
+            this.descending = descending;
+            this.parent = parent;
+        }
+
+        internal override AsyncEnumerableSorter<TElement> GetAsyncEnumerableSorter(AsyncEnumerableSorter<TElement> next, CancellationToken cancellationToken)
+        {
+            AsyncEnumerableSorter<TElement> sorter = new SyncSelectorAsyncEnumerableSorter<TElement, TKey>(keySelector, comparer, descending, next);
+            if (parent != null) sorter = parent.GetAsyncEnumerableSorter(sorter, cancellationToken);
+            return sorter;
+        }
+    }
+
+    internal class OrderedAsyncEnumerableAwait<TElement, TKey> : OrderedAsyncEnumerable<TElement>
+    {
+        readonly Func<TElement, UniTask<TKey>> keySelector;
+        readonly IComparer<TKey> comparer;
+        readonly bool descending;
+        readonly OrderedAsyncEnumerable<TElement> parent;
+
+        public OrderedAsyncEnumerableAwait(IUniTaskAsyncEnumerable<TElement> source, Func<TElement, UniTask<TKey>> keySelector, IComparer<TKey> comparer, bool descending, OrderedAsyncEnumerable<TElement> parent)
+            : base(source)
+        {
+            this.keySelector = keySelector;
+            this.comparer = comparer;
+            this.descending = descending;
+            this.parent = parent;
+        }
+
+        internal override AsyncEnumerableSorter<TElement> GetAsyncEnumerableSorter(AsyncEnumerableSorter<TElement> next, CancellationToken cancellationToken)
+        {
+            AsyncEnumerableSorter<TElement> sorter = new AsyncSelectorEnumerableSorter<TElement, TKey>(keySelector, comparer, descending, next);
+            if (parent != null) sorter = parent.GetAsyncEnumerableSorter(sorter, cancellationToken);
+            return sorter;
+        }
+    }
+
+    internal class OrderedAsyncEnumerableAwaitWithCancellation<TElement, TKey> : OrderedAsyncEnumerable<TElement>
+    {
+        readonly Func<TElement, CancellationToken, UniTask<TKey>> keySelector;
+        readonly IComparer<TKey> comparer;
+        readonly bool descending;
+        readonly OrderedAsyncEnumerable<TElement> parent;
+
+        public OrderedAsyncEnumerableAwaitWithCancellation(IUniTaskAsyncEnumerable<TElement> source, Func<TElement, CancellationToken, UniTask<TKey>> keySelector, IComparer<TKey> comparer, bool descending, OrderedAsyncEnumerable<TElement> parent)
+            : base(source)
+        {
+            this.keySelector = keySelector;
+            this.comparer = comparer;
+            this.descending = descending;
+            this.parent = parent;
+        }
+
+        internal override AsyncEnumerableSorter<TElement> GetAsyncEnumerableSorter(AsyncEnumerableSorter<TElement> next, CancellationToken cancellationToken)
+        {
+            AsyncEnumerableSorter<TElement> sorter = new AsyncSelectorWithCancellationEnumerableSorter<TElement, TKey>(keySelector, comparer, descending, next, cancellationToken);
+            if (parent != null) sorter = parent.GetAsyncEnumerableSorter(sorter, cancellationToken);
+            return sorter;
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/OrderBy.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/OrderBy.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 413883ceff8546143bdf200aafa4b8f7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Pairwise.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Pairwise.cs
@@ -1,0 +1,128 @@
+﻿using Cysharp.Threading.Tasks.Internal;
+using System;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static IUniTaskAsyncEnumerable<(TSource, TSource)> Pairwise<TSource>(this IUniTaskAsyncEnumerable<TSource> source)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return new Pairwise<TSource>(source);
+        }
+    }
+
+    internal sealed class Pairwise<TSource> : IUniTaskAsyncEnumerable<(TSource, TSource)>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+
+        public Pairwise(IUniTaskAsyncEnumerable<TSource> source)
+        {
+            this.source = source;
+        }
+
+        public IUniTaskAsyncEnumerator<(TSource, TSource)> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _Pairwise(source, cancellationToken);
+        }
+
+        sealed class _Pairwise : MoveNextSource, IUniTaskAsyncEnumerator<(TSource, TSource)>
+        {
+            static readonly Action<object> MoveNextCoreDelegate = MoveNextCore;
+
+            readonly IUniTaskAsyncEnumerable<TSource> source;
+            CancellationToken cancellationToken;
+
+            IUniTaskAsyncEnumerator<TSource> enumerator;
+            UniTask<bool>.Awaiter awaiter;
+
+            TSource prev;
+            bool isFirst;
+
+            public _Pairwise(IUniTaskAsyncEnumerable<TSource> source, CancellationToken cancellationToken)
+            {
+                this.source = source;
+                this.cancellationToken = cancellationToken;
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public (TSource, TSource) Current { get; private set; }
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (enumerator == null)
+                {
+                    isFirst = true;
+                    enumerator = source.GetAsyncEnumerator(cancellationToken);
+                }
+
+                completionSource.Reset();
+                SourceMoveNext();
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            void SourceMoveNext()
+            {
+                try
+                {
+                    awaiter = enumerator.MoveNextAsync().GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        MoveNextCore(this);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(MoveNextCoreDelegate, this);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    completionSource.TrySetException(ex);
+                }
+            }
+
+            static void MoveNextCore(object state)
+            {
+                var self = (_Pairwise)state;
+
+                if (self.TryGetResult(self.awaiter, out var result))
+                {
+                    if (result)
+                    {
+                        if (self.isFirst)
+                        {
+                            self.isFirst = false;
+                            self.prev = self.enumerator.Current;
+                            self.SourceMoveNext(); // run again. okay to use recursive(only one more).
+                        }
+                        else
+                        {
+                            var p = self.prev;
+                            self.prev = self.enumerator.Current;
+                            self.Current = (p, self.prev);
+                            self.completionSource.TrySetResult(true);
+                        }
+                    }
+                    else
+                    {
+                        self.completionSource.TrySetResult(false);
+                    }
+                }
+            }
+
+            public UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                if (enumerator != null)
+                {
+                    return enumerator.DisposeAsync();
+                }
+                return default;
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Pairwise.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Pairwise.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cddbf051d2a88f549986c468b23214af
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Publish.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Publish.cs
@@ -1,0 +1,173 @@
+﻿using Cysharp.Threading.Tasks.Internal;
+using System;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static IConnectableUniTaskAsyncEnumerable<TSource> Publish<TSource>(this IUniTaskAsyncEnumerable<TSource> source)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return new Publish<TSource>(source);
+        }
+    }
+
+    internal sealed class Publish<TSource> : IConnectableUniTaskAsyncEnumerable<TSource>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+        readonly CancellationTokenSource cancellationTokenSource;
+
+        TriggerEvent<TSource> trigger;
+        IUniTaskAsyncEnumerator<TSource> enumerator;
+        IDisposable connectedDisposable;
+        bool isCompleted;
+
+        public Publish(IUniTaskAsyncEnumerable<TSource> source)
+        {
+            this.source = source;
+            this.cancellationTokenSource = new CancellationTokenSource();
+        }
+
+        public IDisposable Connect()
+        {
+            if (connectedDisposable != null) return connectedDisposable;
+
+            if (enumerator == null)
+            {
+                enumerator = source.GetAsyncEnumerator(cancellationTokenSource.Token);
+            }
+
+            ConsumeEnumerator().Forget();
+
+            connectedDisposable = new ConnectDisposable(cancellationTokenSource);
+            return connectedDisposable;
+        }
+
+        async UniTaskVoid ConsumeEnumerator()
+        {
+            try
+            {
+                try
+                {
+                    while (await enumerator.MoveNextAsync())
+                    {
+                        trigger.SetResult(enumerator.Current);
+                    }
+                    trigger.SetCompleted();
+                }
+                catch (Exception ex)
+                {
+                    trigger.SetError(ex);
+                }
+            }
+            finally
+            {
+                isCompleted = true;
+                await enumerator.DisposeAsync();
+            }
+        }
+
+        public IUniTaskAsyncEnumerator<TSource> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _Publish(this, cancellationToken);
+        }
+
+        sealed class ConnectDisposable : IDisposable
+        {
+            readonly CancellationTokenSource cancellationTokenSource;
+
+            public ConnectDisposable(CancellationTokenSource cancellationTokenSource)
+            {
+                this.cancellationTokenSource = cancellationTokenSource;
+            }
+
+            public void Dispose()
+            {
+                this.cancellationTokenSource.Cancel();
+            }
+        }
+
+        sealed class _Publish : MoveNextSource, IUniTaskAsyncEnumerator<TSource>, ITriggerHandler<TSource>
+        {
+            static readonly Action<object> CancelDelegate = OnCanceled;
+
+            readonly Publish<TSource> parent;
+            CancellationToken cancellationToken;
+            CancellationTokenRegistration cancellationTokenRegistration;
+            bool isDisposed;
+
+            public _Publish(Publish<TSource> parent, CancellationToken cancellationToken)
+            {
+                if (cancellationToken.IsCancellationRequested) return;
+
+                this.parent = parent;
+                this.cancellationToken = cancellationToken;
+
+                if (cancellationToken.CanBeCanceled)
+                {
+                    this.cancellationTokenRegistration = cancellationToken.RegisterWithoutCaptureExecutionContext(CancelDelegate, this);
+                }
+
+                parent.trigger.Add(this);
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public TSource Current { get; private set; }
+            ITriggerHandler<TSource> ITriggerHandler<TSource>.Prev { get; set; }
+            ITriggerHandler<TSource> ITriggerHandler<TSource>.Next { get; set; }
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (parent.isCompleted) return CompletedTasks.False;
+
+                completionSource.Reset();
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            static void OnCanceled(object state)
+            {
+                var self = (_Publish)state;
+                self.completionSource.TrySetCanceled(self.cancellationToken);
+                self.DisposeAsync().Forget();
+            }
+
+            public UniTask DisposeAsync()
+            {
+                if (!isDisposed)
+                {
+                    isDisposed = true;
+                    TaskTracker.RemoveTracking(this);
+                    cancellationTokenRegistration.Dispose();
+                    parent.trigger.Remove(this);
+                }
+
+                return default;
+            }
+
+            public void OnNext(TSource value)
+            {
+                Current = value;
+                completionSource.TrySetResult(true);
+            }
+
+            public void OnCanceled(CancellationToken cancellationToken)
+            {
+                completionSource.TrySetCanceled(cancellationToken);
+            }
+
+            public void OnCompleted()
+            {
+                completionSource.TrySetResult(false);
+            }
+
+            public void OnError(Exception ex)
+            {
+                completionSource.TrySetException(ex);
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Publish.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Publish.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 93c684d1e88c09d4e89b79437d97b810
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Queue.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Queue.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static IUniTaskAsyncEnumerable<TSource> Queue<TSource>(this IUniTaskAsyncEnumerable<TSource> source)
+        {
+            return new QueueOperator<TSource>(source);
+        }
+    }
+
+    internal sealed class QueueOperator<TSource> : IUniTaskAsyncEnumerable<TSource>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+
+        public QueueOperator(IUniTaskAsyncEnumerable<TSource> source)
+        {
+            this.source = source;
+        }
+
+        public IUniTaskAsyncEnumerator<TSource> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _Queue(source, cancellationToken);
+        }
+
+        sealed class _Queue : IUniTaskAsyncEnumerator<TSource>
+        {
+            readonly IUniTaskAsyncEnumerable<TSource> source;
+            CancellationToken cancellationToken;
+
+            Channel<TSource> channel;
+            IUniTaskAsyncEnumerator<TSource> channelEnumerator;
+            IUniTaskAsyncEnumerator<TSource> sourceEnumerator;
+            bool channelClosed;
+
+            public _Queue(IUniTaskAsyncEnumerable<TSource> source, CancellationToken cancellationToken)
+            {
+                this.source = source;
+                this.cancellationToken = cancellationToken;
+            }
+
+            public TSource Current => channelEnumerator.Current;
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (sourceEnumerator == null)
+                {
+                    sourceEnumerator = source.GetAsyncEnumerator(cancellationToken);
+                    channel = Channel.CreateSingleConsumerUnbounded<TSource>();
+
+                    channelEnumerator = channel.Reader.ReadAllAsync().GetAsyncEnumerator(cancellationToken);
+
+                    ConsumeAll(this, sourceEnumerator, channel).Forget();
+                }
+
+                return channelEnumerator.MoveNextAsync();
+            }
+
+            static async UniTaskVoid ConsumeAll(_Queue self, IUniTaskAsyncEnumerator<TSource> enumerator, ChannelWriter<TSource> writer)
+            {
+                try
+                {
+                    while (await enumerator.MoveNextAsync())
+                    {
+                        writer.TryWrite(enumerator.Current);
+                    }
+                    writer.TryComplete();
+                }
+                catch (Exception ex)
+                {
+                    writer.TryComplete(ex);
+                }
+                finally
+                {
+                    self.channelClosed = true;
+                    await enumerator.DisposeAsync();
+                }
+            }
+
+            public async UniTask DisposeAsync()
+            {
+                if (sourceEnumerator != null)
+                {
+                    await sourceEnumerator.DisposeAsync();
+                }
+                if (channelEnumerator != null)
+                {
+                    await channelEnumerator.DisposeAsync();
+                }
+
+                if (!channelClosed)
+                {
+                    channelClosed = true;
+                    channel.Writer.TryComplete(new OperationCanceledException());
+                }
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Queue.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Queue.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b7ea1bcf9dbebb042bc99c7816249e02
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Range.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Range.cs
@@ -1,0 +1,75 @@
+﻿using Cysharp.Threading.Tasks.Internal;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static IUniTaskAsyncEnumerable<int> Range(int start, int count)
+        {
+            if (count < 0) throw Error.ArgumentOutOfRange(nameof(count));
+
+            var end = (long)start + count - 1L;
+            if (end > int.MaxValue) throw Error.ArgumentOutOfRange(nameof(count));
+
+            if (count == 0) UniTaskAsyncEnumerable.Empty<int>();
+
+            return new Cysharp.Threading.Tasks.Linq.Range(start, count);
+        }
+    }
+
+    internal class Range : IUniTaskAsyncEnumerable<int>
+    {
+        readonly int start;
+        readonly int end;
+
+        public Range(int start, int count)
+        {
+            this.start = start;
+            this.end = start + count;
+        }
+
+        public IUniTaskAsyncEnumerator<int> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _Range(start, end, cancellationToken);
+        }
+
+        class _Range : IUniTaskAsyncEnumerator<int>
+        {
+            readonly int start;
+            readonly int end;
+            int current;
+            CancellationToken cancellationToken;
+
+            public _Range(int start, int end, CancellationToken cancellationToken)
+            {
+                this.start = start;
+                this.end = end;
+                this.cancellationToken = cancellationToken;
+
+                this.current = start - 1;
+            }
+
+            public int Current => current;
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                current++;
+
+                if (current != end)
+                {
+                    return CompletedTasks.True;
+                }
+
+                return CompletedTasks.False;
+            }
+
+            public UniTask DisposeAsync()
+            {
+                return default;
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Range.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Range.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d826418a813498648b10542d0a5fb173
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Repeat.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Repeat.cs
@@ -1,0 +1,68 @@
+﻿using Cysharp.Threading.Tasks.Internal;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static IUniTaskAsyncEnumerable<TElement> Repeat<TElement>(TElement element, int count)
+        {
+            if (count < 0) throw Error.ArgumentOutOfRange(nameof(count));
+
+            return new Repeat<TElement>(element, count);
+        }
+    }
+
+    internal class Repeat<TElement> : IUniTaskAsyncEnumerable<TElement>
+    {
+        readonly TElement element;
+        readonly int count;
+
+        public Repeat(TElement element, int count)
+        {
+            this.element = element;
+            this.count = count;
+        }
+
+        public IUniTaskAsyncEnumerator<TElement> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _Repeat(element, count, cancellationToken);
+        }
+
+        class _Repeat : IUniTaskAsyncEnumerator<TElement>
+        {
+            readonly TElement element;
+            readonly int count;
+            int remaining;
+            CancellationToken cancellationToken;
+
+            public _Repeat(TElement element, int count, CancellationToken cancellationToken)
+            {
+                this.element = element;
+                this.count = count;
+                this.cancellationToken = cancellationToken;
+
+                this.remaining = count;
+            }
+
+            public TElement Current => element;
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (remaining-- != 0)
+                {
+                    return CompletedTasks.True;
+                }
+
+                return CompletedTasks.False;
+            }
+
+            public UniTask DisposeAsync()
+            {
+                return default;
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Repeat.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Repeat.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3819a3925165a674d80ee848c8600379
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Return.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Return.cs
@@ -1,0 +1,63 @@
+﻿using Cysharp.Threading.Tasks.Internal;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static IUniTaskAsyncEnumerable<TValue> Return<TValue>(TValue value)
+        {
+            return new Return<TValue>(value);
+        }
+    }
+
+    internal class Return<TValue> : IUniTaskAsyncEnumerable<TValue>
+    {
+        readonly TValue value;
+
+        public Return(TValue value)
+        {
+            this.value = value;
+        }
+
+        public IUniTaskAsyncEnumerator<TValue> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _Return(value, cancellationToken);
+        }
+
+        class _Return : IUniTaskAsyncEnumerator<TValue>
+        {
+            readonly TValue value;
+            CancellationToken cancellationToken;
+
+            bool called;
+
+            public _Return(TValue value, CancellationToken cancellationToken)
+            {
+                this.value = value;
+                this.cancellationToken = cancellationToken;
+                this.called = false;
+            }
+
+            public TValue Current => value;
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (!called)
+                {
+                    called = true;
+                    return CompletedTasks.True;
+                }
+
+                return CompletedTasks.False;
+            }
+
+            public UniTask DisposeAsync()
+            {
+                return default;
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Return.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Return.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4313cd8ecf705e44f9064ce46e293c2c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Reverse.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Reverse.cs
@@ -1,0 +1,78 @@
+﻿using Cysharp.Threading.Tasks.Internal;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static IUniTaskAsyncEnumerable<TSource> Reverse<TSource>(this IUniTaskAsyncEnumerable<TSource> source)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            return new Reverse<TSource>(source);
+        }
+    }
+
+    internal sealed class Reverse<TSource> : IUniTaskAsyncEnumerable<TSource>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+
+        public Reverse(IUniTaskAsyncEnumerable<TSource> source)
+        {
+            this.source = source;
+        }
+
+        public IUniTaskAsyncEnumerator<TSource> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _Reverse(source, cancellationToken);
+        }
+
+        sealed class _Reverse : MoveNextSource, IUniTaskAsyncEnumerator<TSource>
+        {
+            readonly IUniTaskAsyncEnumerable<TSource> source;
+            CancellationToken cancellationToken;
+
+            TSource[] array;
+            int index;
+
+            public _Reverse(IUniTaskAsyncEnumerable<TSource> source, CancellationToken cancellationToken)
+            {
+                this.source = source;
+                this.cancellationToken = cancellationToken;
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public TSource Current { get; private set; }
+
+            // after consumed array, don't use await so allow async(not require UniTaskCompletionSourceCore).
+            public async UniTask<bool> MoveNextAsync()
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (array == null)
+                {
+                    array = await source.ToArrayAsync(cancellationToken);
+                    index = array.Length - 1;
+                }
+
+                if (index != -1)
+                {
+                    Current = array[index];
+                    --index;
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
+            public UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                return default;
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Reverse.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Reverse.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b2769e65c729b4f4ca6af9826d9c7b90
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Select.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Select.cs
@@ -1,0 +1,760 @@
+﻿using Cysharp.Threading.Tasks.Internal;
+using System;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static IUniTaskAsyncEnumerable<TResult> Select<TSource, TResult>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, TResult> selector)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(selector, nameof(selector));
+
+            return new Cysharp.Threading.Tasks.Linq.Select<TSource, TResult>(source, selector);
+        }
+
+        public static IUniTaskAsyncEnumerable<TResult> Select<TSource, TResult>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Int32, TResult> selector)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(selector, nameof(selector));
+
+            return new Cysharp.Threading.Tasks.Linq.SelectInt<TSource, TResult>(source, selector);
+        }
+
+        public static IUniTaskAsyncEnumerable<TResult> SelectAwait<TSource, TResult>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<TResult>> selector)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(selector, nameof(selector));
+
+            return new Cysharp.Threading.Tasks.Linq.SelectAwait<TSource, TResult>(source, selector);
+        }
+
+        public static IUniTaskAsyncEnumerable<TResult> SelectAwait<TSource, TResult>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Int32, UniTask<TResult>> selector)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(selector, nameof(selector));
+
+            return new Cysharp.Threading.Tasks.Linq.SelectIntAwait<TSource, TResult>(source, selector);
+        }
+
+        public static IUniTaskAsyncEnumerable<TResult> SelectAwaitWithCancellation<TSource, TResult>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<TResult>> selector)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(selector, nameof(selector));
+
+            return new Cysharp.Threading.Tasks.Linq.SelectAwaitWithCancellation<TSource, TResult>(source, selector);
+        }
+
+        public static IUniTaskAsyncEnumerable<TResult> SelectAwaitWithCancellation<TSource, TResult>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Int32, CancellationToken, UniTask<TResult>> selector)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(selector, nameof(selector));
+
+            return new Cysharp.Threading.Tasks.Linq.SelectIntAwaitWithCancellation<TSource, TResult>(source, selector);
+        }
+    }
+
+    internal sealed class Select<TSource, TResult> : IUniTaskAsyncEnumerable<TResult>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+        readonly Func<TSource, TResult> selector;
+
+        public Select(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, TResult> selector)
+        {
+            this.source = source;
+            this.selector = selector;
+        }
+
+        public IUniTaskAsyncEnumerator<TResult> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _Select(source, selector, cancellationToken);
+        }
+
+        sealed class _Select : MoveNextSource, IUniTaskAsyncEnumerator<TResult>
+        {
+            readonly IUniTaskAsyncEnumerable<TSource> source;
+            readonly Func<TSource, TResult> selector;
+            readonly CancellationToken cancellationToken;
+
+            int state = -1;
+            IUniTaskAsyncEnumerator<TSource> enumerator;
+            UniTask<bool>.Awaiter awaiter;
+            Action moveNextAction;
+
+            public _Select(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, TResult> selector, CancellationToken cancellationToken)
+            {
+                this.source = source;
+                this.selector = selector;
+                this.cancellationToken = cancellationToken;
+                this.moveNextAction = MoveNext;
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public TResult Current { get; private set; }
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                if (state == -2) return default;
+
+                completionSource.Reset();
+                MoveNext();
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            void MoveNext()
+            {
+                try
+                {
+                    switch (state)
+                    {
+                        case -1: // init
+                            enumerator = source.GetAsyncEnumerator(cancellationToken);
+                            goto case 0;
+                        case 0:
+                            awaiter = enumerator.MoveNextAsync().GetAwaiter();
+                            if (awaiter.IsCompleted)
+                            {
+                                goto case 1;
+                            }
+                            else
+                            {
+                                state = 1;
+                                awaiter.UnsafeOnCompleted(moveNextAction);
+                                return;
+                            }
+                        case 1:
+                            if (awaiter.GetResult())
+                            {
+                                Current = selector(enumerator.Current);
+                                goto CONTINUE;
+                            }
+                            else
+                            {
+                                goto DONE;
+                            }
+                        default:
+                            goto DONE;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    state = -2;
+                    completionSource.TrySetException(ex);
+                    return;
+                }
+
+                DONE:
+                state = -2;
+                completionSource.TrySetResult(false);
+                return;
+
+                CONTINUE:
+                state = 0;
+                completionSource.TrySetResult(true);
+                return;
+            }
+
+            public UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                return enumerator.DisposeAsync();
+            }
+        }
+    }
+
+    internal sealed class SelectInt<TSource, TResult> : IUniTaskAsyncEnumerable<TResult>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+        readonly Func<TSource, int, TResult> selector;
+
+        public SelectInt(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, int, TResult> selector)
+        {
+            this.source = source;
+            this.selector = selector;
+        }
+
+        public IUniTaskAsyncEnumerator<TResult> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _Select(source, selector, cancellationToken);
+        }
+
+        sealed class _Select : MoveNextSource, IUniTaskAsyncEnumerator<TResult>
+        {
+            readonly IUniTaskAsyncEnumerable<TSource> source;
+            readonly Func<TSource, int, TResult> selector;
+            readonly CancellationToken cancellationToken;
+
+            int state = -1;
+            IUniTaskAsyncEnumerator<TSource> enumerator;
+            UniTask<bool>.Awaiter awaiter;
+            Action moveNextAction;
+            int index;
+
+            public _Select(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, int, TResult> selector, CancellationToken cancellationToken)
+            {
+                this.source = source;
+                this.selector = selector;
+                this.cancellationToken = cancellationToken;
+                this.moveNextAction = MoveNext;
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public TResult Current { get; private set; }
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                if (state == -2) return default;
+
+                completionSource.Reset();
+                MoveNext();
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            void MoveNext()
+            {
+                try
+                {
+                    switch (state)
+                    {
+                        case -1: // init
+                            enumerator = source.GetAsyncEnumerator(cancellationToken);
+                            goto case 0;
+                        case 0:
+                            awaiter = enumerator.MoveNextAsync().GetAwaiter();
+                            if (awaiter.IsCompleted)
+                            {
+                                goto case 1;
+                            }
+                            else
+                            {
+                                state = 1;
+                                awaiter.UnsafeOnCompleted(moveNextAction);
+                                return;
+                            }
+                        case 1:
+                            if (awaiter.GetResult())
+                            {
+                                Current = selector(enumerator.Current, checked(index++));
+                                goto CONTINUE;
+                            }
+                            else
+                            {
+                                goto DONE;
+                            }
+                        default:
+                            goto DONE;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    state = -2;
+                    completionSource.TrySetException(ex);
+                    return;
+                }
+
+                DONE:
+                state = -2;
+                completionSource.TrySetResult(false);
+                return;
+
+                CONTINUE:
+                state = 0;
+                completionSource.TrySetResult(true);
+                return;
+            }
+
+            public UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                return enumerator.DisposeAsync();
+            }
+        }
+    }
+
+    internal sealed class SelectAwait<TSource, TResult> : IUniTaskAsyncEnumerable<TResult>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+        readonly Func<TSource, UniTask<TResult>> selector;
+
+        public SelectAwait(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<TResult>> selector)
+        {
+            this.source = source;
+            this.selector = selector;
+        }
+
+        public IUniTaskAsyncEnumerator<TResult> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _SelectAwait(source, selector, cancellationToken);
+        }
+
+        sealed class _SelectAwait : MoveNextSource, IUniTaskAsyncEnumerator<TResult>
+        {
+            readonly IUniTaskAsyncEnumerable<TSource> source;
+            readonly Func<TSource, UniTask<TResult>> selector;
+            readonly CancellationToken cancellationToken;
+
+            int state = -1;
+            IUniTaskAsyncEnumerator<TSource> enumerator;
+            UniTask<bool>.Awaiter awaiter;
+            UniTask<TResult>.Awaiter awaiter2;
+            Action moveNextAction;
+
+            public _SelectAwait(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<TResult>> selector, CancellationToken cancellationToken)
+            {
+                this.source = source;
+                this.selector = selector;
+                this.cancellationToken = cancellationToken;
+                this.moveNextAction = MoveNext;
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public TResult Current { get; private set; }
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                if (state == -2) return default;
+
+                completionSource.Reset();
+                MoveNext();
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            void MoveNext()
+            {
+                try
+                {
+                    switch (state)
+                    {
+                        case -1: // init
+                            enumerator = source.GetAsyncEnumerator(cancellationToken);
+                            goto case 0;
+                        case 0:
+                            awaiter = enumerator.MoveNextAsync().GetAwaiter();
+                            if (awaiter.IsCompleted)
+                            {
+                                goto case 1;
+                            }
+                            else
+                            {
+                                state = 1;
+                                awaiter.UnsafeOnCompleted(moveNextAction);
+                                return;
+                            }
+                        case 1:
+                            if (awaiter.GetResult())
+                            {
+                                awaiter2 = selector(enumerator.Current).GetAwaiter();
+                                if (awaiter2.IsCompleted)
+                                {
+                                    goto case 2;
+                                }
+                                else
+                                {
+                                    state = 2;
+                                    awaiter2.UnsafeOnCompleted(moveNextAction);
+                                    return;
+                                }
+                            }
+                            else
+                            {
+                                goto DONE;
+                            }
+                        case 2:
+                            Current = awaiter2.GetResult();
+                            goto CONTINUE;
+                        default:
+                            goto DONE;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    state = -2;
+                    completionSource.TrySetException(ex);
+                    return;
+                }
+
+                DONE:
+                state = -2;
+                completionSource.TrySetResult(false);
+                return;
+
+                CONTINUE:
+                state = 0;
+                completionSource.TrySetResult(true);
+                return;
+            }
+
+            public UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                return enumerator.DisposeAsync();
+            }
+        }
+    }
+
+    internal sealed class SelectIntAwait<TSource, TResult> : IUniTaskAsyncEnumerable<TResult>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+        readonly Func<TSource, int, UniTask<TResult>> selector;
+
+        public SelectIntAwait(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, int, UniTask<TResult>> selector)
+        {
+            this.source = source;
+            this.selector = selector;
+        }
+
+        public IUniTaskAsyncEnumerator<TResult> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _SelectAwait(source, selector, cancellationToken);
+        }
+
+        sealed class _SelectAwait : MoveNextSource, IUniTaskAsyncEnumerator<TResult>
+        {
+            readonly IUniTaskAsyncEnumerable<TSource> source;
+            readonly Func<TSource, int, UniTask<TResult>> selector;
+            readonly CancellationToken cancellationToken;
+
+            int state = -1;
+            IUniTaskAsyncEnumerator<TSource> enumerator;
+            UniTask<bool>.Awaiter awaiter;
+            UniTask<TResult>.Awaiter awaiter2;
+            Action moveNextAction;
+            int index;
+
+            public _SelectAwait(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, int, UniTask<TResult>> selector, CancellationToken cancellationToken)
+            {
+                this.source = source;
+                this.selector = selector;
+                this.cancellationToken = cancellationToken;
+                this.moveNextAction = MoveNext;
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public TResult Current { get; private set; }
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                if (state == -2) return default;
+
+                completionSource.Reset();
+                MoveNext();
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            void MoveNext()
+            {
+                try
+                {
+                    switch (state)
+                    {
+                        case -1: // init
+                            enumerator = source.GetAsyncEnumerator(cancellationToken);
+                            goto case 0;
+                        case 0:
+                            awaiter = enumerator.MoveNextAsync().GetAwaiter();
+                            if (awaiter.IsCompleted)
+                            {
+                                goto case 1;
+                            }
+                            else
+                            {
+                                state = 1;
+                                awaiter.UnsafeOnCompleted(moveNextAction);
+                                return;
+                            }
+                        case 1:
+                            if (awaiter.GetResult())
+                            {
+                                awaiter2 = selector(enumerator.Current, checked(index++)).GetAwaiter();
+                                if (awaiter2.IsCompleted)
+                                {
+                                    goto case 2;
+                                }
+                                else
+                                {
+                                    state = 2;
+                                    awaiter2.UnsafeOnCompleted(moveNextAction);
+                                    return;
+                                }
+                            }
+                            else
+                            {
+                                goto DONE;
+                            }
+                        case 2:
+                            Current = awaiter2.GetResult();
+                            goto CONTINUE;
+                        default:
+                            goto DONE;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    state = -2;
+                    completionSource.TrySetException(ex);
+                    return;
+                }
+
+                DONE:
+                state = -2;
+                completionSource.TrySetResult(false);
+                return;
+
+                CONTINUE:
+                state = 0;
+                completionSource.TrySetResult(true);
+                return;
+            }
+
+            public UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                return enumerator.DisposeAsync();
+            }
+        }
+    }
+
+    internal sealed class SelectAwaitWithCancellation<TSource, TResult> : IUniTaskAsyncEnumerable<TResult>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+        readonly Func<TSource, CancellationToken, UniTask<TResult>> selector;
+
+        public SelectAwaitWithCancellation(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<TResult>> selector)
+        {
+            this.source = source;
+            this.selector = selector;
+        }
+
+        public IUniTaskAsyncEnumerator<TResult> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _SelectAwaitWithCancellation(source, selector, cancellationToken);
+        }
+
+        sealed class _SelectAwaitWithCancellation : MoveNextSource, IUniTaskAsyncEnumerator<TResult>
+        {
+            readonly IUniTaskAsyncEnumerable<TSource> source;
+            readonly Func<TSource, CancellationToken, UniTask<TResult>> selector;
+            readonly CancellationToken cancellationToken;
+
+            int state = -1;
+            IUniTaskAsyncEnumerator<TSource> enumerator;
+            UniTask<bool>.Awaiter awaiter;
+            UniTask<TResult>.Awaiter awaiter2;
+            Action moveNextAction;
+
+            public _SelectAwaitWithCancellation(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<TResult>> selector, CancellationToken cancellationToken)
+            {
+                this.source = source;
+                this.selector = selector;
+                this.cancellationToken = cancellationToken;
+                this.moveNextAction = MoveNext;
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public TResult Current { get; private set; }
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                if (state == -2) return default;
+
+                completionSource.Reset();
+                MoveNext();
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            void MoveNext()
+            {
+                try
+                {
+                    switch (state)
+                    {
+                        case -1: // init
+                            enumerator = source.GetAsyncEnumerator(cancellationToken);
+                            goto case 0;
+                        case 0:
+                            awaiter = enumerator.MoveNextAsync().GetAwaiter();
+                            if (awaiter.IsCompleted)
+                            {
+                                goto case 1;
+                            }
+                            else
+                            {
+                                state = 1;
+                                awaiter.UnsafeOnCompleted(moveNextAction);
+                                return;
+                            }
+                        case 1:
+                            if (awaiter.GetResult())
+                            {
+                                awaiter2 = selector(enumerator.Current, cancellationToken).GetAwaiter();
+                                if (awaiter2.IsCompleted)
+                                {
+                                    goto case 2;
+                                }
+                                else
+                                {
+                                    state = 2;
+                                    awaiter2.UnsafeOnCompleted(moveNextAction);
+                                    return;
+                                }
+                            }
+                            else
+                            {
+                                goto DONE;
+                            }
+                        case 2:
+                            Current = awaiter2.GetResult();
+                            goto CONTINUE;
+                        default:
+                            goto DONE;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    state = -2;
+                    completionSource.TrySetException(ex);
+                    return;
+                }
+
+                DONE:
+                state = -2;
+                completionSource.TrySetResult(false);
+                return;
+
+                CONTINUE:
+                state = 0;
+                completionSource.TrySetResult(true);
+                return;
+            }
+
+            public UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                return enumerator.DisposeAsync();
+            }
+        }
+    }
+
+    internal sealed class SelectIntAwaitWithCancellation<TSource, TResult> : IUniTaskAsyncEnumerable<TResult>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+        readonly Func<TSource, int, CancellationToken, UniTask<TResult>> selector;
+
+        public SelectIntAwaitWithCancellation(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, int, CancellationToken, UniTask<TResult>> selector)
+        {
+            this.source = source;
+            this.selector = selector;
+        }
+
+        public IUniTaskAsyncEnumerator<TResult> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _SelectAwaitWithCancellation(source, selector, cancellationToken);
+        }
+
+        sealed class _SelectAwaitWithCancellation : MoveNextSource, IUniTaskAsyncEnumerator<TResult>
+        {
+            readonly IUniTaskAsyncEnumerable<TSource> source;
+            readonly Func<TSource, int, CancellationToken, UniTask<TResult>> selector;
+            readonly CancellationToken cancellationToken;
+
+            int state = -1;
+            IUniTaskAsyncEnumerator<TSource> enumerator;
+            UniTask<bool>.Awaiter awaiter;
+            UniTask<TResult>.Awaiter awaiter2;
+            Action moveNextAction;
+            int index;
+
+            public _SelectAwaitWithCancellation(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, int, CancellationToken, UniTask<TResult>> selector, CancellationToken cancellationToken)
+            {
+                this.source = source;
+                this.selector = selector;
+                this.cancellationToken = cancellationToken;
+                this.moveNextAction = MoveNext;
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public TResult Current { get; private set; }
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                if (state == -2) return default;
+
+                completionSource.Reset();
+                MoveNext();
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            void MoveNext()
+            {
+                try
+                {
+                    switch (state)
+                    {
+                        case -1: // init
+                            enumerator = source.GetAsyncEnumerator(cancellationToken);
+                            goto case 0;
+                        case 0:
+                            awaiter = enumerator.MoveNextAsync().GetAwaiter();
+                            if (awaiter.IsCompleted)
+                            {
+                                goto case 1;
+                            }
+                            else
+                            {
+                                state = 1;
+                                awaiter.UnsafeOnCompleted(moveNextAction);
+                                return;
+                            }
+                        case 1:
+                            if (awaiter.GetResult())
+                            {
+                                awaiter2 = selector(enumerator.Current, checked(index++), cancellationToken).GetAwaiter();
+                                if (awaiter2.IsCompleted)
+                                {
+                                    goto case 2;
+                                }
+                                else
+                                {
+                                    state = 2;
+                                    awaiter2.UnsafeOnCompleted(moveNextAction);
+                                    return;
+                                }
+                            }
+                            else
+                            {
+                                goto DONE;
+                            }
+                        case 2:
+                            Current = awaiter2.GetResult();
+                            goto CONTINUE;
+                        default:
+                            goto DONE;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    state = -2;
+                    completionSource.TrySetException(ex);
+                    return;
+                }
+
+                DONE:
+                state = -2;
+                completionSource.TrySetResult(false);
+                return;
+
+                CONTINUE:
+                state = 0;
+                completionSource.TrySetResult(true);
+                return;
+            }
+
+            public UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                return enumerator.DisposeAsync();
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Select.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Select.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dc68e598ca44a134b988dfaf5e53bfba
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/SelectMany.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/SelectMany.cs
@@ -1,0 +1,892 @@
+﻿using Cysharp.Threading.Tasks.Internal;
+using System;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+
+        public static IUniTaskAsyncEnumerable<TResult> SelectMany<TSource, TResult>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, IUniTaskAsyncEnumerable<TResult>> selector)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(selector, nameof(selector));
+
+            return new SelectMany<TSource, TResult, TResult>(source, selector, (x, y) => y);
+        }
+
+        public static IUniTaskAsyncEnumerable<TResult> SelectMany<TSource, TResult>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Int32, IUniTaskAsyncEnumerable<TResult>> selector)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(selector, nameof(selector));
+
+            return new SelectMany<TSource, TResult, TResult>(source, selector, (x, y) => y);
+        }
+
+        public static IUniTaskAsyncEnumerable<TResult> SelectMany<TSource, TCollection, TResult>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, IUniTaskAsyncEnumerable<TCollection>> collectionSelector, Func<TSource, TCollection, TResult> resultSelector)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(collectionSelector, nameof(collectionSelector));
+
+            return new SelectMany<TSource, TCollection, TResult>(source, collectionSelector, resultSelector);
+        }
+
+        public static IUniTaskAsyncEnumerable<TResult> SelectMany<TSource, TCollection, TResult>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Int32, IUniTaskAsyncEnumerable<TCollection>> collectionSelector, Func<TSource, TCollection, TResult> resultSelector)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(collectionSelector, nameof(collectionSelector));
+
+            return new SelectMany<TSource, TCollection, TResult>(source, collectionSelector, resultSelector);
+        }
+
+        public static IUniTaskAsyncEnumerable<TResult> SelectManyAwait<TSource, TResult>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<IUniTaskAsyncEnumerable<TResult>>> selector)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(selector, nameof(selector));
+
+            return new SelectManyAwait<TSource, TResult, TResult>(source, selector, (x, y) => UniTask.FromResult(y));
+        }
+
+        public static IUniTaskAsyncEnumerable<TResult> SelectManyAwait<TSource, TResult>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Int32, UniTask<IUniTaskAsyncEnumerable<TResult>>> selector)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(selector, nameof(selector));
+
+            return new SelectManyAwait<TSource, TResult, TResult>(source, selector, (x, y) => UniTask.FromResult(y));
+        }
+
+        public static IUniTaskAsyncEnumerable<TResult> SelectManyAwait<TSource, TCollection, TResult>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<IUniTaskAsyncEnumerable<TCollection>>> collectionSelector, Func<TSource, TCollection, UniTask<TResult>> resultSelector)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(collectionSelector, nameof(collectionSelector));
+
+            return new SelectManyAwait<TSource, TCollection, TResult>(source, collectionSelector, resultSelector);
+        }
+
+        public static IUniTaskAsyncEnumerable<TResult> SelectManyAwait<TSource, TCollection, TResult>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Int32, UniTask<IUniTaskAsyncEnumerable<TCollection>>> collectionSelector, Func<TSource, TCollection, UniTask<TResult>> resultSelector)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(collectionSelector, nameof(collectionSelector));
+
+            return new SelectManyAwait<TSource, TCollection, TResult>(source, collectionSelector, resultSelector);
+        }
+
+        public static IUniTaskAsyncEnumerable<TResult> SelectManyAwaitWithCancellation<TSource, TResult>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<IUniTaskAsyncEnumerable<TResult>>> selector)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(selector, nameof(selector));
+
+            return new SelectManyAwaitWithCancellation<TSource, TResult, TResult>(source, selector, (x, y, c) => UniTask.FromResult(y));
+        }
+
+        public static IUniTaskAsyncEnumerable<TResult> SelectManyAwaitWithCancellation<TSource, TResult>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Int32, CancellationToken, UniTask<IUniTaskAsyncEnumerable<TResult>>> selector)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(selector, nameof(selector));
+
+            return new SelectManyAwaitWithCancellation<TSource, TResult, TResult>(source, selector, (x, y, c) => UniTask.FromResult(y));
+        }
+
+        public static IUniTaskAsyncEnumerable<TResult> SelectManyAwaitWithCancellation<TSource, TCollection, TResult>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<IUniTaskAsyncEnumerable<TCollection>>> collectionSelector, Func<TSource, TCollection, CancellationToken, UniTask<TResult>> resultSelector)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(collectionSelector, nameof(collectionSelector));
+
+            return new SelectManyAwaitWithCancellation<TSource, TCollection, TResult>(source, collectionSelector, resultSelector);
+        }
+
+        public static IUniTaskAsyncEnumerable<TResult> SelectManyAwaitWithCancellation<TSource, TCollection, TResult>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Int32, CancellationToken, UniTask<IUniTaskAsyncEnumerable<TCollection>>> collectionSelector, Func<TSource, TCollection, CancellationToken, UniTask<TResult>> resultSelector)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(collectionSelector, nameof(collectionSelector));
+
+            return new SelectManyAwaitWithCancellation<TSource, TCollection, TResult>(source, collectionSelector, resultSelector);
+        }
+    }
+
+    internal sealed class SelectMany<TSource, TCollection, TResult> : IUniTaskAsyncEnumerable<TResult>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+        readonly Func<TSource, IUniTaskAsyncEnumerable<TCollection>> selector1;
+        readonly Func<TSource, int, IUniTaskAsyncEnumerable<TCollection>> selector2;
+        readonly Func<TSource, TCollection, TResult> resultSelector;
+
+        public SelectMany(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, IUniTaskAsyncEnumerable<TCollection>> selector, Func<TSource, TCollection, TResult> resultSelector)
+        {
+            this.source = source;
+            this.selector1 = selector;
+            this.selector2 = null;
+            this.resultSelector = resultSelector;
+        }
+
+        public SelectMany(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, int, IUniTaskAsyncEnumerable<TCollection>> selector, Func<TSource, TCollection, TResult> resultSelector)
+        {
+            this.source = source;
+            this.selector1 = null;
+            this.selector2 = selector;
+            this.resultSelector = resultSelector;
+        }
+
+        public IUniTaskAsyncEnumerator<TResult> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _SelectMany(source, selector1, selector2, resultSelector, cancellationToken);
+        }
+
+        sealed class _SelectMany : MoveNextSource, IUniTaskAsyncEnumerator<TResult>
+        {
+            static readonly Action<object> sourceMoveNextCoreDelegate = SourceMoveNextCore;
+            static readonly Action<object> selectedSourceMoveNextCoreDelegate = SeletedSourceMoveNextCore;
+            static readonly Action<object> selectedEnumeratorDisposeAsyncCoreDelegate = SelectedEnumeratorDisposeAsyncCore;
+
+            readonly IUniTaskAsyncEnumerable<TSource> source;
+
+            readonly Func<TSource, IUniTaskAsyncEnumerable<TCollection>> selector1;
+            readonly Func<TSource, int, IUniTaskAsyncEnumerable<TCollection>> selector2;
+            readonly Func<TSource, TCollection, TResult> resultSelector;
+            CancellationToken cancellationToken;
+
+            TSource sourceCurrent;
+            int sourceIndex;
+            IUniTaskAsyncEnumerator<TSource> sourceEnumerator;
+            IUniTaskAsyncEnumerator<TCollection> selectedEnumerator;
+            UniTask<bool>.Awaiter sourceAwaiter;
+            UniTask<bool>.Awaiter selectedAwaiter;
+            UniTask.Awaiter selectedDisposeAsyncAwaiter;
+
+            public _SelectMany(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, IUniTaskAsyncEnumerable<TCollection>> selector1, Func<TSource, int, IUniTaskAsyncEnumerable<TCollection>> selector2, Func<TSource, TCollection, TResult> resultSelector, CancellationToken cancellationToken)
+            {
+                this.source = source;
+                this.selector1 = selector1;
+                this.selector2 = selector2;
+                this.resultSelector = resultSelector;
+                this.cancellationToken = cancellationToken;
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public TResult Current { get; private set; }
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                completionSource.Reset();
+
+                // iterate selected field
+                if (selectedEnumerator != null)
+                {
+                    MoveNextSelected();
+                }
+                else
+                {
+                    // iterate source field
+                    if (sourceEnumerator == null)
+                    {
+                        sourceEnumerator = source.GetAsyncEnumerator(cancellationToken);
+                    }
+                    MoveNextSource();
+                }
+
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            void MoveNextSource()
+            {
+                try
+                {
+                    sourceAwaiter = sourceEnumerator.MoveNextAsync().GetAwaiter();
+                }
+                catch (Exception ex)
+                {
+                    completionSource.TrySetException(ex);
+                    return;
+                }
+
+                if (sourceAwaiter.IsCompleted)
+                {
+                    SourceMoveNextCore(this);
+                }
+                else
+                {
+                    sourceAwaiter.SourceOnCompleted(sourceMoveNextCoreDelegate, this);
+                }
+            }
+
+            void MoveNextSelected()
+            {
+                try
+                {
+                    selectedAwaiter = selectedEnumerator.MoveNextAsync().GetAwaiter();
+                }
+                catch (Exception ex)
+                {
+                    completionSource.TrySetException(ex);
+                    return;
+                }
+
+                if (selectedAwaiter.IsCompleted)
+                {
+                    SeletedSourceMoveNextCore(this);
+                }
+                else
+                {
+                    selectedAwaiter.SourceOnCompleted(selectedSourceMoveNextCoreDelegate, this);
+                }
+            }
+
+            static void SourceMoveNextCore(object state)
+            {
+                var self = (_SelectMany)state;
+
+                if (self.TryGetResult(self.sourceAwaiter, out var result))
+                {
+                    if (result)
+                    {
+                        try
+                        {
+                            self.sourceCurrent = self.sourceEnumerator.Current;
+                            if (self.selector1 != null)
+                            {
+                                self.selectedEnumerator = self.selector1(self.sourceCurrent).GetAsyncEnumerator(self.cancellationToken);
+                            }
+                            else
+                            {
+                                self.selectedEnumerator = self.selector2(self.sourceCurrent, checked(self.sourceIndex++)).GetAsyncEnumerator(self.cancellationToken);
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            self.completionSource.TrySetException(ex);
+                            return;
+                        }
+
+                        self.MoveNextSelected(); // iterated selected source.
+                    }
+                    else
+                    {
+                        self.completionSource.TrySetResult(false);
+                    }
+                }
+            }
+
+            static void SeletedSourceMoveNextCore(object state)
+            {
+                var self = (_SelectMany)state;
+
+                if (self.TryGetResult(self.selectedAwaiter, out var result))
+                {
+                    if (result)
+                    {
+                        try
+                        {
+                            self.Current = self.resultSelector(self.sourceCurrent, self.selectedEnumerator.Current);
+                        }
+                        catch (Exception ex)
+                        {
+                            self.completionSource.TrySetException(ex);
+                            return;
+                        }
+
+                        self.completionSource.TrySetResult(true);
+                    }
+                    else
+                    {
+                        // dispose selected source and try iterate source.
+                        try
+                        {
+                            self.selectedDisposeAsyncAwaiter = self.selectedEnumerator.DisposeAsync().GetAwaiter();
+                        }
+                        catch (Exception ex)
+                        {
+                            self.completionSource.TrySetException(ex);
+                            return;
+                        }
+                        if (self.selectedDisposeAsyncAwaiter.IsCompleted)
+                        {
+                            SelectedEnumeratorDisposeAsyncCore(self);
+                        }
+                        else
+                        {
+                            self.selectedDisposeAsyncAwaiter.SourceOnCompleted(selectedEnumeratorDisposeAsyncCoreDelegate, self);
+                        }
+                    }
+                }
+            }
+
+            static void SelectedEnumeratorDisposeAsyncCore(object state)
+            {
+                var self = (_SelectMany)state;
+
+                if (self.TryGetResult(self.selectedDisposeAsyncAwaiter))
+                {
+                    self.selectedEnumerator = null;
+                    self.selectedAwaiter = default;
+
+                    self.MoveNextSource(); // iterate next source
+                }
+            }
+
+            public async UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                if (selectedEnumerator != null)
+                {
+                    await selectedEnumerator.DisposeAsync();
+                }
+                if (sourceEnumerator != null)
+                {
+                    await sourceEnumerator.DisposeAsync();
+                }
+            }
+        }
+    }
+
+    internal sealed class SelectManyAwait<TSource, TCollection, TResult> : IUniTaskAsyncEnumerable<TResult>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+        readonly Func<TSource, UniTask<IUniTaskAsyncEnumerable<TCollection>>> selector1;
+        readonly Func<TSource, int, UniTask<IUniTaskAsyncEnumerable<TCollection>>> selector2;
+        readonly Func<TSource, TCollection, UniTask<TResult>> resultSelector;
+
+        public SelectManyAwait(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<IUniTaskAsyncEnumerable<TCollection>>> selector, Func<TSource, TCollection, UniTask<TResult>> resultSelector)
+        {
+            this.source = source;
+            this.selector1 = selector;
+            this.selector2 = null;
+            this.resultSelector = resultSelector;
+        }
+
+        public SelectManyAwait(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, int, UniTask<IUniTaskAsyncEnumerable<TCollection>>> selector, Func<TSource, TCollection, UniTask<TResult>> resultSelector)
+        {
+            this.source = source;
+            this.selector1 = null;
+            this.selector2 = selector;
+            this.resultSelector = resultSelector;
+        }
+
+        public IUniTaskAsyncEnumerator<TResult> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _SelectManyAwait(source, selector1, selector2, resultSelector, cancellationToken);
+        }
+
+        sealed class _SelectManyAwait : MoveNextSource, IUniTaskAsyncEnumerator<TResult>
+        {
+            static readonly Action<object> sourceMoveNextCoreDelegate = SourceMoveNextCore;
+            static readonly Action<object> selectedSourceMoveNextCoreDelegate = SeletedSourceMoveNextCore;
+            static readonly Action<object> selectedEnumeratorDisposeAsyncCoreDelegate = SelectedEnumeratorDisposeAsyncCore;
+            static readonly Action<object> selectorAwaitCoreDelegate = SelectorAwaitCore;
+            static readonly Action<object> resultSelectorAwaitCoreDelegate = ResultSelectorAwaitCore;
+
+            readonly IUniTaskAsyncEnumerable<TSource> source;
+
+            readonly Func<TSource, UniTask<IUniTaskAsyncEnumerable<TCollection>>> selector1;
+            readonly Func<TSource, int, UniTask<IUniTaskAsyncEnumerable<TCollection>>> selector2;
+            readonly Func<TSource, TCollection, UniTask<TResult>> resultSelector;
+            CancellationToken cancellationToken;
+
+            TSource sourceCurrent;
+            int sourceIndex;
+            IUniTaskAsyncEnumerator<TSource> sourceEnumerator;
+            IUniTaskAsyncEnumerator<TCollection> selectedEnumerator;
+            UniTask<bool>.Awaiter sourceAwaiter;
+            UniTask<bool>.Awaiter selectedAwaiter;
+            UniTask.Awaiter selectedDisposeAsyncAwaiter;
+
+            // await additional
+            UniTask<IUniTaskAsyncEnumerable<TCollection>>.Awaiter collectionSelectorAwaiter;
+            UniTask<TResult>.Awaiter resultSelectorAwaiter;
+
+            public _SelectManyAwait(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<IUniTaskAsyncEnumerable<TCollection>>> selector1, Func<TSource, int, UniTask<IUniTaskAsyncEnumerable<TCollection>>> selector2, Func<TSource, TCollection, UniTask<TResult>> resultSelector, CancellationToken cancellationToken)
+            {
+                this.source = source;
+                this.selector1 = selector1;
+                this.selector2 = selector2;
+                this.resultSelector = resultSelector;
+                this.cancellationToken = cancellationToken;
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public TResult Current { get; private set; }
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                completionSource.Reset();
+
+                // iterate selected field
+                if (selectedEnumerator != null)
+                {
+                    MoveNextSelected();
+                }
+                else
+                {
+                    // iterate source field
+                    if (sourceEnumerator == null)
+                    {
+                        sourceEnumerator = source.GetAsyncEnumerator(cancellationToken);
+                    }
+                    MoveNextSource();
+                }
+
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            void MoveNextSource()
+            {
+                try
+                {
+                    sourceAwaiter = sourceEnumerator.MoveNextAsync().GetAwaiter();
+                }
+                catch (Exception ex)
+                {
+                    completionSource.TrySetException(ex);
+                    return;
+                }
+
+                if (sourceAwaiter.IsCompleted)
+                {
+                    SourceMoveNextCore(this);
+                }
+                else
+                {
+                    sourceAwaiter.SourceOnCompleted(sourceMoveNextCoreDelegate, this);
+                }
+            }
+
+            void MoveNextSelected()
+            {
+                try
+                {
+                    selectedAwaiter = selectedEnumerator.MoveNextAsync().GetAwaiter();
+                }
+                catch (Exception ex)
+                {
+                    completionSource.TrySetException(ex);
+                    return;
+                }
+
+                if (selectedAwaiter.IsCompleted)
+                {
+                    SeletedSourceMoveNextCore(this);
+                }
+                else
+                {
+                    selectedAwaiter.SourceOnCompleted(selectedSourceMoveNextCoreDelegate, this);
+                }
+            }
+
+            static void SourceMoveNextCore(object state)
+            {
+                var self = (_SelectManyAwait)state;
+
+                if (self.TryGetResult(self.sourceAwaiter, out var result))
+                {
+                    if (result)
+                    {
+                        try
+                        {
+                            self.sourceCurrent = self.sourceEnumerator.Current;
+
+                            if (self.selector1 != null)
+                            {
+                                self.collectionSelectorAwaiter = self.selector1(self.sourceCurrent).GetAwaiter();
+                            }
+                            else
+                            {
+                                self.collectionSelectorAwaiter = self.selector2(self.sourceCurrent, checked(self.sourceIndex++)).GetAwaiter();
+                            }
+
+                            if (self.collectionSelectorAwaiter.IsCompleted)
+                            {
+                                SelectorAwaitCore(self);
+                            }
+                            else
+                            {
+                                self.collectionSelectorAwaiter.SourceOnCompleted(selectorAwaitCoreDelegate, self);
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            self.completionSource.TrySetException(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        self.completionSource.TrySetResult(false);
+                    }
+                }
+            }
+
+            static void SeletedSourceMoveNextCore(object state)
+            {
+                var self = (_SelectManyAwait)state;
+
+                if (self.TryGetResult(self.selectedAwaiter, out var result))
+                {
+                    if (result)
+                    {
+                        try
+                        {
+                            self.resultSelectorAwaiter = self.resultSelector(self.sourceCurrent, self.selectedEnumerator.Current).GetAwaiter();
+                            if (self.resultSelectorAwaiter.IsCompleted)
+                            {
+                                ResultSelectorAwaitCore(self);
+                            }
+                            else
+                            {
+                                self.resultSelectorAwaiter.SourceOnCompleted(resultSelectorAwaitCoreDelegate, self);
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            self.completionSource.TrySetException(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        // dispose selected source and try iterate source.
+                        try
+                        {
+                            self.selectedDisposeAsyncAwaiter = self.selectedEnumerator.DisposeAsync().GetAwaiter();
+                        }
+                        catch (Exception ex)
+                        {
+                            self.completionSource.TrySetException(ex);
+                            return;
+                        }
+                        if (self.selectedDisposeAsyncAwaiter.IsCompleted)
+                        {
+                            SelectedEnumeratorDisposeAsyncCore(self);
+                        }
+                        else
+                        {
+                            self.selectedDisposeAsyncAwaiter.SourceOnCompleted(selectedEnumeratorDisposeAsyncCoreDelegate, self);
+                        }
+                    }
+                }
+            }
+
+            static void SelectedEnumeratorDisposeAsyncCore(object state)
+            {
+                var self = (_SelectManyAwait)state;
+
+                if (self.TryGetResult(self.selectedDisposeAsyncAwaiter))
+                {
+                    self.selectedEnumerator = null;
+                    self.selectedAwaiter = default;
+
+                    self.MoveNextSource(); // iterate next source
+                }
+            }
+
+            static void SelectorAwaitCore(object state)
+            {
+                var self = (_SelectManyAwait)state;
+
+                if (self.TryGetResult(self.collectionSelectorAwaiter, out var result))
+                {
+                    self.selectedEnumerator = result.GetAsyncEnumerator(self.cancellationToken);
+                    self.MoveNextSelected(); // iterated selected source.
+                }
+            }
+
+            static void ResultSelectorAwaitCore(object state)
+            {
+                var self = (_SelectManyAwait)state;
+
+                if (self.TryGetResult(self.resultSelectorAwaiter, out var result))
+                {
+                    self.Current = result;
+                    self.completionSource.TrySetResult(true);
+                }
+            }
+
+            public async UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                if (selectedEnumerator != null)
+                {
+                    await selectedEnumerator.DisposeAsync();
+                }
+                if (sourceEnumerator != null)
+                {
+                    await sourceEnumerator.DisposeAsync();
+                }
+            }
+        }
+    }
+
+    internal sealed class SelectManyAwaitWithCancellation<TSource, TCollection, TResult> : IUniTaskAsyncEnumerable<TResult>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+        readonly Func<TSource, CancellationToken, UniTask<IUniTaskAsyncEnumerable<TCollection>>> selector1;
+        readonly Func<TSource, int, CancellationToken, UniTask<IUniTaskAsyncEnumerable<TCollection>>> selector2;
+        readonly Func<TSource, TCollection, CancellationToken, UniTask<TResult>> resultSelector;
+
+        public SelectManyAwaitWithCancellation(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<IUniTaskAsyncEnumerable<TCollection>>> selector, Func<TSource, TCollection, CancellationToken, UniTask<TResult>> resultSelector)
+        {
+            this.source = source;
+            this.selector1 = selector;
+            this.selector2 = null;
+            this.resultSelector = resultSelector;
+        }
+
+        public SelectManyAwaitWithCancellation(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, int, CancellationToken, UniTask<IUniTaskAsyncEnumerable<TCollection>>> selector, Func<TSource, TCollection, CancellationToken, UniTask<TResult>> resultSelector)
+        {
+            this.source = source;
+            this.selector1 = null;
+            this.selector2 = selector;
+            this.resultSelector = resultSelector;
+        }
+
+        public IUniTaskAsyncEnumerator<TResult> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _SelectManyAwaitWithCancellation(source, selector1, selector2, resultSelector, cancellationToken);
+        }
+
+        sealed class _SelectManyAwaitWithCancellation : MoveNextSource, IUniTaskAsyncEnumerator<TResult>
+        {
+            static readonly Action<object> sourceMoveNextCoreDelegate = SourceMoveNextCore;
+            static readonly Action<object> selectedSourceMoveNextCoreDelegate = SeletedSourceMoveNextCore;
+            static readonly Action<object> selectedEnumeratorDisposeAsyncCoreDelegate = SelectedEnumeratorDisposeAsyncCore;
+            static readonly Action<object> selectorAwaitCoreDelegate = SelectorAwaitCore;
+            static readonly Action<object> resultSelectorAwaitCoreDelegate = ResultSelectorAwaitCore;
+
+            readonly IUniTaskAsyncEnumerable<TSource> source;
+
+            readonly Func<TSource, CancellationToken, UniTask<IUniTaskAsyncEnumerable<TCollection>>> selector1;
+            readonly Func<TSource, int, CancellationToken, UniTask<IUniTaskAsyncEnumerable<TCollection>>> selector2;
+            readonly Func<TSource, TCollection, CancellationToken, UniTask<TResult>> resultSelector;
+            CancellationToken cancellationToken;
+
+            TSource sourceCurrent;
+            int sourceIndex;
+            IUniTaskAsyncEnumerator<TSource> sourceEnumerator;
+            IUniTaskAsyncEnumerator<TCollection> selectedEnumerator;
+            UniTask<bool>.Awaiter sourceAwaiter;
+            UniTask<bool>.Awaiter selectedAwaiter;
+            UniTask.Awaiter selectedDisposeAsyncAwaiter;
+
+            // await additional
+            UniTask<IUniTaskAsyncEnumerable<TCollection>>.Awaiter collectionSelectorAwaiter;
+            UniTask<TResult>.Awaiter resultSelectorAwaiter;
+
+            public _SelectManyAwaitWithCancellation(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<IUniTaskAsyncEnumerable<TCollection>>> selector1, Func<TSource, int, CancellationToken, UniTask<IUniTaskAsyncEnumerable<TCollection>>> selector2, Func<TSource, TCollection, CancellationToken, UniTask<TResult>> resultSelector, CancellationToken cancellationToken)
+            {
+                this.source = source;
+                this.selector1 = selector1;
+                this.selector2 = selector2;
+                this.resultSelector = resultSelector;
+                this.cancellationToken = cancellationToken;
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public TResult Current { get; private set; }
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                completionSource.Reset();
+
+                // iterate selected field
+                if (selectedEnumerator != null)
+                {
+                    MoveNextSelected();
+                }
+                else
+                {
+                    // iterate source field
+                    if (sourceEnumerator == null)
+                    {
+                        sourceEnumerator = source.GetAsyncEnumerator(cancellationToken);
+                    }
+                    MoveNextSource();
+                }
+
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            void MoveNextSource()
+            {
+                try
+                {
+                    sourceAwaiter = sourceEnumerator.MoveNextAsync().GetAwaiter();
+                }
+                catch (Exception ex)
+                {
+                    completionSource.TrySetException(ex);
+                    return;
+                }
+
+                if (sourceAwaiter.IsCompleted)
+                {
+                    SourceMoveNextCore(this);
+                }
+                else
+                {
+                    sourceAwaiter.SourceOnCompleted(sourceMoveNextCoreDelegate, this);
+                }
+            }
+
+            void MoveNextSelected()
+            {
+                try
+                {
+                    selectedAwaiter = selectedEnumerator.MoveNextAsync().GetAwaiter();
+                }
+                catch (Exception ex)
+                {
+                    completionSource.TrySetException(ex);
+                    return;
+                }
+
+                if (selectedAwaiter.IsCompleted)
+                {
+                    SeletedSourceMoveNextCore(this);
+                }
+                else
+                {
+                    selectedAwaiter.SourceOnCompleted(selectedSourceMoveNextCoreDelegate, this);
+                }
+            }
+
+            static void SourceMoveNextCore(object state)
+            {
+                var self = (_SelectManyAwaitWithCancellation)state;
+
+                if (self.TryGetResult(self.sourceAwaiter, out var result))
+                {
+                    if (result)
+                    {
+                        try
+                        {
+                            self.sourceCurrent = self.sourceEnumerator.Current;
+
+                            if (self.selector1 != null)
+                            {
+                                self.collectionSelectorAwaiter = self.selector1(self.sourceCurrent, self.cancellationToken).GetAwaiter();
+                            }
+                            else
+                            {
+                                self.collectionSelectorAwaiter = self.selector2(self.sourceCurrent, checked(self.sourceIndex++), self.cancellationToken).GetAwaiter();
+                            }
+
+                            if (self.collectionSelectorAwaiter.IsCompleted)
+                            {
+                                SelectorAwaitCore(self);
+                            }
+                            else
+                            {
+                                self.collectionSelectorAwaiter.SourceOnCompleted(selectorAwaitCoreDelegate, self);
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            self.completionSource.TrySetException(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        self.completionSource.TrySetResult(false);
+                    }
+                }
+            }
+
+            static void SeletedSourceMoveNextCore(object state)
+            {
+                var self = (_SelectManyAwaitWithCancellation)state;
+
+                if (self.TryGetResult(self.selectedAwaiter, out var result))
+                {
+                    if (result)
+                    {
+                        try
+                        {
+                            self.resultSelectorAwaiter = self.resultSelector(self.sourceCurrent, self.selectedEnumerator.Current, self.cancellationToken).GetAwaiter();
+                            if (self.resultSelectorAwaiter.IsCompleted)
+                            {
+                                ResultSelectorAwaitCore(self);
+                            }
+                            else
+                            {
+                                self.resultSelectorAwaiter.SourceOnCompleted(resultSelectorAwaitCoreDelegate, self);
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            self.completionSource.TrySetException(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        // dispose selected source and try iterate source.
+                        try
+                        {
+                            self.selectedDisposeAsyncAwaiter = self.selectedEnumerator.DisposeAsync().GetAwaiter();
+                        }
+                        catch (Exception ex)
+                        {
+                            self.completionSource.TrySetException(ex);
+                            return;
+                        }
+                        if (self.selectedDisposeAsyncAwaiter.IsCompleted)
+                        {
+                            SelectedEnumeratorDisposeAsyncCore(self);
+                        }
+                        else
+                        {
+                            self.selectedDisposeAsyncAwaiter.SourceOnCompleted(selectedEnumeratorDisposeAsyncCoreDelegate, self);
+                        }
+                    }
+                }
+            }
+
+            static void SelectedEnumeratorDisposeAsyncCore(object state)
+            {
+                var self = (_SelectManyAwaitWithCancellation)state;
+
+                if (self.TryGetResult(self.selectedDisposeAsyncAwaiter))
+                {
+                    self.selectedEnumerator = null;
+                    self.selectedAwaiter = default;
+
+                    self.MoveNextSource(); // iterate next source
+                }
+            }
+
+            static void SelectorAwaitCore(object state)
+            {
+                var self = (_SelectManyAwaitWithCancellation)state;
+
+                if (self.TryGetResult(self.collectionSelectorAwaiter, out var result))
+                {
+                    self.selectedEnumerator = result.GetAsyncEnumerator(self.cancellationToken);
+                    self.MoveNextSelected(); // iterated selected source.
+                }
+            }
+
+            static void ResultSelectorAwaitCore(object state)
+            {
+                var self = (_SelectManyAwaitWithCancellation)state;
+
+                if (self.TryGetResult(self.resultSelectorAwaiter, out var result))
+                {
+                    self.Current = result;
+                    self.completionSource.TrySetResult(true);
+                }
+            }
+
+            public async UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                if (selectedEnumerator != null)
+                {
+                    await selectedEnumerator.DisposeAsync();
+                }
+                if (sourceEnumerator != null)
+                {
+                    await sourceEnumerator.DisposeAsync();
+                }
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/SelectMany.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/SelectMany.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d81862f0eb12680479ccaaf2ac319d24
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/SequenceEqual.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/SequenceEqual.cs
@@ -1,0 +1,87 @@
+﻿using Cysharp.Threading.Tasks.Internal;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static UniTask<Boolean> SequenceEqualAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> first, IUniTaskAsyncEnumerable<TSource> second, CancellationToken cancellationToken = default)
+        {
+            return SequenceEqualAsync(first, second, EqualityComparer<TSource>.Default, cancellationToken);
+        }
+
+        public static UniTask<Boolean> SequenceEqualAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> first, IUniTaskAsyncEnumerable<TSource> second, IEqualityComparer<TSource> comparer, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(first, nameof(first));
+            Error.ThrowArgumentNullException(second, nameof(second));
+            Error.ThrowArgumentNullException(comparer, nameof(comparer));
+
+            return SequenceEqual.SequenceEqualAsync(first, second, comparer, cancellationToken);
+        }
+    }
+
+    internal static class SequenceEqual
+    {
+        internal static async UniTask<bool> SequenceEqualAsync<TSource>(IUniTaskAsyncEnumerable<TSource> first, IUniTaskAsyncEnumerable<TSource> second, IEqualityComparer<TSource> comparer, CancellationToken cancellationToken)
+        {
+            var e1 = first.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                var e2 = second.GetAsyncEnumerator(cancellationToken);
+                try
+                {
+                    while (true)
+                    {
+                        if (await e1.MoveNextAsync())
+                        {
+                            if (await e2.MoveNextAsync())
+                            {
+                                if (comparer.Equals(e1.Current, e2.Current))
+                                {
+                                    continue;
+                                }
+                                else
+                                {
+                                    return false;
+                                }
+                            }
+                            else
+                            {
+                                // e2 is finished, but e1 has value
+                                return false;
+                            }
+                        }
+                        else
+                        {
+                            // e1 is finished, e2?
+                            if (await e2.MoveNextAsync())
+                            {
+                                return false;
+                            }
+                            else
+                            {
+                                return true;
+                            }
+                        }
+                    }
+                }
+                finally
+                {
+                    if (e2 != null)
+                    {
+                        await e2.DisposeAsync();
+                    }
+                }
+            }
+            finally
+            {
+                if (e1 != null)
+                {
+                    await e1.DisposeAsync();
+                }
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/SequenceEqual.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/SequenceEqual.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b382772aba6128842928cdb6b2e034b0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Single.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Single.cs
@@ -1,0 +1,230 @@
+﻿using Cysharp.Threading.Tasks.Internal;
+using System;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static UniTask<TSource> SingleAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return SingleOperator.SingleAsync(source, cancellationToken, false);
+        }
+
+        public static UniTask<TSource> SingleAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Boolean> predicate, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(predicate, nameof(predicate));
+
+            return SingleOperator.SingleAsync(source, predicate, cancellationToken, false);
+        }
+
+        public static UniTask<TSource> SingleAwaitAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Boolean>> predicate, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(predicate, nameof(predicate));
+
+            return SingleOperator.SingleAwaitAsync(source, predicate, cancellationToken, false);
+        }
+
+        public static UniTask<TSource> SingleAwaitWithCancellationAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Boolean>> predicate, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(predicate, nameof(predicate));
+
+            return SingleOperator.SingleAwaitWithCancellationAsync(source, predicate, cancellationToken, false);
+        }
+
+        public static UniTask<TSource> SingleOrDefaultAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return SingleOperator.SingleAsync(source, cancellationToken, true);
+        }
+
+        public static UniTask<TSource> SingleOrDefaultAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Boolean> predicate, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(predicate, nameof(predicate));
+
+            return SingleOperator.SingleAsync(source, predicate, cancellationToken, true);
+        }
+
+        public static UniTask<TSource> SingleOrDefaultAwaitAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Boolean>> predicate, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(predicate, nameof(predicate));
+
+            return SingleOperator.SingleAwaitAsync(source, predicate, cancellationToken, true);
+        }
+
+        public static UniTask<TSource> SingleOrDefaultAwaitWithCancellationAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Boolean>> predicate, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(predicate, nameof(predicate));
+
+            return SingleOperator.SingleAwaitWithCancellationAsync(source, predicate, cancellationToken, true);
+        }
+    }
+
+    internal static class SingleOperator
+    {
+        public static async UniTask<TSource> SingleAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, CancellationToken cancellationToken, bool defaultIfEmpty)
+        {
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                if (await e.MoveNextAsync())
+                {
+                    var v = e.Current;
+                    if (!await e.MoveNextAsync())
+                    {
+                        return v;
+                    }
+
+                    throw Error.MoreThanOneElement();
+                }
+                else
+                {
+                    if (defaultIfEmpty)
+                    {
+                        return default;
+                    }
+                    else
+                    {
+                        throw Error.NoElements();
+                    }
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+        }
+
+        public static async UniTask<TSource> SingleAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Boolean> predicate, CancellationToken cancellationToken, bool defaultIfEmpty)
+        {
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                TSource value = default;
+                bool found = false;
+                while (await e.MoveNextAsync())
+                {
+                    var v = e.Current;
+                    if (predicate(v))
+                    {
+                        if (found)
+                        {
+                            throw Error.MoreThanOneElement();
+                        }
+                        else
+                        {
+                            found = true;
+                            value = v;
+                        }
+                    }
+                }
+
+                if (found || defaultIfEmpty)
+                {
+                    return value;
+                }
+
+                throw Error.NoElements();
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+        }
+
+        public static async UniTask<TSource> SingleAwaitAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Boolean>> predicate, CancellationToken cancellationToken, bool defaultIfEmpty)
+        {
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                TSource value = default;
+                bool found = false;
+                while (await e.MoveNextAsync())
+                {
+                    var v = e.Current;
+                    if (await predicate(v))
+                    {
+                        if (found)
+                        {
+                            throw Error.MoreThanOneElement();
+                        }
+                        else
+                        {
+                            found = true;
+                            value = v;
+                        }
+                    }
+                }
+
+                if (found || defaultIfEmpty)
+                {
+                    return value;
+                }
+
+                throw Error.NoElements();
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+        }
+
+        public static async UniTask<TSource> SingleAwaitWithCancellationAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Boolean>> predicate, CancellationToken cancellationToken, bool defaultIfEmpty)
+        {
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                TSource value = default;
+                bool found = false;
+                while (await e.MoveNextAsync())
+                {
+                    var v = e.Current;
+                    if (await predicate(v, cancellationToken))
+                    {
+                        if (found)
+                        {
+                            throw Error.MoreThanOneElement();
+                        }
+                        else
+                        {
+                            found = true;
+                            value = v;
+                        }
+                    }
+                }
+
+                if (found || defaultIfEmpty)
+                {
+                    return value;
+                }
+
+                throw Error.NoElements();
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Single.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Single.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1bcd3928b90472e43a3a92c3ba708967
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Skip.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Skip.cs
@@ -1,0 +1,69 @@
+﻿using Cysharp.Threading.Tasks.Internal;
+using System;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static IUniTaskAsyncEnumerable<TSource> Skip<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Int32 count)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return new Skip<TSource>(source, count);
+        }
+    }
+
+    internal sealed class Skip<TSource> : IUniTaskAsyncEnumerable<TSource>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+        readonly int count;
+
+        public Skip(IUniTaskAsyncEnumerable<TSource> source, int count)
+        {
+            this.source = source;
+            this.count = count;
+        }
+
+        public IUniTaskAsyncEnumerator<TSource> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _Skip(source, count, cancellationToken);
+        }
+
+        sealed class _Skip : AsyncEnumeratorBase<TSource, TSource>
+        {
+            readonly int count;
+
+            int index;
+
+            public _Skip(IUniTaskAsyncEnumerable<TSource> source, int count, CancellationToken cancellationToken)
+                : base(source, cancellationToken)
+            {
+                this.count = count;
+            }
+
+            protected override bool TryMoveNextCore(bool sourceHasCurrent, out bool result)
+            {
+                if (sourceHasCurrent)
+                {
+                    if (count <= checked(index++))
+                    {
+                        Current = SourceCurrent;
+                        result = true;
+                        return true;
+                    }
+                    else
+                    {
+                        result = default;
+                        return false;
+                    }
+                }
+                else
+                {
+                    result = false;
+                    return true;
+                }
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Skip.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Skip.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9c46b6c7dce0cb049a73c81084c75154
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/SkipLast.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/SkipLast.cs
@@ -1,0 +1,159 @@
+﻿using Cysharp.Threading.Tasks.Internal;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static IUniTaskAsyncEnumerable<TSource> SkipLast<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Int32 count)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            // non skip.
+            if (count <= 0)
+            {
+                return source;
+            }
+
+            return new SkipLast<TSource>(source, count);
+        }
+    }
+
+    internal sealed class SkipLast<TSource> : IUniTaskAsyncEnumerable<TSource>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+        readonly int count;
+
+        public SkipLast(IUniTaskAsyncEnumerable<TSource> source, int count)
+        {
+            this.source = source;
+            this.count = count;
+        }
+
+        public IUniTaskAsyncEnumerator<TSource> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _SkipLast(source, count, cancellationToken);
+        }
+
+        sealed class _SkipLast : MoveNextSource, IUniTaskAsyncEnumerator<TSource>
+        {
+            static readonly Action<object> MoveNextCoreDelegate = MoveNextCore;
+
+            readonly IUniTaskAsyncEnumerable<TSource> source;
+            readonly int count;
+            CancellationToken cancellationToken;
+
+            IUniTaskAsyncEnumerator<TSource> enumerator;
+            UniTask<bool>.Awaiter awaiter;
+            Queue<TSource> queue;
+
+            bool continueNext;
+
+            public _SkipLast(IUniTaskAsyncEnumerable<TSource> source, int count, CancellationToken cancellationToken)
+            {
+                this.source = source;
+                this.count = count;
+                this.cancellationToken = cancellationToken;
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public TSource Current { get; private set; }
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (enumerator == null)
+                {
+                    enumerator = source.GetAsyncEnumerator(cancellationToken);
+                    queue = new Queue<TSource>();
+                }
+
+                completionSource.Reset();
+                SourceMoveNext();
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            void SourceMoveNext()
+            {
+                try
+                {
+
+                    LOOP:
+                    awaiter = enumerator.MoveNextAsync().GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        continueNext = true;
+                        MoveNextCore(this);
+                        if (continueNext)
+                        {
+                            continueNext = false;
+                            goto LOOP; // avoid recursive
+                        }
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(MoveNextCoreDelegate, this);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    completionSource.TrySetException(ex);
+                }
+            }
+
+
+            static void MoveNextCore(object state)
+            {
+                var self = (_SkipLast)state;
+
+                if (self.TryGetResult(self.awaiter, out var result))
+                {
+                    if (result)
+                    {
+                        if (self.queue.Count == self.count)
+                        {
+                            self.continueNext = false;
+
+                            var deq = self.queue.Dequeue();
+                            self.Current = deq;
+                            self.queue.Enqueue(self.enumerator.Current);
+
+                            self.completionSource.TrySetResult(true);
+                        }
+                        else
+                        {
+                            self.queue.Enqueue(self.enumerator.Current);
+
+                            if (!self.continueNext)
+                            {
+                                self.SourceMoveNext();
+                            }
+                        }
+                    }
+                    else
+                    {
+                        self.continueNext = false;
+                        self.completionSource.TrySetResult(false);
+                    }
+                }
+                else
+                {
+                    self.continueNext = false;
+                }
+            }
+
+            public UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                if (enumerator != null)
+                {
+                    return enumerator.DisposeAsync();
+                }
+                return default;
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/SkipLast.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/SkipLast.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: df1d7f44d4fe7754f972c9e0b6fa72d5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/SkipUntil.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/SkipUntil.cs
@@ -1,0 +1,187 @@
+﻿using Cysharp.Threading.Tasks.Internal;
+using System;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static IUniTaskAsyncEnumerable<TSource> SkipUntil<TSource>(this IUniTaskAsyncEnumerable<TSource> source, UniTask other)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return new SkipUntil<TSource>(source, other, null);
+        }
+
+        public static IUniTaskAsyncEnumerable<TSource> SkipUntil<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<CancellationToken, UniTask> other)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(other));
+
+            return new SkipUntil<TSource>(source, default, other);
+        }
+    }
+
+    internal sealed class SkipUntil<TSource> : IUniTaskAsyncEnumerable<TSource>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+        readonly UniTask other;
+        readonly Func<CancellationToken, UniTask> other2;
+
+        public SkipUntil(IUniTaskAsyncEnumerable<TSource> source, UniTask other, Func<CancellationToken, UniTask> other2)
+        {
+            this.source = source;
+            this.other = other;
+            this.other2 = other2;
+        }
+
+        public IUniTaskAsyncEnumerator<TSource> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            if (other2 != null)
+            {
+                return new _SkipUntil(source, this.other2(cancellationToken), cancellationToken);
+            }
+            else
+            {
+                return new _SkipUntil(source, this.other, cancellationToken);
+            }
+        }
+
+        sealed class _SkipUntil : MoveNextSource, IUniTaskAsyncEnumerator<TSource>
+        {
+            static readonly Action<object> CancelDelegate1 = OnCanceled1;
+            static readonly Action<object> MoveNextCoreDelegate = MoveNextCore;
+
+            readonly IUniTaskAsyncEnumerable<TSource> source;
+            CancellationToken cancellationToken1;
+
+            bool completed;
+            CancellationTokenRegistration cancellationTokenRegistration1;
+            IUniTaskAsyncEnumerator<TSource> enumerator;
+            UniTask<bool>.Awaiter awaiter;
+            bool continueNext;
+            Exception exception;
+
+            public _SkipUntil(IUniTaskAsyncEnumerable<TSource> source, UniTask other, CancellationToken cancellationToken1)
+            {
+                this.source = source;
+                this.cancellationToken1 = cancellationToken1;
+                if (cancellationToken1.CanBeCanceled)
+                {
+                    this.cancellationTokenRegistration1 = cancellationToken1.RegisterWithoutCaptureExecutionContext(CancelDelegate1, this);
+                }
+
+                TaskTracker.TrackActiveTask(this, 3);
+                RunOther(other).Forget();
+            }
+
+            public TSource Current { get; private set; }
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                if (exception != null)
+                {
+                    return UniTask.FromException<bool>(exception);
+                }
+
+                if (cancellationToken1.IsCancellationRequested)
+                {
+                    return UniTask.FromCanceled<bool>(cancellationToken1);
+                }
+
+                if (enumerator == null)
+                {
+                    enumerator = source.GetAsyncEnumerator(cancellationToken1);
+                }
+                completionSource.Reset();
+
+                if (completed)
+                {
+                    SourceMoveNext();
+                }
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            void SourceMoveNext()
+            {
+                try
+                {
+                    LOOP:
+                    awaiter = enumerator.MoveNextAsync().GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        continueNext = true;
+                        MoveNextCore(this);
+                        if (continueNext)
+                        {
+                            continueNext = false;
+                            goto LOOP;
+                        }
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(MoveNextCoreDelegate, this);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    completionSource.TrySetException(ex);
+                }
+            }
+
+            static void MoveNextCore(object state)
+            {
+                var self = (_SkipUntil)state;
+
+                if (self.TryGetResult(self.awaiter, out var result))
+                {
+                    if (result)
+                    {
+                        self.Current = self.enumerator.Current;
+                        self.completionSource.TrySetResult(true);
+                        if (self.continueNext)
+                        {
+                            self.SourceMoveNext();
+                        }
+                    }
+                    else
+                    {
+                        self.completionSource.TrySetResult(false);
+                    }
+                }
+            }
+
+            async UniTaskVoid RunOther(UniTask other)
+            {
+                try
+                {
+                    await other;
+                    completed = true;
+                    SourceMoveNext();
+                }
+                catch (Exception ex)
+                {
+                    exception = ex;
+                    completionSource.TrySetException(ex);
+                }
+            }
+
+            static void OnCanceled1(object state)
+            {
+                var self = (_SkipUntil)state;
+                self.completionSource.TrySetCanceled(self.cancellationToken1);
+            }
+
+            public UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                cancellationTokenRegistration1.Dispose();
+                if (enumerator != null)
+                {
+                    return enumerator.DisposeAsync();
+                }
+                return default;
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/SkipUntil.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/SkipUntil.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: de932d79c8d9f3841a066d05ff29edc9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/SkipUntilCanceled.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/SkipUntilCanceled.cs
@@ -1,0 +1,173 @@
+﻿using Cysharp.Threading.Tasks.Internal;
+using System;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static IUniTaskAsyncEnumerable<TSource> SkipUntilCanceled<TSource>(this IUniTaskAsyncEnumerable<TSource> source, CancellationToken cancellationToken)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return new SkipUntilCanceled<TSource>(source, cancellationToken);
+        }
+    }
+
+    internal sealed class SkipUntilCanceled<TSource> : IUniTaskAsyncEnumerable<TSource>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+        readonly CancellationToken cancellationToken;
+
+        public SkipUntilCanceled(IUniTaskAsyncEnumerable<TSource> source, CancellationToken cancellationToken)
+        {
+            this.source = source;
+            this.cancellationToken = cancellationToken;
+        }
+
+        public IUniTaskAsyncEnumerator<TSource> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _SkipUntilCanceled(source, this.cancellationToken, cancellationToken);
+        }
+
+        sealed class _SkipUntilCanceled : MoveNextSource, IUniTaskAsyncEnumerator<TSource>
+        {
+            static readonly Action<object> CancelDelegate1 = OnCanceled1;
+            static readonly Action<object> CancelDelegate2 = OnCanceled2;
+            static readonly Action<object> MoveNextCoreDelegate = MoveNextCore;
+
+            readonly IUniTaskAsyncEnumerable<TSource> source;
+            CancellationToken cancellationToken1;
+            CancellationToken cancellationToken2;
+            CancellationTokenRegistration cancellationTokenRegistration1;
+            CancellationTokenRegistration cancellationTokenRegistration2;
+
+            int isCanceled;
+            IUniTaskAsyncEnumerator<TSource> enumerator;
+            UniTask<bool>.Awaiter awaiter;
+            bool continueNext;
+
+            public _SkipUntilCanceled(IUniTaskAsyncEnumerable<TSource> source, CancellationToken cancellationToken1, CancellationToken cancellationToken2)
+            {
+                this.source = source;
+                this.cancellationToken1 = cancellationToken1;
+                this.cancellationToken2 = cancellationToken2;
+                if (cancellationToken1.CanBeCanceled)
+                {
+                    this.cancellationTokenRegistration1 = cancellationToken1.RegisterWithoutCaptureExecutionContext(CancelDelegate1, this);
+                }
+                if (cancellationToken1 != cancellationToken2 && cancellationToken2.CanBeCanceled)
+                {
+                    this.cancellationTokenRegistration2 = cancellationToken2.RegisterWithoutCaptureExecutionContext(CancelDelegate2, this);
+                }
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public TSource Current { get; private set; }
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                if (enumerator == null)
+                {
+                    if (cancellationToken1.IsCancellationRequested) isCanceled = 1;
+                    if (cancellationToken2.IsCancellationRequested) isCanceled = 1;
+                    enumerator = source.GetAsyncEnumerator(cancellationToken2); // use only AsyncEnumerator provided token.
+                }
+                completionSource.Reset();
+
+                if (isCanceled != 0)
+                {
+                    SourceMoveNext();
+                }
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            void SourceMoveNext()
+            {
+                try
+                {
+                    LOOP:
+                    awaiter = enumerator.MoveNextAsync().GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        continueNext = true;
+                        MoveNextCore(this);
+                        if (continueNext)
+                        {
+                            continueNext = false;
+                            goto LOOP;
+                        }
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(MoveNextCoreDelegate, this);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    completionSource.TrySetException(ex);
+                }
+            }
+
+            static void MoveNextCore(object state)
+            {
+                var self = (_SkipUntilCanceled)state;
+
+                if (self.TryGetResult(self.awaiter, out var result))
+                {
+                    if (result)
+                    {
+                        self.Current = self.enumerator.Current;
+                        self.completionSource.TrySetResult(true);
+                        if (self.continueNext)
+                        {
+                            self.SourceMoveNext();
+                        }
+                    }
+                    else
+                    {
+                        self.completionSource.TrySetResult(false);
+                    }
+                }
+            }
+
+            static void OnCanceled1(object state)
+            {
+                var self = (_SkipUntilCanceled)state;
+                if (self.isCanceled == 0)
+                {
+                    if (Interlocked.Increment(ref self.isCanceled) == 1)
+                    {
+                        self.cancellationTokenRegistration2.Dispose();
+                        self.SourceMoveNext();
+                    }
+                }
+            }
+
+            static void OnCanceled2(object state)
+            {
+                var self = (_SkipUntilCanceled)state;
+                if (self.isCanceled == 0)
+                {
+                    if (Interlocked.Increment(ref self.isCanceled) == 1)
+                    {
+                        self.cancellationTokenRegistration2.Dispose();
+                        self.SourceMoveNext();
+                    }
+                }
+            }
+
+            public UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                cancellationTokenRegistration1.Dispose();
+                cancellationTokenRegistration2.Dispose();
+                if (enumerator != null)
+                {
+                    return enumerator.DisposeAsync();
+                }
+                return default;
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/SkipUntilCanceled.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/SkipUntilCanceled.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4b1a778aef7150d47b93a49aa1bc34ae
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/SkipWhile.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/SkipWhile.cs
@@ -1,0 +1,379 @@
+﻿using Cysharp.Threading.Tasks.Internal;
+using System;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static IUniTaskAsyncEnumerable<TSource> SkipWhile<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Boolean> predicate)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(predicate, nameof(predicate));
+
+            return new SkipWhile<TSource>(source, predicate);
+        }
+
+        public static IUniTaskAsyncEnumerable<TSource> SkipWhile<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Int32, Boolean> predicate)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(predicate, nameof(predicate));
+
+            return new SkipWhileInt<TSource>(source, predicate);
+        }
+
+        public static IUniTaskAsyncEnumerable<TSource> SkipWhileAwait<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Boolean>> predicate)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(predicate, nameof(predicate));
+
+            return new SkipWhileAwait<TSource>(source, predicate);
+        }
+
+        public static IUniTaskAsyncEnumerable<TSource> SkipWhileAwait<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Int32, UniTask<Boolean>> predicate)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(predicate, nameof(predicate));
+
+            return new SkipWhileIntAwait<TSource>(source, predicate);
+        }
+
+        public static IUniTaskAsyncEnumerable<TSource> SkipWhileAwaitWithCancellation<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Boolean>> predicate)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(predicate, nameof(predicate));
+
+            return new SkipWhileAwaitWithCancellation<TSource>(source, predicate);
+        }
+
+        public static IUniTaskAsyncEnumerable<TSource> SkipWhileAwaitWithCancellation<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Int32, CancellationToken, UniTask<Boolean>> predicate)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(predicate, nameof(predicate));
+
+            return new SkipWhileIntAwaitWithCancellation<TSource>(source, predicate);
+        }
+    }
+
+    internal sealed class SkipWhile<TSource> : IUniTaskAsyncEnumerable<TSource>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+        readonly Func<TSource, bool> predicate;
+
+        public SkipWhile(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, bool> predicate)
+        {
+            this.source = source;
+            this.predicate = predicate;
+        }
+
+        public IUniTaskAsyncEnumerator<TSource> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _SkipWhile(source, predicate, cancellationToken);
+        }
+
+        class _SkipWhile : AsyncEnumeratorBase<TSource, TSource>
+        {
+            Func<TSource, bool> predicate;
+
+            public _SkipWhile(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, bool> predicate, CancellationToken cancellationToken)
+
+                : base(source, cancellationToken)
+            {
+                this.predicate = predicate;
+            }
+
+            protected override bool TryMoveNextCore(bool sourceHasCurrent, out bool result)
+            {
+                if (sourceHasCurrent)
+                {
+                    if (predicate == null || !predicate(SourceCurrent))
+                    {
+                        predicate = null;
+                        Current = SourceCurrent;
+                        result = true;
+                        return true;
+                    }
+                    else
+                    {
+                        result = default;
+                        return false;
+                    }
+                }
+
+                result = false;
+                return true;
+            }
+        }
+    }
+
+    internal sealed class SkipWhileInt<TSource> : IUniTaskAsyncEnumerable<TSource>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+        readonly Func<TSource, int, bool> predicate;
+
+        public SkipWhileInt(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, int, bool> predicate)
+        {
+            this.source = source;
+            this.predicate = predicate;
+        }
+
+        public IUniTaskAsyncEnumerator<TSource> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _SkipWhileInt(source, predicate, cancellationToken);
+        }
+
+        class _SkipWhileInt : AsyncEnumeratorBase<TSource, TSource>
+        {
+            Func<TSource, int, bool> predicate;
+            int index;
+
+            public _SkipWhileInt(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, int, bool> predicate, CancellationToken cancellationToken)
+
+                : base(source, cancellationToken)
+            {
+                this.predicate = predicate;
+            }
+
+            protected override bool TryMoveNextCore(bool sourceHasCurrent, out bool result)
+            {
+                if (sourceHasCurrent)
+                {
+                    if (predicate == null || !predicate(SourceCurrent, checked(index++)))
+                    {
+                        predicate = null;
+                        Current = SourceCurrent;
+                        result = true;
+                        return true;
+                    }
+                    else
+                    {
+                        result = default;
+                        return false;
+                    }
+                }
+
+                result = false;
+                return true;
+            }
+        }
+    }
+
+    internal sealed class SkipWhileAwait<TSource> : IUniTaskAsyncEnumerable<TSource>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+        readonly Func<TSource, UniTask<bool>> predicate;
+
+        public SkipWhileAwait(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<bool>> predicate)
+        {
+            this.source = source;
+            this.predicate = predicate;
+        }
+
+        public IUniTaskAsyncEnumerator<TSource> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _SkipWhileAwait(source, predicate, cancellationToken);
+        }
+
+        class _SkipWhileAwait : AsyncEnumeratorAwaitSelectorBase<TSource, TSource, bool>
+        {
+            Func<TSource, UniTask<bool>> predicate;
+
+            public _SkipWhileAwait(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<bool>> predicate, CancellationToken cancellationToken)
+
+                : base(source, cancellationToken)
+            {
+                this.predicate = predicate;
+            }
+
+            protected override UniTask<bool> TransformAsync(TSource sourceCurrent)
+            {
+                if (predicate == null)
+                {
+                    return CompletedTasks.False;
+                }
+
+                return predicate(sourceCurrent);
+            }
+
+            protected override bool TrySetCurrentCore(bool awaitResult, out bool terminateIteration)
+            {
+                if (!awaitResult)
+                {
+                    predicate = null;
+                    Current = SourceCurrent;
+                    terminateIteration= false;
+                    return true;
+                }
+                else
+                {
+                    terminateIteration= false;
+                    return false;
+                }
+            }
+        }
+    }
+
+    internal sealed class SkipWhileIntAwait<TSource> : IUniTaskAsyncEnumerable<TSource>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+        readonly Func<TSource, int, UniTask<bool>> predicate;
+
+        public SkipWhileIntAwait(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, int, UniTask<bool>> predicate)
+        {
+            this.source = source;
+            this.predicate = predicate;
+        }
+
+        public IUniTaskAsyncEnumerator<TSource> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _SkipWhileIntAwait(source, predicate, cancellationToken);
+        }
+
+        class _SkipWhileIntAwait : AsyncEnumeratorAwaitSelectorBase<TSource, TSource, bool>
+        {
+            Func<TSource, int, UniTask<bool>> predicate;
+            int index;
+
+            public _SkipWhileIntAwait(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, int, UniTask<bool>> predicate, CancellationToken cancellationToken)
+
+                : base(source, cancellationToken)
+            {
+                this.predicate = predicate;
+            }
+
+            protected override UniTask<bool> TransformAsync(TSource sourceCurrent)
+            {
+                if (predicate == null)
+                {
+                    return CompletedTasks.False;
+                }
+
+                return predicate(sourceCurrent, checked(index++));
+            }
+
+            protected override bool TrySetCurrentCore(bool awaitResult, out bool terminateIteration)
+            {
+                terminateIteration= false;
+                if (!awaitResult)
+                {
+                    predicate = null;
+                    Current = SourceCurrent;
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+        }
+    }
+
+    internal sealed class SkipWhileAwaitWithCancellation<TSource> : IUniTaskAsyncEnumerable<TSource>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+        readonly Func<TSource, CancellationToken, UniTask<bool>> predicate;
+
+        public SkipWhileAwaitWithCancellation(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<bool>> predicate)
+        {
+            this.source = source;
+            this.predicate = predicate;
+        }
+
+        public IUniTaskAsyncEnumerator<TSource> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _SkipWhileAwaitWithCancellation(source, predicate, cancellationToken);
+        }
+
+        class _SkipWhileAwaitWithCancellation : AsyncEnumeratorAwaitSelectorBase<TSource, TSource, bool>
+        {
+            Func<TSource, CancellationToken, UniTask<bool>> predicate;
+
+            public _SkipWhileAwaitWithCancellation(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<bool>> predicate, CancellationToken cancellationToken)
+
+                : base(source, cancellationToken)
+            {
+                this.predicate = predicate;
+            }
+
+            protected override UniTask<bool> TransformAsync(TSource sourceCurrent)
+            {
+                if (predicate == null)
+                {
+                    return CompletedTasks.False;
+                }
+
+                return predicate(sourceCurrent, cancellationToken);
+            }
+
+            protected override bool TrySetCurrentCore(bool awaitResult, out bool terminateIteration)
+            {
+                terminateIteration= false;
+                if (!awaitResult)
+                {
+                    predicate = null;
+                    Current = SourceCurrent;
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+        }
+    }
+
+    internal sealed class SkipWhileIntAwaitWithCancellation<TSource> : IUniTaskAsyncEnumerable<TSource>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+        readonly Func<TSource, int, CancellationToken, UniTask<bool>> predicate;
+
+        public SkipWhileIntAwaitWithCancellation(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, int, CancellationToken, UniTask<bool>> predicate)
+        {
+            this.source = source;
+            this.predicate = predicate;
+        }
+
+        public IUniTaskAsyncEnumerator<TSource> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _SkipWhileIntAwaitWithCancellation(source, predicate, cancellationToken);
+        }
+
+        class _SkipWhileIntAwaitWithCancellation : AsyncEnumeratorAwaitSelectorBase<TSource, TSource, bool>
+        {
+            Func<TSource, int, CancellationToken, UniTask<bool>> predicate;
+            int index;
+
+            public _SkipWhileIntAwaitWithCancellation(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, int, CancellationToken, UniTask<bool>> predicate, CancellationToken cancellationToken)
+
+                : base(source, cancellationToken)
+            {
+                this.predicate = predicate;
+            }
+
+            protected override UniTask<bool> TransformAsync(TSource sourceCurrent)
+            {
+                if (predicate == null)
+                {
+                    return CompletedTasks.False;
+                }
+
+                return predicate(sourceCurrent, checked(index++), cancellationToken);
+            }
+
+            protected override bool TrySetCurrentCore(bool awaitResult, out bool terminateIteration)
+            {
+                terminateIteration= false;
+                if (!awaitResult)
+                {
+                    predicate = null;
+                    Current = SourceCurrent;
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/SkipWhile.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/SkipWhile.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0b74b9fe361bf7148b51a29c8b2561e8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Subscribe.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Subscribe.cs
@@ -1,0 +1,536 @@
+﻿using Cysharp.Threading.Tasks.Internal;
+using System;
+using System.Threading;
+using Subscribes = Cysharp.Threading.Tasks.Linq.Subscribe;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        // OnNext
+
+        public static IDisposable Subscribe<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Action<TSource> action)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(action, nameof(action));
+
+            var cts = new CancellationTokenDisposable();
+            Subscribes.SubscribeCore(source, action, Subscribes.NopError, Subscribes.NopCompleted, cts.Token).Forget();
+            return cts;
+        }
+
+        public static IDisposable Subscribe<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTaskVoid> action)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(action, nameof(action));
+
+            var cts = new CancellationTokenDisposable();
+            Subscribes.SubscribeCore(source, action, Subscribes.NopError, Subscribes.NopCompleted, cts.Token).Forget();
+            return cts;
+        }
+
+        public static IDisposable Subscribe<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTaskVoid> action)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(action, nameof(action));
+
+            var cts = new CancellationTokenDisposable();
+            Subscribes.SubscribeCore(source, action, Subscribes.NopError, Subscribes.NopCompleted, cts.Token).Forget();
+            return cts;
+        }
+
+        public static void Subscribe<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Action<TSource> action, CancellationToken cancellationToken)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(action, nameof(action));
+
+            Subscribes.SubscribeCore(source, action, Subscribes.NopError, Subscribes.NopCompleted, cancellationToken).Forget();
+        }
+
+        public static void Subscribe<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTaskVoid> action, CancellationToken cancellationToken)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(action, nameof(action));
+
+            Subscribes.SubscribeCore(source, action, Subscribes.NopError, Subscribes.NopCompleted, cancellationToken).Forget();
+        }
+
+        public static void Subscribe<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTaskVoid> action, CancellationToken cancellationToken)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(action, nameof(action));
+
+            Subscribes.SubscribeCore(source, action, Subscribes.NopError, Subscribes.NopCompleted, cancellationToken).Forget();
+        }
+
+        public static IDisposable SubscribeAwait<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask> onNext)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(onNext, nameof(onNext));
+
+            var cts = new CancellationTokenDisposable();
+            Subscribes.SubscribeAwaitCore(source, onNext, Subscribes.NopError, Subscribes.NopCompleted, cts.Token).Forget();
+            return cts;
+        }
+
+        public static void SubscribeAwait<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask> onNext, CancellationToken cancellationToken)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(onNext, nameof(onNext));
+
+            Subscribes.SubscribeAwaitCore(source, onNext, Subscribes.NopError, Subscribes.NopCompleted, cancellationToken).Forget();
+        }
+
+        public static IDisposable SubscribeAwait<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask> onNext)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(onNext, nameof(onNext));
+
+            var cts = new CancellationTokenDisposable();
+            Subscribes.SubscribeAwaitCore(source, onNext, Subscribes.NopError, Subscribes.NopCompleted, cts.Token).Forget();
+            return cts;
+        }
+
+        public static void SubscribeAwait<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask> onNext, CancellationToken cancellationToken)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(onNext, nameof(onNext));
+
+            Subscribes.SubscribeAwaitCore(source, onNext, Subscribes.NopError, Subscribes.NopCompleted, cancellationToken).Forget();
+        }
+
+        // OnNext, OnError
+
+        public static IDisposable Subscribe<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Action<TSource> onNext, Action<Exception> onError)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(onNext, nameof(onNext));
+            Error.ThrowArgumentNullException(onError, nameof(onError));
+
+            var cts = new CancellationTokenDisposable();
+            Subscribes.SubscribeCore(source, onNext, onError, Subscribes.NopCompleted, cts.Token).Forget();
+            return cts;
+        }
+
+        public static IDisposable Subscribe<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTaskVoid> onNext, Action<Exception> onError)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(onNext, nameof(onNext));
+            Error.ThrowArgumentNullException(onError, nameof(onError));
+
+            var cts = new CancellationTokenDisposable();
+            Subscribes.SubscribeCore(source, onNext, onError, Subscribes.NopCompleted, cts.Token).Forget();
+            return cts;
+        }
+
+        public static void Subscribe<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Action<TSource> onNext, Action<Exception> onError, CancellationToken cancellationToken)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(onNext, nameof(onNext));
+            Error.ThrowArgumentNullException(onError, nameof(onError));
+
+            Subscribes.SubscribeCore(source, onNext, onError, Subscribes.NopCompleted, cancellationToken).Forget();
+        }
+
+        public static void Subscribe<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTaskVoid> onNext, Action<Exception> onError, CancellationToken cancellationToken)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(onNext, nameof(onNext));
+            Error.ThrowArgumentNullException(onError, nameof(onError));
+
+            Subscribes.SubscribeCore(source, onNext, onError, Subscribes.NopCompleted, cancellationToken).Forget();
+        }
+
+        public static IDisposable SubscribeAwait<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask> onNext, Action<Exception> onError)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(onNext, nameof(onNext));
+            Error.ThrowArgumentNullException(onError, nameof(onError));
+
+            var cts = new CancellationTokenDisposable();
+            Subscribes.SubscribeAwaitCore(source, onNext, onError, Subscribes.NopCompleted, cts.Token).Forget();
+            return cts;
+        }
+
+        public static void SubscribeAwait<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask> onNext, Action<Exception> onError, CancellationToken cancellationToken)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(onNext, nameof(onNext));
+            Error.ThrowArgumentNullException(onError, nameof(onError));
+
+            Subscribes.SubscribeAwaitCore(source, onNext, onError, Subscribes.NopCompleted, cancellationToken).Forget();
+        }
+
+        public static IDisposable SubscribeAwait<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask> onNext, Action<Exception> onError)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(onNext, nameof(onNext));
+            Error.ThrowArgumentNullException(onError, nameof(onError));
+
+            var cts = new CancellationTokenDisposable();
+            Subscribes.SubscribeAwaitCore(source, onNext, onError, Subscribes.NopCompleted, cts.Token).Forget();
+            return cts;
+        }
+
+        public static void SubscribeAwait<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask> onNext, Action<Exception> onError, CancellationToken cancellationToken)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(onNext, nameof(onNext));
+            Error.ThrowArgumentNullException(onError, nameof(onError));
+
+            Subscribes.SubscribeAwaitCore(source, onNext, onError, Subscribes.NopCompleted, cancellationToken).Forget();
+        }
+
+        // OnNext, OnCompleted
+
+        public static IDisposable Subscribe<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Action<TSource> onNext, Action onCompleted)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(onNext, nameof(onNext));
+            Error.ThrowArgumentNullException(onCompleted, nameof(onCompleted));
+
+            var cts = new CancellationTokenDisposable();
+            Subscribes.SubscribeCore(source, onNext, Subscribes.NopError, onCompleted, cts.Token).Forget();
+            return cts;
+        }
+
+        public static IDisposable Subscribe<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTaskVoid> onNext, Action onCompleted)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(onNext, nameof(onNext));
+            Error.ThrowArgumentNullException(onCompleted, nameof(onCompleted));
+
+            var cts = new CancellationTokenDisposable();
+            Subscribes.SubscribeCore(source, onNext, Subscribes.NopError, onCompleted, cts.Token).Forget();
+            return cts;
+        }
+
+        public static void Subscribe<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Action<TSource> onNext, Action onCompleted, CancellationToken cancellationToken)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(onNext, nameof(onNext));
+            Error.ThrowArgumentNullException(onCompleted, nameof(onCompleted));
+
+            Subscribes.SubscribeCore(source, onNext, Subscribes.NopError, onCompleted, cancellationToken).Forget();
+        }
+
+        public static void Subscribe<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTaskVoid> onNext, Action onCompleted, CancellationToken cancellationToken)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(onNext, nameof(onNext));
+            Error.ThrowArgumentNullException(onCompleted, nameof(onCompleted));
+
+            Subscribes.SubscribeCore(source, onNext, Subscribes.NopError, onCompleted, cancellationToken).Forget();
+        }
+
+        public static IDisposable SubscribeAwait<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask> onNext, Action onCompleted)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(onNext, nameof(onNext));
+            Error.ThrowArgumentNullException(onCompleted, nameof(onCompleted));
+
+            var cts = new CancellationTokenDisposable();
+            Subscribes.SubscribeAwaitCore(source, onNext, Subscribes.NopError, onCompleted, cts.Token).Forget();
+            return cts;
+        }
+
+        public static void SubscribeAwait<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask> onNext, Action onCompleted, CancellationToken cancellationToken)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(onNext, nameof(onNext));
+            Error.ThrowArgumentNullException(onCompleted, nameof(onCompleted));
+
+            Subscribes.SubscribeAwaitCore(source, onNext, Subscribes.NopError, onCompleted, cancellationToken).Forget();
+        }
+
+        public static IDisposable SubscribeAwait<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask> onNext, Action onCompleted)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(onNext, nameof(onNext));
+            Error.ThrowArgumentNullException(onCompleted, nameof(onCompleted));
+
+            var cts = new CancellationTokenDisposable();
+            Subscribes.SubscribeAwaitCore(source, onNext, Subscribes.NopError, onCompleted, cts.Token).Forget();
+            return cts;
+        }
+
+        public static void SubscribeAwait<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask> onNext, Action onCompleted, CancellationToken cancellationToken)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(onNext, nameof(onNext));
+            Error.ThrowArgumentNullException(onCompleted, nameof(onCompleted));
+
+            Subscribes.SubscribeAwaitCore(source, onNext, Subscribes.NopError, onCompleted, cancellationToken).Forget();
+        }
+
+        // IObserver
+
+        public static IDisposable Subscribe<TSource>(this IUniTaskAsyncEnumerable<TSource> source, IObserver<TSource> observer)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(observer, nameof(observer));
+
+            var cts = new CancellationTokenDisposable();
+            Subscribes.SubscribeCore(source, observer, cts.Token).Forget();
+            return cts;
+        }
+
+        public static void Subscribe<TSource>(this IUniTaskAsyncEnumerable<TSource> source, IObserver<TSource> observer, CancellationToken cancellationToken)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(observer, nameof(observer));
+
+            Subscribes.SubscribeCore(source, observer, cancellationToken).Forget();
+        }
+    }
+
+    internal sealed class CancellationTokenDisposable : IDisposable
+    {
+        readonly CancellationTokenSource cts = new CancellationTokenSource();
+
+        public CancellationToken Token => cts.Token;
+
+        public void Dispose()
+        {
+            if (!cts.IsCancellationRequested)
+            {
+                cts.Cancel();
+            }
+        }
+    }
+
+    internal static class Subscribe
+    {
+        public static readonly Action<Exception> NopError = _ => { };
+        public static readonly Action NopCompleted = () => { };
+
+        public static async UniTaskVoid SubscribeCore<TSource>(IUniTaskAsyncEnumerable<TSource> source, Action<TSource> onNext, Action<Exception> onError, Action onCompleted, CancellationToken cancellationToken)
+        {
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    try
+                    {
+                        onNext(e.Current);
+                    }
+                    catch (Exception ex)
+                    {
+                        UniTaskScheduler.PublishUnobservedTaskException(ex);
+                    }
+                }
+                onCompleted();
+            }
+            catch (Exception ex)
+            {
+                if (onError == NopError)
+                {
+                    UniTaskScheduler.PublishUnobservedTaskException(ex);
+                    return;
+                }
+
+                if (ex is OperationCanceledException) return;
+
+                onError(ex);
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+        }
+
+        public static async UniTaskVoid SubscribeCore<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTaskVoid> onNext, Action<Exception> onError, Action onCompleted, CancellationToken cancellationToken)
+        {
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    try
+                    {
+                        onNext(e.Current).Forget();
+                    }
+                    catch (Exception ex)
+                    {
+                        UniTaskScheduler.PublishUnobservedTaskException(ex);
+                    }
+                }
+                onCompleted();
+            }
+            catch (Exception ex)
+            {
+                if (onError == NopError)
+                {
+                    UniTaskScheduler.PublishUnobservedTaskException(ex);
+                    return;
+                }
+
+                if (ex is OperationCanceledException) return;
+
+                onError(ex);
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+        }
+
+        public static async UniTaskVoid SubscribeCore<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTaskVoid> onNext, Action<Exception> onError, Action onCompleted, CancellationToken cancellationToken)
+        {
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    try
+                    {
+                        onNext(e.Current, cancellationToken).Forget();
+                    }
+                    catch (Exception ex)
+                    {
+                        UniTaskScheduler.PublishUnobservedTaskException(ex);
+                    }
+                }
+                onCompleted();
+            }
+            catch (Exception ex)
+            {
+                if (onError == NopError)
+                {
+                    UniTaskScheduler.PublishUnobservedTaskException(ex);
+                    return;
+                }
+
+                if (ex is OperationCanceledException) return;
+
+                onError(ex);
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+        }
+
+        public static async UniTaskVoid SubscribeCore<TSource>(IUniTaskAsyncEnumerable<TSource> source, IObserver<TSource> observer, CancellationToken cancellationToken)
+        {
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    try
+                    {
+                        observer.OnNext(e.Current);
+                    }
+                    catch (Exception ex)
+                    {
+                        UniTaskScheduler.PublishUnobservedTaskException(ex);
+                    }
+                }
+                observer.OnCompleted();
+            }
+            catch (Exception ex)
+            {
+                if (ex is OperationCanceledException) return;
+
+                observer.OnError(ex);
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+        }
+
+        public static async UniTaskVoid SubscribeAwaitCore<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask> onNext, Action<Exception> onError, Action onCompleted, CancellationToken cancellationToken)
+        {
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    try
+                    {
+                        await onNext(e.Current);
+                    }
+                    catch (Exception ex)
+                    {
+                        UniTaskScheduler.PublishUnobservedTaskException(ex);
+                    }
+                }
+                onCompleted();
+            }
+            catch (Exception ex)
+            {
+                if (onError == NopError)
+                {
+                    UniTaskScheduler.PublishUnobservedTaskException(ex);
+                    return;
+                }
+
+                if (ex is OperationCanceledException) return;
+
+                onError(ex);
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+        }
+
+        public static async UniTaskVoid SubscribeAwaitCore<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask> onNext, Action<Exception> onError, Action onCompleted, CancellationToken cancellationToken)
+        {
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    try
+                    {
+                        await onNext(e.Current, cancellationToken);
+                    }
+                    catch (Exception ex)
+                    {
+                        UniTaskScheduler.PublishUnobservedTaskException(ex);
+                    }
+                }
+                onCompleted();
+            }
+            catch (Exception ex)
+            {
+                if (onError == NopError)
+                {
+                    UniTaskScheduler.PublishUnobservedTaskException(ex);
+                    return;
+                }
+
+                if (ex is OperationCanceledException) return;
+
+                onError(ex);
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+        }
+
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Subscribe.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Subscribe.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 263479eb04c189741931fc0e2f615c2d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Sum.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Sum.cs
@@ -1,0 +1,1244 @@
+﻿using System;
+using System.Threading;
+using Cysharp.Threading.Tasks.Internal;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static UniTask<Int32> SumAsync(this IUniTaskAsyncEnumerable<Int32> source, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return Sum.SumAsync(source, cancellationToken);
+        }
+
+        public static UniTask<Int32> SumAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Int32> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Sum.SumAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Int32> SumAwaitAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Int32>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Sum.SumAwaitAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Int32> SumAwaitWithCancellationAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Int32>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Sum.SumAwaitWithCancellationAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Int64> SumAsync(this IUniTaskAsyncEnumerable<Int64> source, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return Sum.SumAsync(source, cancellationToken);
+        }
+
+        public static UniTask<Int64> SumAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Int64> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Sum.SumAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Int64> SumAwaitAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Int64>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Sum.SumAwaitAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Int64> SumAwaitWithCancellationAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Int64>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Sum.SumAwaitWithCancellationAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Single> SumAsync(this IUniTaskAsyncEnumerable<Single> source, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return Sum.SumAsync(source, cancellationToken);
+        }
+
+        public static UniTask<Single> SumAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Single> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Sum.SumAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Single> SumAwaitAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Single>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Sum.SumAwaitAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Single> SumAwaitWithCancellationAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Single>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Sum.SumAwaitWithCancellationAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Double> SumAsync(this IUniTaskAsyncEnumerable<Double> source, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return Sum.SumAsync(source, cancellationToken);
+        }
+
+        public static UniTask<Double> SumAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Double> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Sum.SumAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Double> SumAwaitAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Double>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Sum.SumAwaitAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Double> SumAwaitWithCancellationAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Double>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Sum.SumAwaitWithCancellationAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Decimal> SumAsync(this IUniTaskAsyncEnumerable<Decimal> source, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return Sum.SumAsync(source, cancellationToken);
+        }
+
+        public static UniTask<Decimal> SumAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Decimal> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Sum.SumAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Decimal> SumAwaitAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Decimal>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Sum.SumAwaitAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Decimal> SumAwaitWithCancellationAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Decimal>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Sum.SumAwaitWithCancellationAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Int32?> SumAsync(this IUniTaskAsyncEnumerable<Int32?> source, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return Sum.SumAsync(source, cancellationToken);
+        }
+
+        public static UniTask<Int32?> SumAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Int32?> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Sum.SumAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Int32?> SumAwaitAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Int32?>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Sum.SumAwaitAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Int32?> SumAwaitWithCancellationAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Int32?>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Sum.SumAwaitWithCancellationAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Int64?> SumAsync(this IUniTaskAsyncEnumerable<Int64?> source, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return Sum.SumAsync(source, cancellationToken);
+        }
+
+        public static UniTask<Int64?> SumAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Int64?> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Sum.SumAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Int64?> SumAwaitAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Int64?>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Sum.SumAwaitAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Int64?> SumAwaitWithCancellationAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Int64?>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Sum.SumAwaitWithCancellationAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Single?> SumAsync(this IUniTaskAsyncEnumerable<Single?> source, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return Sum.SumAsync(source, cancellationToken);
+        }
+
+        public static UniTask<Single?> SumAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Single?> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Sum.SumAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Single?> SumAwaitAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Single?>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Sum.SumAwaitAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Single?> SumAwaitWithCancellationAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Single?>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Sum.SumAwaitWithCancellationAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Double?> SumAsync(this IUniTaskAsyncEnumerable<Double?> source, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return Sum.SumAsync(source, cancellationToken);
+        }
+
+        public static UniTask<Double?> SumAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Double?> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Sum.SumAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Double?> SumAwaitAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Double?>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Sum.SumAwaitAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Double?> SumAwaitWithCancellationAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Double?>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Sum.SumAwaitWithCancellationAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Decimal?> SumAsync(this IUniTaskAsyncEnumerable<Decimal?> source, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return Sum.SumAsync(source, cancellationToken);
+        }
+
+        public static UniTask<Decimal?> SumAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Decimal?> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Sum.SumAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Decimal?> SumAwaitAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Decimal?>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Sum.SumAwaitAsync(source, selector, cancellationToken);
+        }
+
+        public static UniTask<Decimal?> SumAwaitWithCancellationAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Decimal?>> selector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(selector));
+
+            return Sum.SumAwaitWithCancellationAsync(source, selector, cancellationToken);
+        }
+
+    }
+
+    internal static class Sum
+    {
+        public static async UniTask<Int32> SumAsync(IUniTaskAsyncEnumerable<Int32> source, CancellationToken cancellationToken)
+        {
+            Int32 sum = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    sum += e.Current;
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return sum;
+        }
+
+        public static async UniTask<Int32> SumAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Int32> selector, CancellationToken cancellationToken)
+        {
+            Int32 sum = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    sum += selector(e.Current);
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return sum;
+        }
+
+        public static async UniTask<Int32> SumAwaitAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Int32>> selector, CancellationToken cancellationToken)
+        {
+            Int32 sum = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    sum += (await selector(e.Current));
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return sum;
+        }
+
+        public static async UniTask<Int32> SumAwaitWithCancellationAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Int32>> selector, CancellationToken cancellationToken)
+        {
+            Int32 sum = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    sum += (await selector(e.Current, cancellationToken));
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return sum;
+        }
+
+        public static async UniTask<Int64> SumAsync(IUniTaskAsyncEnumerable<Int64> source, CancellationToken cancellationToken)
+        {
+            Int64 sum = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    sum += e.Current;
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return sum;
+        }
+
+        public static async UniTask<Int64> SumAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Int64> selector, CancellationToken cancellationToken)
+        {
+            Int64 sum = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    sum += selector(e.Current);
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return sum;
+        }
+
+        public static async UniTask<Int64> SumAwaitAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Int64>> selector, CancellationToken cancellationToken)
+        {
+            Int64 sum = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    sum += (await selector(e.Current));
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return sum;
+        }
+
+        public static async UniTask<Int64> SumAwaitWithCancellationAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Int64>> selector, CancellationToken cancellationToken)
+        {
+            Int64 sum = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    sum += (await selector(e.Current, cancellationToken));
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return sum;
+        }
+
+        public static async UniTask<Single> SumAsync(IUniTaskAsyncEnumerable<Single> source, CancellationToken cancellationToken)
+        {
+            Single sum = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    sum += e.Current;
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return sum;
+        }
+
+        public static async UniTask<Single> SumAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Single> selector, CancellationToken cancellationToken)
+        {
+            Single sum = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    sum += selector(e.Current);
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return sum;
+        }
+
+        public static async UniTask<Single> SumAwaitAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Single>> selector, CancellationToken cancellationToken)
+        {
+            Single sum = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    sum += (await selector(e.Current));
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return sum;
+        }
+
+        public static async UniTask<Single> SumAwaitWithCancellationAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Single>> selector, CancellationToken cancellationToken)
+        {
+            Single sum = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    sum += (await selector(e.Current, cancellationToken));
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return sum;
+        }
+
+        public static async UniTask<Double> SumAsync(IUniTaskAsyncEnumerable<Double> source, CancellationToken cancellationToken)
+        {
+            Double sum = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    sum += e.Current;
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return sum;
+        }
+
+        public static async UniTask<Double> SumAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Double> selector, CancellationToken cancellationToken)
+        {
+            Double sum = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    sum += selector(e.Current);
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return sum;
+        }
+
+        public static async UniTask<Double> SumAwaitAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Double>> selector, CancellationToken cancellationToken)
+        {
+            Double sum = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    sum += (await selector(e.Current));
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return sum;
+        }
+
+        public static async UniTask<Double> SumAwaitWithCancellationAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Double>> selector, CancellationToken cancellationToken)
+        {
+            Double sum = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    sum += (await selector(e.Current, cancellationToken));
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return sum;
+        }
+
+        public static async UniTask<Decimal> SumAsync(IUniTaskAsyncEnumerable<Decimal> source, CancellationToken cancellationToken)
+        {
+            Decimal sum = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    sum += e.Current;
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return sum;
+        }
+
+        public static async UniTask<Decimal> SumAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Decimal> selector, CancellationToken cancellationToken)
+        {
+            Decimal sum = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    sum += selector(e.Current);
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return sum;
+        }
+
+        public static async UniTask<Decimal> SumAwaitAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Decimal>> selector, CancellationToken cancellationToken)
+        {
+            Decimal sum = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    sum += (await selector(e.Current));
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return sum;
+        }
+
+        public static async UniTask<Decimal> SumAwaitWithCancellationAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Decimal>> selector, CancellationToken cancellationToken)
+        {
+            Decimal sum = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    sum += (await selector(e.Current, cancellationToken));
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return sum;
+        }
+
+        public static async UniTask<Int32?> SumAsync(IUniTaskAsyncEnumerable<Int32?> source, CancellationToken cancellationToken)
+        {
+            Int32? sum = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    sum += e.Current.GetValueOrDefault();
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return sum;
+        }
+
+        public static async UniTask<Int32?> SumAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Int32?> selector, CancellationToken cancellationToken)
+        {
+            Int32? sum = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    sum += selector(e.Current).GetValueOrDefault();
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return sum;
+        }
+
+        public static async UniTask<Int32?> SumAwaitAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Int32?>> selector, CancellationToken cancellationToken)
+        {
+            Int32? sum = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    sum += (await selector(e.Current)).GetValueOrDefault();
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return sum;
+        }
+
+        public static async UniTask<Int32?> SumAwaitWithCancellationAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Int32?>> selector, CancellationToken cancellationToken)
+        {
+            Int32? sum = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    sum += (await selector(e.Current, cancellationToken)).GetValueOrDefault();
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return sum;
+        }
+
+        public static async UniTask<Int64?> SumAsync(IUniTaskAsyncEnumerable<Int64?> source, CancellationToken cancellationToken)
+        {
+            Int64? sum = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    sum += e.Current.GetValueOrDefault();
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return sum;
+        }
+
+        public static async UniTask<Int64?> SumAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Int64?> selector, CancellationToken cancellationToken)
+        {
+            Int64? sum = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    sum += selector(e.Current).GetValueOrDefault();
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return sum;
+        }
+
+        public static async UniTask<Int64?> SumAwaitAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Int64?>> selector, CancellationToken cancellationToken)
+        {
+            Int64? sum = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    sum += (await selector(e.Current)).GetValueOrDefault();
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return sum;
+        }
+
+        public static async UniTask<Int64?> SumAwaitWithCancellationAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Int64?>> selector, CancellationToken cancellationToken)
+        {
+            Int64? sum = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    sum += (await selector(e.Current, cancellationToken)).GetValueOrDefault();
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return sum;
+        }
+
+        public static async UniTask<Single?> SumAsync(IUniTaskAsyncEnumerable<Single?> source, CancellationToken cancellationToken)
+        {
+            Single? sum = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    sum += e.Current.GetValueOrDefault();
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return sum;
+        }
+
+        public static async UniTask<Single?> SumAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Single?> selector, CancellationToken cancellationToken)
+        {
+            Single? sum = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    sum += selector(e.Current).GetValueOrDefault();
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return sum;
+        }
+
+        public static async UniTask<Single?> SumAwaitAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Single?>> selector, CancellationToken cancellationToken)
+        {
+            Single? sum = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    sum += (await selector(e.Current)).GetValueOrDefault();
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return sum;
+        }
+
+        public static async UniTask<Single?> SumAwaitWithCancellationAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Single?>> selector, CancellationToken cancellationToken)
+        {
+            Single? sum = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    sum += (await selector(e.Current, cancellationToken)).GetValueOrDefault();
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return sum;
+        }
+
+        public static async UniTask<Double?> SumAsync(IUniTaskAsyncEnumerable<Double?> source, CancellationToken cancellationToken)
+        {
+            Double? sum = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    sum += e.Current.GetValueOrDefault();
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return sum;
+        }
+
+        public static async UniTask<Double?> SumAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Double?> selector, CancellationToken cancellationToken)
+        {
+            Double? sum = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    sum += selector(e.Current).GetValueOrDefault();
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return sum;
+        }
+
+        public static async UniTask<Double?> SumAwaitAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Double?>> selector, CancellationToken cancellationToken)
+        {
+            Double? sum = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    sum += (await selector(e.Current)).GetValueOrDefault();
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return sum;
+        }
+
+        public static async UniTask<Double?> SumAwaitWithCancellationAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Double?>> selector, CancellationToken cancellationToken)
+        {
+            Double? sum = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    sum += (await selector(e.Current, cancellationToken)).GetValueOrDefault();
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return sum;
+        }
+
+        public static async UniTask<Decimal?> SumAsync(IUniTaskAsyncEnumerable<Decimal?> source, CancellationToken cancellationToken)
+        {
+            Decimal? sum = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    sum += e.Current.GetValueOrDefault();
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return sum;
+        }
+
+        public static async UniTask<Decimal?> SumAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Decimal?> selector, CancellationToken cancellationToken)
+        {
+            Decimal? sum = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    sum += selector(e.Current).GetValueOrDefault();
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return sum;
+        }
+
+        public static async UniTask<Decimal?> SumAwaitAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Decimal?>> selector, CancellationToken cancellationToken)
+        {
+            Decimal? sum = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    sum += (await selector(e.Current)).GetValueOrDefault();
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return sum;
+        }
+
+        public static async UniTask<Decimal?> SumAwaitWithCancellationAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Decimal?>> selector, CancellationToken cancellationToken)
+        {
+            Decimal? sum = default;
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    sum += (await selector(e.Current, cancellationToken)).GetValueOrDefault();
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return sum;
+        }
+
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Sum.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Sum.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4149754066a21a341be58c04357061f6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Take.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Take.cs
@@ -1,0 +1,124 @@
+﻿using Cysharp.Threading.Tasks.Internal;
+using System;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static IUniTaskAsyncEnumerable<TSource> Take<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Int32 count)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return new Take<TSource>(source, count);
+        }
+    }
+
+    internal sealed class Take<TSource> : IUniTaskAsyncEnumerable<TSource>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+        readonly int count;
+
+        public Take(IUniTaskAsyncEnumerable<TSource> source, int count)
+        {
+            this.source = source;
+            this.count = count;
+        }
+
+        public IUniTaskAsyncEnumerator<TSource> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _Take(source, count, cancellationToken);
+        }
+
+        sealed class _Take : MoveNextSource, IUniTaskAsyncEnumerator<TSource>
+        {
+            static readonly Action<object> MoveNextCoreDelegate = MoveNextCore;
+
+            readonly IUniTaskAsyncEnumerable<TSource> source;
+            readonly int count;
+            CancellationToken cancellationToken;
+
+            IUniTaskAsyncEnumerator<TSource> enumerator;
+            UniTask<bool>.Awaiter awaiter;
+            int index;
+
+            public _Take(IUniTaskAsyncEnumerable<TSource> source, int count, CancellationToken cancellationToken)
+            {
+                this.source = source;
+                this.count = count;
+                this.cancellationToken = cancellationToken;
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public TSource Current { get; private set; }
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (enumerator == null)
+                {
+                    enumerator = source.GetAsyncEnumerator(cancellationToken);
+                }
+
+                if (checked(index) >= count)
+                {
+                    return CompletedTasks.False;
+                }
+
+                completionSource.Reset();
+                SourceMoveNext();
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            void SourceMoveNext()
+            {
+                try
+                {
+                    awaiter = enumerator.MoveNextAsync().GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        MoveNextCore(this);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(MoveNextCoreDelegate, this);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    completionSource.TrySetException(ex);
+                }
+            }
+
+            static void MoveNextCore(object state)
+            {
+                var self = (_Take)state;
+
+                if (self.TryGetResult(self.awaiter, out var result))
+                {
+                    if (result)
+                    {
+                        self.index++;
+                        self.Current = self.enumerator.Current;
+                        self.completionSource.TrySetResult(true);
+                    }
+                    else
+                    {
+                        self.completionSource.TrySetResult(false);
+                    }
+                }
+            }
+
+            public UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                if (enumerator != null)
+                {
+                    return enumerator.DisposeAsync();
+                }
+                return default;
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Take.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Take.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 42f02cb84e5875b488304755d0e1383d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/TakeLast.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/TakeLast.cs
@@ -1,0 +1,175 @@
+﻿using Cysharp.Threading.Tasks.Internal;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static IUniTaskAsyncEnumerable<TSource> TakeLast<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Int32 count)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            // non take.
+            if (count <= 0)
+            {
+                return Empty<TSource>();
+            }
+
+            return new TakeLast<TSource>(source, count);
+        }
+    }
+
+    internal sealed class TakeLast<TSource> : IUniTaskAsyncEnumerable<TSource>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+        readonly int count;
+
+        public TakeLast(IUniTaskAsyncEnumerable<TSource> source, int count)
+        {
+            this.source = source;
+            this.count = count;
+        }
+
+        public IUniTaskAsyncEnumerator<TSource> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _TakeLast(source, count, cancellationToken);
+        }
+
+        sealed class _TakeLast : MoveNextSource, IUniTaskAsyncEnumerator<TSource>
+        {
+            static readonly Action<object> MoveNextCoreDelegate = MoveNextCore;
+
+            readonly IUniTaskAsyncEnumerable<TSource> source;
+            readonly int count;
+            CancellationToken cancellationToken;
+
+            IUniTaskAsyncEnumerator<TSource> enumerator;
+            UniTask<bool>.Awaiter awaiter;
+            Queue<TSource> queue;
+
+            bool iterateCompleted;
+            bool continueNext;
+
+            public _TakeLast(IUniTaskAsyncEnumerable<TSource> source, int count, CancellationToken cancellationToken)
+            {
+                this.source = source;
+                this.count = count;
+                this.cancellationToken = cancellationToken;
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public TSource Current { get; private set; }
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (enumerator == null)
+                {
+                    enumerator = source.GetAsyncEnumerator(cancellationToken);
+                    queue = new Queue<TSource>();
+                }
+
+                completionSource.Reset();
+                SourceMoveNext();
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            void SourceMoveNext()
+            {
+                if (iterateCompleted)
+                {
+                    if (queue.Count > 0)
+                    {
+                        Current = queue.Dequeue();
+                        completionSource.TrySetResult(true);
+                    }
+                    else
+                    {
+                        completionSource.TrySetResult(false);
+                    }
+
+                    return;
+                }
+
+                try
+                {
+                    LOOP:
+                    awaiter = enumerator.MoveNextAsync().GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        continueNext = true;
+                        MoveNextCore(this);
+                        if (continueNext)
+                        {
+                            continueNext = false;
+                            goto LOOP; // avoid recursive
+                        }
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(MoveNextCoreDelegate, this);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    completionSource.TrySetException(ex);
+                }
+            }
+
+
+            static void MoveNextCore(object state)
+            {
+                var self = (_TakeLast)state;
+
+                if (self.TryGetResult(self.awaiter, out var result))
+                {
+                    if (result)
+                    {
+                        if (self.queue.Count < self.count)
+                        {
+                            self.queue.Enqueue(self.enumerator.Current);
+
+                            if (!self.continueNext)
+                            {
+                                self.SourceMoveNext();
+                            }
+                        }
+                        else
+                        {
+                            self.queue.Dequeue();
+                            self.queue.Enqueue(self.enumerator.Current);
+
+                            if (!self.continueNext)
+                            {
+                                self.SourceMoveNext();
+                            }
+                        }
+                    }
+                    else
+                    {
+                        self.continueNext = false;
+                        self.iterateCompleted = true;
+                        self.SourceMoveNext();
+                    }
+                }
+                else
+                {
+                    self.continueNext = false;
+                }
+            }
+
+            public UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                if (enumerator != null)
+                {
+                    return enumerator.DisposeAsync();
+                }
+                return default;
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/TakeLast.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/TakeLast.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 510aa9fd35b45fc40bcdb7e59f01fd1b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/TakeUntil.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/TakeUntil.cs
@@ -1,0 +1,190 @@
+﻿using Cysharp.Threading.Tasks.Internal;
+using System;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static IUniTaskAsyncEnumerable<TSource> TakeUntil<TSource>(this IUniTaskAsyncEnumerable<TSource> source, UniTask other)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return new TakeUntil<TSource>(source, other, null);
+        }
+
+        public static IUniTaskAsyncEnumerable<TSource> TakeUntil<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<CancellationToken, UniTask> other)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(source, nameof(other));
+
+            return new TakeUntil<TSource>(source, default, other);
+        }
+    }
+
+    internal sealed class TakeUntil<TSource> : IUniTaskAsyncEnumerable<TSource>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+        readonly UniTask other;
+        readonly Func<CancellationToken, UniTask> other2;
+
+        public TakeUntil(IUniTaskAsyncEnumerable<TSource> source, UniTask other, Func<CancellationToken, UniTask> other2)
+        {
+            this.source = source;
+            this.other = other;
+            this.other2 = other2;
+        }
+
+        public IUniTaskAsyncEnumerator<TSource> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            if (other2 != null)
+            {
+                return new _TakeUntil(source, this.other2(cancellationToken), cancellationToken);
+            }
+            else
+            {
+                return new _TakeUntil(source, this.other, cancellationToken);
+            }
+        }
+
+        sealed class _TakeUntil : MoveNextSource, IUniTaskAsyncEnumerator<TSource>
+        {
+            static readonly Action<object> CancelDelegate1 = OnCanceled1;
+            static readonly Action<object> MoveNextCoreDelegate = MoveNextCore;
+
+            readonly IUniTaskAsyncEnumerable<TSource> source;
+            CancellationToken cancellationToken1;
+            CancellationTokenRegistration cancellationTokenRegistration1;
+
+            bool completed;
+            Exception exception;
+            IUniTaskAsyncEnumerator<TSource> enumerator;
+            UniTask<bool>.Awaiter awaiter;
+
+            public _TakeUntil(IUniTaskAsyncEnumerable<TSource> source, UniTask other, CancellationToken cancellationToken1)
+            {
+                this.source = source;
+                this.cancellationToken1 = cancellationToken1;
+
+                if (cancellationToken1.CanBeCanceled)
+                {
+                    this.cancellationTokenRegistration1 = cancellationToken1.RegisterWithoutCaptureExecutionContext(CancelDelegate1, this);
+                }
+
+                TaskTracker.TrackActiveTask(this, 3);
+
+                RunOther(other).Forget();
+            }
+
+            public TSource Current { get; private set; }
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                if (completed)
+                {
+                    return CompletedTasks.False;
+                }
+
+                if (exception != null)
+                {
+                    return UniTask.FromException<bool>(exception);
+                }
+
+                if (cancellationToken1.IsCancellationRequested)
+                {
+                    return UniTask.FromCanceled<bool>(cancellationToken1);
+                }
+
+                if (enumerator == null)
+                {
+                    enumerator = source.GetAsyncEnumerator(cancellationToken1);
+                }
+
+                completionSource.Reset();
+                SourceMoveNext();
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            void SourceMoveNext()
+            {
+                try
+                {
+                    awaiter = enumerator.MoveNextAsync().GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        MoveNextCore(this);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(MoveNextCoreDelegate, this);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    completionSource.TrySetException(ex);
+                }
+            }
+
+            static void MoveNextCore(object state)
+            {
+                var self = (_TakeUntil)state;
+
+                if (self.TryGetResult(self.awaiter, out var result))
+                {
+                    if (result)
+                    {
+                        if (self.exception != null)
+                        {
+                            self.completionSource.TrySetException(self.exception);
+                        }
+                        else if (self.cancellationToken1.IsCancellationRequested)
+                        {
+                            self.completionSource.TrySetCanceled(self.cancellationToken1);
+                        }
+                        else
+                        {
+                            self.Current = self.enumerator.Current;
+                            self.completionSource.TrySetResult(true);
+                        }
+                    }
+                    else
+                    {
+                        self.completionSource.TrySetResult(false);
+                    }
+                }
+            }
+
+            async UniTaskVoid RunOther(UniTask other)
+            {
+                try
+                {
+                    await other;
+                    completed = true;
+                    completionSource.TrySetResult(false);
+                }
+                catch (Exception ex)
+                {
+                    exception = ex;
+                    completionSource.TrySetException(ex);
+                }
+            }
+
+            static void OnCanceled1(object state)
+            {
+                var self = (_TakeUntil)state;
+                self.completionSource.TrySetCanceled(self.cancellationToken1);
+            }
+
+            public UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                cancellationTokenRegistration1.Dispose();
+                if (enumerator != null)
+                {
+                    return enumerator.DisposeAsync();
+                }
+                return default;
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/TakeUntil.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/TakeUntil.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 12bda324162f15349afefc2c152ac07f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/TakeUntilCanceled.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/TakeUntilCanceled.cs
@@ -1,0 +1,164 @@
+﻿using Cysharp.Threading.Tasks.Internal;
+using System;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static IUniTaskAsyncEnumerable<TSource> TakeUntilCanceled<TSource>(this IUniTaskAsyncEnumerable<TSource> source, CancellationToken cancellationToken)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return new TakeUntilCanceled<TSource>(source, cancellationToken);
+        }
+    }
+
+    internal sealed class TakeUntilCanceled<TSource> : IUniTaskAsyncEnumerable<TSource>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+        readonly CancellationToken cancellationToken;
+
+        public TakeUntilCanceled(IUniTaskAsyncEnumerable<TSource> source, CancellationToken cancellationToken)
+        {
+            this.source = source;
+            this.cancellationToken = cancellationToken;
+        }
+
+        public IUniTaskAsyncEnumerator<TSource> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _TakeUntilCanceled(source, this.cancellationToken, cancellationToken);
+        }
+
+        sealed class _TakeUntilCanceled : MoveNextSource, IUniTaskAsyncEnumerator<TSource>
+        {
+            static readonly Action<object> CancelDelegate1 = OnCanceled1;
+            static readonly Action<object> CancelDelegate2 = OnCanceled2;
+            static readonly Action<object> MoveNextCoreDelegate = MoveNextCore;
+
+            readonly IUniTaskAsyncEnumerable<TSource> source;
+            CancellationToken cancellationToken1;
+            CancellationToken cancellationToken2;
+            CancellationTokenRegistration cancellationTokenRegistration1;
+            CancellationTokenRegistration cancellationTokenRegistration2;
+
+            bool isCanceled;
+            IUniTaskAsyncEnumerator<TSource> enumerator;
+            UniTask<bool>.Awaiter awaiter;
+
+            public _TakeUntilCanceled(IUniTaskAsyncEnumerable<TSource> source, CancellationToken cancellationToken1, CancellationToken cancellationToken2)
+            {
+                this.source = source;
+                this.cancellationToken1 = cancellationToken1;
+                this.cancellationToken2 = cancellationToken2;
+
+                if (cancellationToken1.CanBeCanceled)
+                {
+                    this.cancellationTokenRegistration1 = cancellationToken1.RegisterWithoutCaptureExecutionContext(CancelDelegate1, this);
+                }
+
+                if (cancellationToken1 != cancellationToken2 && cancellationToken2.CanBeCanceled)
+                {
+                    this.cancellationTokenRegistration2 = cancellationToken2.RegisterWithoutCaptureExecutionContext(CancelDelegate2, this);
+                }
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public TSource Current { get; private set; }
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                if (cancellationToken1.IsCancellationRequested) isCanceled = true;
+                if (cancellationToken2.IsCancellationRequested) isCanceled = true;
+
+                if (enumerator == null)
+                {
+                    enumerator = source.GetAsyncEnumerator(cancellationToken2); // use only AsyncEnumerator provided token.
+                }
+
+                if (isCanceled) return CompletedTasks.False;
+
+                completionSource.Reset();
+                SourceMoveNext();
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            void SourceMoveNext()
+            {
+                try
+                {
+                    awaiter = enumerator.MoveNextAsync().GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        MoveNextCore(this);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(MoveNextCoreDelegate, this);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    completionSource.TrySetException(ex);
+                }
+            }
+
+            static void MoveNextCore(object state)
+            {
+                var self = (_TakeUntilCanceled)state;
+
+                if (self.TryGetResult(self.awaiter, out var result))
+                {
+                    if (result)
+                    {
+                        if (self.isCanceled)
+                        {
+                            self.completionSource.TrySetResult(false);
+                        }
+                        else
+                        {
+                            self.Current = self.enumerator.Current;
+                            self.completionSource.TrySetResult(true);
+                        }
+                    }
+                    else
+                    {
+                        self.completionSource.TrySetResult(false);
+                    }
+                }
+            }
+
+            static void OnCanceled1(object state)
+            {
+                var self = (_TakeUntilCanceled)state;
+                if (!self.isCanceled)
+                {
+                    self.cancellationTokenRegistration2.Dispose();
+                    self.completionSource.TrySetResult(false);
+                }
+            }
+
+            static void OnCanceled2(object state)
+            {
+                var self = (_TakeUntilCanceled)state;
+                if (!self.isCanceled)
+                {
+                    self.cancellationTokenRegistration1.Dispose();
+                    self.completionSource.TrySetResult(false);
+                }
+            }
+
+            public UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                cancellationTokenRegistration1.Dispose();
+                cancellationTokenRegistration2.Dispose();
+                if (enumerator != null)
+                {
+                    return enumerator.DisposeAsync();
+                }
+                return default;
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/TakeUntilCanceled.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/TakeUntilCanceled.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e82f498cf3a1df04cbf646773fc11319
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/TakeWhile.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/TakeWhile.cs
@@ -1,0 +1,342 @@
+﻿using Cysharp.Threading.Tasks.Internal;
+using System;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static IUniTaskAsyncEnumerable<TSource> TakeWhile<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Boolean> predicate)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(predicate, nameof(predicate));
+
+            return new TakeWhile<TSource>(source, predicate);
+        }
+
+        public static IUniTaskAsyncEnumerable<TSource> TakeWhile<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Int32, Boolean> predicate)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(predicate, nameof(predicate));
+
+            return new TakeWhileInt<TSource>(source, predicate);
+        }
+
+        public static IUniTaskAsyncEnumerable<TSource> TakeWhileAwait<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Boolean>> predicate)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(predicate, nameof(predicate));
+
+            return new TakeWhileAwait<TSource>(source, predicate);
+        }
+
+        public static IUniTaskAsyncEnumerable<TSource> TakeWhileAwait<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Int32, UniTask<Boolean>> predicate)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(predicate, nameof(predicate));
+
+            return new TakeWhileIntAwait<TSource>(source, predicate);
+        }
+
+        public static IUniTaskAsyncEnumerable<TSource> TakeWhileAwaitWithCancellation<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Boolean>> predicate)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(predicate, nameof(predicate));
+
+            return new TakeWhileAwaitWithCancellation<TSource>(source, predicate);
+        }
+
+        public static IUniTaskAsyncEnumerable<TSource> TakeWhileAwaitWithCancellation<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Int32, CancellationToken, UniTask<Boolean>> predicate)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(predicate, nameof(predicate));
+
+            return new TakeWhileIntAwaitWithCancellation<TSource>(source, predicate);
+        }
+    }
+
+    internal sealed class TakeWhile<TSource> : IUniTaskAsyncEnumerable<TSource>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+        readonly Func<TSource, bool> predicate;
+
+        public TakeWhile(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, bool> predicate)
+        {
+            this.source = source;
+            this.predicate = predicate;
+        }
+
+        public IUniTaskAsyncEnumerator<TSource> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _TakeWhile(source, predicate, cancellationToken);
+        }
+
+        class _TakeWhile : AsyncEnumeratorBase<TSource, TSource>
+        {
+            Func<TSource, bool> predicate;
+
+            public _TakeWhile(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, bool> predicate, CancellationToken cancellationToken)
+
+                : base(source, cancellationToken)
+            {
+                this.predicate = predicate;
+            }
+
+            protected override bool TryMoveNextCore(bool sourceHasCurrent, out bool result)
+            {
+                if (sourceHasCurrent)
+                {
+                    if (predicate(SourceCurrent))
+                    {
+                        Current = SourceCurrent;
+                        result = true;
+                        return true;
+                    }
+                }
+
+                result = false;
+                return true;
+            }
+        }
+    }
+
+    internal sealed class TakeWhileInt<TSource> : IUniTaskAsyncEnumerable<TSource>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+        readonly Func<TSource, int, bool> predicate;
+
+        public TakeWhileInt(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, int, bool> predicate)
+        {
+            this.source = source;
+            this.predicate = predicate;
+        }
+
+        public IUniTaskAsyncEnumerator<TSource> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _TakeWhileInt(source, predicate, cancellationToken);
+        }
+
+        class _TakeWhileInt : AsyncEnumeratorBase<TSource, TSource>
+        {
+            readonly Func<TSource, int, bool> predicate;
+            int index;
+
+            public _TakeWhileInt(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, int, bool> predicate, CancellationToken cancellationToken)
+
+                : base(source, cancellationToken)
+            {
+                this.predicate = predicate;
+            }
+
+            protected override bool TryMoveNextCore(bool sourceHasCurrent, out bool result)
+            {
+                if (sourceHasCurrent)
+                {
+                    if (predicate(SourceCurrent, checked(index++)))
+                    {
+                        Current = SourceCurrent;
+                        result = true;
+                        return true;
+                    }
+                }
+
+                result = false;
+                return true;
+            }
+        }
+    }
+
+    internal sealed class TakeWhileAwait<TSource> : IUniTaskAsyncEnumerable<TSource>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+        readonly Func<TSource, UniTask<bool>> predicate;
+
+        public TakeWhileAwait(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<bool>> predicate)
+        {
+            this.source = source;
+            this.predicate = predicate;
+        }
+
+        public IUniTaskAsyncEnumerator<TSource> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _TakeWhileAwait(source, predicate, cancellationToken);
+        }
+
+        class _TakeWhileAwait : AsyncEnumeratorAwaitSelectorBase<TSource, TSource, bool>
+        {
+            Func<TSource, UniTask<bool>> predicate;
+
+            public _TakeWhileAwait(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<bool>> predicate, CancellationToken cancellationToken)
+                : base(source, cancellationToken)
+            {
+                this.predicate = predicate;
+            }
+
+            protected override UniTask<bool> TransformAsync(TSource sourceCurrent)
+            {
+                return predicate(sourceCurrent);
+            }
+
+            protected override bool TrySetCurrentCore(bool awaitResult, out bool terminateIteration)
+            {
+                if (awaitResult)
+                {
+                    Current = SourceCurrent;
+                    terminateIteration = false;
+                    return true;
+                }
+                else
+                {
+                    terminateIteration = true;
+                    return false;
+                }
+            }
+        }
+    }
+
+    internal sealed class TakeWhileIntAwait<TSource> : IUniTaskAsyncEnumerable<TSource>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+        readonly Func<TSource, int, UniTask<bool>> predicate;
+
+        public TakeWhileIntAwait(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, int, UniTask<bool>> predicate)
+        {
+            this.source = source;
+            this.predicate = predicate;
+        }
+
+        public IUniTaskAsyncEnumerator<TSource> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _TakeWhileIntAwait(source, predicate, cancellationToken);
+        }
+
+        class _TakeWhileIntAwait : AsyncEnumeratorAwaitSelectorBase<TSource, TSource, bool>
+        {
+            readonly Func<TSource, int, UniTask<bool>> predicate;
+            int index;
+
+            public _TakeWhileIntAwait(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, int, UniTask<bool>> predicate, CancellationToken cancellationToken)
+                : base(source, cancellationToken)
+            {
+                this.predicate = predicate;
+            }
+
+            protected override UniTask<bool> TransformAsync(TSource sourceCurrent)
+            {
+                return predicate(sourceCurrent, checked(index++));
+            }
+
+            protected override bool TrySetCurrentCore(bool awaitResult, out bool terminateIteration)
+            {
+                if (awaitResult)
+                {
+                    Current = SourceCurrent;
+                    terminateIteration = false;
+                    return true;
+                }
+                else
+                {
+                    terminateIteration = true;
+                    return false;
+                }
+            }
+        }
+    }
+
+    internal sealed class TakeWhileAwaitWithCancellation<TSource> : IUniTaskAsyncEnumerable<TSource>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+        readonly Func<TSource, CancellationToken, UniTask<bool>> predicate;
+
+        public TakeWhileAwaitWithCancellation(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<bool>> predicate)
+        {
+            this.source = source;
+            this.predicate = predicate;
+        }
+
+        public IUniTaskAsyncEnumerator<TSource> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _TakeWhileAwaitWithCancellation(source, predicate, cancellationToken);
+        }
+
+        class _TakeWhileAwaitWithCancellation : AsyncEnumeratorAwaitSelectorBase<TSource, TSource, bool>
+        {
+            Func<TSource, CancellationToken, UniTask<bool>> predicate;
+
+            public _TakeWhileAwaitWithCancellation(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<bool>> predicate, CancellationToken cancellationToken)
+                : base(source, cancellationToken)
+            {
+                this.predicate = predicate;
+            }
+
+            protected override UniTask<bool> TransformAsync(TSource sourceCurrent)
+            {
+                return predicate(sourceCurrent, cancellationToken);
+            }
+
+            protected override bool TrySetCurrentCore(bool awaitResult, out bool terminateIteration)
+            {
+                if (awaitResult)
+                {
+                    Current = SourceCurrent;
+                    terminateIteration = false;
+                    return true;
+                }
+                else
+                {
+                    terminateIteration = true;
+                    return false;
+                }
+            }
+        }
+    }
+
+    internal sealed class TakeWhileIntAwaitWithCancellation<TSource> : IUniTaskAsyncEnumerable<TSource>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+        readonly Func<TSource, int, CancellationToken, UniTask<bool>> predicate;
+
+        public TakeWhileIntAwaitWithCancellation(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, int, CancellationToken, UniTask<bool>> predicate)
+        {
+            this.source = source;
+            this.predicate = predicate;
+        }
+
+        public IUniTaskAsyncEnumerator<TSource> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _TakeWhileIntAwaitWithCancellation(source, predicate, cancellationToken);
+        }
+
+        class _TakeWhileIntAwaitWithCancellation : AsyncEnumeratorAwaitSelectorBase<TSource, TSource, bool>
+        {
+            readonly Func<TSource, int, CancellationToken, UniTask<bool>> predicate;
+            int index;
+
+            public _TakeWhileIntAwaitWithCancellation(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, int, CancellationToken, UniTask<bool>> predicate, CancellationToken cancellationToken)
+                : base(source, cancellationToken)
+            {
+                this.predicate = predicate;
+            }
+
+            protected override UniTask<bool> TransformAsync(TSource sourceCurrent)
+            {
+                return predicate(sourceCurrent, checked(index++), cancellationToken);
+            }
+
+            protected override bool TrySetCurrentCore(bool awaitResult, out bool terminateIteration)
+            {
+                if (awaitResult)
+                {
+                    Current = SourceCurrent;
+                    terminateIteration = false;
+                    return true;
+                }
+                else
+                {
+                    terminateIteration = true;
+                    return false;
+                }
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/TakeWhile.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/TakeWhile.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bca55adabcc4b3141b50b8b09634f764
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Throw.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Throw.cs
@@ -1,0 +1,54 @@
+﻿using Cysharp.Threading.Tasks.Internal;
+using System;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static IUniTaskAsyncEnumerable<TValue> Throw<TValue>(Exception exception)
+        {
+            return new Throw<TValue>(exception);
+        }
+    }
+
+    internal class Throw<TValue> : IUniTaskAsyncEnumerable<TValue>
+    {
+        readonly Exception exception;
+
+        public Throw(Exception exception)
+        {
+            this.exception = exception;
+        }
+
+        public IUniTaskAsyncEnumerator<TValue> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _Throw(exception, cancellationToken);
+        }
+
+        class _Throw : IUniTaskAsyncEnumerator<TValue>
+        {
+            readonly Exception exception;
+            CancellationToken cancellationToken;
+
+            public _Throw(Exception exception, CancellationToken cancellationToken)
+            {
+                this.exception = exception;
+                this.cancellationToken = cancellationToken;
+            }
+
+            public TValue Current => default;
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                return UniTask.FromException<bool>(exception);
+            }
+
+            public UniTask DisposeAsync()
+            {
+                return default;
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Throw.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Throw.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9d05a7d4f4161e549b4789e1022baae8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/ToArray.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/ToArray.cs
@@ -1,0 +1,60 @@
+﻿using Cysharp.Threading.Tasks.Internal;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static UniTask<TSource[]> ToArrayAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return Cysharp.Threading.Tasks.Linq.ToArray.ToArrayAsync(source, cancellationToken);
+        }
+    }
+
+    internal static class ToArray
+    {
+        internal static async UniTask<TSource[]> ToArrayAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, CancellationToken cancellationToken)
+        {
+            var pool = ArrayPool<TSource>.Shared;
+            var array = pool.Rent(16);
+
+            TSource[] result = default;
+            IUniTaskAsyncEnumerator<TSource> e = default;
+            try
+            {
+                e = source.GetAsyncEnumerator(cancellationToken);
+                var i = 0;
+                while (await e.MoveNextAsync())
+                {
+                    ArrayPoolUtil.EnsureCapacity(ref array, i, pool);
+                    array[i++] = e.Current;
+                }
+
+                if (i == 0)
+                {
+                    result = Array.Empty<TSource>();
+                }
+                else
+                {
+                    result = new TSource[i];
+                    Array.Copy(array, result, i);
+                }
+            }
+            finally
+            {
+                pool.Return(array, clearArray: !RuntimeHelpersAbstraction.IsWellKnownNoReferenceContainsType<TSource>());
+
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return result;
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/ToArray.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/ToArray.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: debb010bbb1622e43b94fe70ec0133dd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/ToDictionary.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/ToDictionary.cs
@@ -1,0 +1,278 @@
+﻿using Cysharp.Threading.Tasks.Internal;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static UniTask<Dictionary<TKey, TSource>> ToDictionaryAsync<TSource, TKey>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+
+            return ToDictionary.ToDictionaryAsync(source, keySelector, EqualityComparer<TKey>.Default, cancellationToken);
+        }
+
+        public static UniTask<Dictionary<TKey, TSource>> ToDictionaryAsync<TSource, TKey>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            Error.ThrowArgumentNullException(comparer, nameof(comparer));
+
+            return ToDictionary.ToDictionaryAsync(source, keySelector, comparer, cancellationToken);
+        }
+
+        public static UniTask<Dictionary<TKey, TElement>> ToDictionaryAsync<TSource, TKey, TElement>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            Error.ThrowArgumentNullException(elementSelector, nameof(elementSelector));
+
+            return ToDictionary.ToDictionaryAsync(source, keySelector, elementSelector, EqualityComparer<TKey>.Default, cancellationToken);
+        }
+
+        public static UniTask<Dictionary<TKey, TElement>> ToDictionaryAsync<TSource, TKey, TElement>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            Error.ThrowArgumentNullException(elementSelector, nameof(elementSelector));
+            Error.ThrowArgumentNullException(comparer, nameof(comparer));
+
+            return ToDictionary.ToDictionaryAsync(source, keySelector, elementSelector, comparer, cancellationToken);
+        }
+
+        public static UniTask<Dictionary<TKey, TSource>> ToDictionaryAwaitAsync<TSource, TKey>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<TKey>> keySelector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+
+            return ToDictionary.ToDictionaryAwaitAsync(source, keySelector, EqualityComparer<TKey>.Default, cancellationToken);
+        }
+
+        public static UniTask<Dictionary<TKey, TSource>> ToDictionaryAwaitAsync<TSource, TKey>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<TKey>> keySelector, IEqualityComparer<TKey> comparer, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            Error.ThrowArgumentNullException(comparer, nameof(comparer));
+
+            return ToDictionary.ToDictionaryAwaitAsync(source, keySelector, comparer, cancellationToken);
+        }
+
+        public static UniTask<Dictionary<TKey, TElement>> ToDictionaryAwaitAsync<TSource, TKey, TElement>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<TKey>> keySelector, Func<TSource, UniTask<TElement>> elementSelector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            Error.ThrowArgumentNullException(elementSelector, nameof(elementSelector));
+
+            return ToDictionary.ToDictionaryAwaitAsync(source, keySelector, elementSelector, EqualityComparer<TKey>.Default, cancellationToken);
+        }
+
+        public static UniTask<Dictionary<TKey, TElement>> ToDictionaryAwaitAsync<TSource, TKey, TElement>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<TKey>> keySelector, Func<TSource, UniTask<TElement>> elementSelector, IEqualityComparer<TKey> comparer, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            Error.ThrowArgumentNullException(elementSelector, nameof(elementSelector));
+            Error.ThrowArgumentNullException(comparer, nameof(comparer));
+
+            return ToDictionary.ToDictionaryAwaitAsync(source, keySelector, elementSelector, comparer, cancellationToken);
+        }
+
+        public static UniTask<Dictionary<TKey, TSource>> ToDictionaryAwaitWithCancellationAsync<TSource, TKey>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<TKey>> keySelector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+
+            return ToDictionary.ToDictionaryAwaitWithCancellationAsync(source, keySelector, EqualityComparer<TKey>.Default, cancellationToken);
+        }
+
+        public static UniTask<Dictionary<TKey, TSource>> ToDictionaryAwaitWithCancellationAsync<TSource, TKey>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<TKey>> keySelector, IEqualityComparer<TKey> comparer, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            Error.ThrowArgumentNullException(comparer, nameof(comparer));
+
+            return ToDictionary.ToDictionaryAwaitWithCancellationAsync(source, keySelector, comparer, cancellationToken);
+        }
+
+        public static UniTask<Dictionary<TKey, TElement>> ToDictionaryAwaitWithCancellationAsync<TSource, TKey, TElement>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<TKey>> keySelector, Func<TSource, CancellationToken, UniTask<TElement>> elementSelector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            Error.ThrowArgumentNullException(elementSelector, nameof(elementSelector));
+
+            return ToDictionary.ToDictionaryAwaitWithCancellationAsync(source, keySelector, elementSelector, EqualityComparer<TKey>.Default, cancellationToken);
+        }
+
+        public static UniTask<Dictionary<TKey, TElement>> ToDictionaryAwaitWithCancellationAsync<TSource, TKey, TElement>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<TKey>> keySelector, Func<TSource, CancellationToken, UniTask<TElement>> elementSelector, IEqualityComparer<TKey> comparer, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            Error.ThrowArgumentNullException(elementSelector, nameof(elementSelector));
+            Error.ThrowArgumentNullException(comparer, nameof(comparer));
+
+            return ToDictionary.ToDictionaryAwaitWithCancellationAsync(source, keySelector, elementSelector, comparer, cancellationToken);
+        }
+    }
+
+    internal static class ToDictionary
+    {
+        internal static async UniTask<Dictionary<TKey, TSource>> ToDictionaryAsync<TSource, TKey>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer, CancellationToken cancellationToken)
+        {
+            var dict = new Dictionary<TKey, TSource>(comparer);
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    var v = e.Current;
+                    var key = keySelector(v);
+                    dict.Add(key, v);
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return dict;
+        }
+
+        internal static async UniTask<Dictionary<TKey, TElement>> ToDictionaryAsync<TSource, TKey, TElement>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer, CancellationToken cancellationToken)
+        {
+            var dict = new Dictionary<TKey, TElement>(comparer);
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    var v = e.Current;
+                    var key = keySelector(v);
+                    var value = elementSelector(v);
+                    dict.Add(key, value);
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return dict;
+        }
+
+        // with await
+
+        internal static async UniTask<Dictionary<TKey, TSource>> ToDictionaryAwaitAsync<TSource, TKey>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<TKey>> keySelector, IEqualityComparer<TKey> comparer, CancellationToken cancellationToken)
+        {
+            var dict = new Dictionary<TKey, TSource>(comparer);
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    var v = e.Current;
+                    var key = await keySelector(v);
+                    dict.Add(key, v);
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return dict;
+        }
+
+        internal static async UniTask<Dictionary<TKey, TElement>> ToDictionaryAwaitAsync<TSource, TKey, TElement>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<TKey>> keySelector, Func<TSource, UniTask<TElement>> elementSelector, IEqualityComparer<TKey> comparer, CancellationToken cancellationToken)
+        {
+            var dict = new Dictionary<TKey, TElement>(comparer);
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    var v = e.Current;
+                    var key = await keySelector(v);
+                    var value = await elementSelector(v);
+                    dict.Add(key, value);
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return dict;
+        }
+
+        // with cancellation
+
+        internal static async UniTask<Dictionary<TKey, TSource>> ToDictionaryAwaitWithCancellationAsync<TSource, TKey>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<TKey>> keySelector, IEqualityComparer<TKey> comparer, CancellationToken cancellationToken)
+        {
+            var dict = new Dictionary<TKey, TSource>(comparer);
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    var v = e.Current;
+                    var key = await keySelector(v, cancellationToken);
+                    dict.Add(key, v);
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return dict;
+        }
+
+        internal static async UniTask<Dictionary<TKey, TElement>> ToDictionaryAwaitWithCancellationAsync<TSource, TKey, TElement>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<TKey>> keySelector, Func<TSource, CancellationToken, UniTask<TElement>> elementSelector, IEqualityComparer<TKey> comparer, CancellationToken cancellationToken)
+        {
+            var dict = new Dictionary<TKey, TElement>(comparer);
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    var v = e.Current;
+                    var key = await keySelector(v, cancellationToken);
+                    var value = await elementSelector(v, cancellationToken);
+                    dict.Add(key, value);
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return dict;
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/ToDictionary.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/ToDictionary.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 03b109b1fe1f2df46aa56ffb26747654
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/ToHashSet.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/ToHashSet.cs
@@ -1,0 +1,50 @@
+﻿using Cysharp.Threading.Tasks.Internal;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static UniTask<HashSet<TSource>> ToHashSetAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return Cysharp.Threading.Tasks.Linq.ToHashSet.ToHashSetAsync(source, EqualityComparer<TSource>.Default, cancellationToken);
+        }
+
+        public static UniTask<HashSet<TSource>> ToHashSetAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, IEqualityComparer<TSource> comparer, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(comparer, nameof(comparer));
+
+            return Cysharp.Threading.Tasks.Linq.ToHashSet.ToHashSetAsync(source, comparer, cancellationToken);
+        }
+    }
+
+    internal static class ToHashSet
+    {
+        internal static async UniTask<HashSet<TSource>> ToHashSetAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, IEqualityComparer<TSource> comparer, CancellationToken cancellationToken)
+        {
+            var set = new HashSet<TSource>(comparer);
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    set.Add(e.Current);
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return set;
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/ToHashSet.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/ToHashSet.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7a3e552113af96e4986805ec3c4fc80a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/ToList.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/ToList.cs
@@ -1,0 +1,42 @@
+﻿using Cysharp.Threading.Tasks.Internal;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static UniTask<List<TSource>> ToListAsync<TSource>(this IUniTaskAsyncEnumerable<TSource> source, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return Cysharp.Threading.Tasks.Linq.ToList.ToListAsync(source, cancellationToken);
+        }
+    }
+
+    internal static class ToList
+    {
+        internal static async UniTask<List<TSource>> ToListAsync<TSource>(IUniTaskAsyncEnumerable<TSource> source, CancellationToken cancellationToken)
+        {
+            var list = new List<TSource>();
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (await e.MoveNextAsync())
+                {
+                    list.Add(e.Current);
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+
+            return list;
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/ToList.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/ToList.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3859c1b31e81d9b44b282e7d97e11635
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/ToLookup.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/ToLookup.cs
@@ -1,0 +1,554 @@
+﻿using Cysharp.Threading.Tasks.Internal;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static UniTask<ILookup<TKey, TSource>> ToLookupAsync<TSource, TKey>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+
+            return ToLookup.ToLookupAsync(source, keySelector, EqualityComparer<TKey>.Default, cancellationToken);
+        }
+
+        public static UniTask<ILookup<TKey, TSource>> ToLookupAsync<TSource, TKey>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            Error.ThrowArgumentNullException(comparer, nameof(comparer));
+
+            return ToLookup.ToLookupAsync(source, keySelector, comparer, cancellationToken);
+        }
+
+        public static UniTask<ILookup<TKey, TElement>> ToLookupAsync<TSource, TKey, TElement>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            Error.ThrowArgumentNullException(elementSelector, nameof(elementSelector));
+
+            return ToLookup.ToLookupAsync(source, keySelector, elementSelector, EqualityComparer<TKey>.Default, cancellationToken);
+        }
+
+        public static UniTask<ILookup<TKey, TElement>> ToLookupAsync<TSource, TKey, TElement>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            Error.ThrowArgumentNullException(elementSelector, nameof(elementSelector));
+            Error.ThrowArgumentNullException(comparer, nameof(comparer));
+
+            return ToLookup.ToLookupAsync(source, keySelector, elementSelector, comparer, cancellationToken);
+        }
+
+        public static UniTask<ILookup<TKey, TSource>> ToLookupAwaitAsync<TSource, TKey>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<TKey>> keySelector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+
+            return ToLookup.ToLookupAwaitAsync(source, keySelector, EqualityComparer<TKey>.Default, cancellationToken);
+        }
+
+        public static UniTask<ILookup<TKey, TSource>> ToLookupAwaitAsync<TSource, TKey>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<TKey>> keySelector, IEqualityComparer<TKey> comparer, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            Error.ThrowArgumentNullException(comparer, nameof(comparer));
+
+            return ToLookup.ToLookupAwaitAsync(source, keySelector, comparer, cancellationToken);
+        }
+
+        public static UniTask<ILookup<TKey, TElement>> ToLookupAwaitAsync<TSource, TKey, TElement>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<TKey>> keySelector, Func<TSource, UniTask<TElement>> elementSelector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            Error.ThrowArgumentNullException(elementSelector, nameof(elementSelector));
+
+            return ToLookup.ToLookupAwaitAsync(source, keySelector, elementSelector, EqualityComparer<TKey>.Default, cancellationToken);
+        }
+
+        public static UniTask<ILookup<TKey, TElement>> ToLookupAwaitAsync<TSource, TKey, TElement>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<TKey>> keySelector, Func<TSource, UniTask<TElement>> elementSelector, IEqualityComparer<TKey> comparer, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            Error.ThrowArgumentNullException(elementSelector, nameof(elementSelector));
+            Error.ThrowArgumentNullException(comparer, nameof(comparer));
+
+            return ToLookup.ToLookupAwaitAsync(source, keySelector, elementSelector, comparer, cancellationToken);
+        }
+
+        public static UniTask<ILookup<TKey, TSource>> ToLookupAwaitWithCancellationAsync<TSource, TKey>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<TKey>> keySelector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+
+            return ToLookup.ToLookupAwaitWithCancellationAsync(source, keySelector, EqualityComparer<TKey>.Default, cancellationToken);
+        }
+
+        public static UniTask<ILookup<TKey, TSource>> ToLookupAwaitWithCancellationAsync<TSource, TKey>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<TKey>> keySelector, IEqualityComparer<TKey> comparer, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            Error.ThrowArgumentNullException(comparer, nameof(comparer));
+
+            return ToLookup.ToLookupAwaitWithCancellationAsync(source, keySelector, comparer, cancellationToken);
+        }
+
+        public static UniTask<ILookup<TKey, TElement>> ToLookupAwaitWithCancellationAsync<TSource, TKey, TElement>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<TKey>> keySelector, Func<TSource, CancellationToken, UniTask<TElement>> elementSelector, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            Error.ThrowArgumentNullException(elementSelector, nameof(elementSelector));
+
+            return ToLookup.ToLookupAwaitWithCancellationAsync(source, keySelector, elementSelector, EqualityComparer<TKey>.Default, cancellationToken);
+        }
+
+        public static UniTask<ILookup<TKey, TElement>> ToLookupAwaitWithCancellationAsync<TSource, TKey, TElement>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<TKey>> keySelector, Func<TSource, CancellationToken, UniTask<TElement>> elementSelector, IEqualityComparer<TKey> comparer, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(keySelector, nameof(keySelector));
+            Error.ThrowArgumentNullException(elementSelector, nameof(elementSelector));
+            Error.ThrowArgumentNullException(comparer, nameof(comparer));
+
+            return ToLookup.ToLookupAwaitWithCancellationAsync(source, keySelector, elementSelector, comparer, cancellationToken);
+        }
+    }
+
+    internal static class ToLookup
+    {
+        internal static async UniTask<ILookup<TKey, TSource>> ToLookupAsync<TSource, TKey>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer, CancellationToken cancellationToken)
+        {
+            var pool = ArrayPool<TSource>.Shared;
+            var array = pool.Rent(16);
+
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                var i = 0;
+                while (await e.MoveNextAsync())
+                {
+                    ArrayPoolUtil.EnsureCapacity(ref array, i, pool);
+                    array[i++] = e.Current;
+                }
+
+                if (i == 0)
+                {
+                    return Lookup<TKey, TSource>.CreateEmpty();
+                }
+                else
+                {
+                    return Lookup<TKey, TSource>.Create(new ArraySegment<TSource>(array, 0, i), keySelector, comparer);
+                }
+            }
+            finally
+            {
+                pool.Return(array, clearArray: !RuntimeHelpersAbstraction.IsWellKnownNoReferenceContainsType<TSource>());
+
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+        }
+
+        internal static async UniTask<ILookup<TKey, TElement>> ToLookupAsync<TSource, TKey, TElement>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer, CancellationToken cancellationToken)
+        {
+            var pool = ArrayPool<TSource>.Shared;
+            var array = pool.Rent(16);
+
+            IUniTaskAsyncEnumerator<TSource> e = default;
+            try
+            {
+                e = source.GetAsyncEnumerator(cancellationToken);
+                var i = 0;
+                while (await e.MoveNextAsync())
+                {
+                    ArrayPoolUtil.EnsureCapacity(ref array, i, pool);
+                    array[i++] = e.Current;
+                }
+
+                if (i == 0)
+                {
+                    return Lookup<TKey, TElement>.CreateEmpty();
+                }
+                else
+                {
+                    return Lookup<TKey, TElement>.Create(new ArraySegment<TSource>(array, 0, i), keySelector, elementSelector, comparer);
+                }
+            }
+            finally
+            {
+                pool.Return(array, clearArray: !RuntimeHelpersAbstraction.IsWellKnownNoReferenceContainsType<TSource>());
+
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+        }
+
+
+        // with await
+
+        internal static async UniTask<ILookup<TKey, TSource>> ToLookupAwaitAsync<TSource, TKey>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<TKey>> keySelector, IEqualityComparer<TKey> comparer, CancellationToken cancellationToken)
+        {
+            var pool = ArrayPool<TSource>.Shared;
+            var array = pool.Rent(16);
+
+            IUniTaskAsyncEnumerator<TSource> e = default;
+            try
+            {
+                e = source.GetAsyncEnumerator(cancellationToken);
+                var i = 0;
+                while (await e.MoveNextAsync())
+                {
+                    ArrayPoolUtil.EnsureCapacity(ref array, i, pool);
+                    array[i++] = e.Current;
+                }
+
+                if (i == 0)
+                {
+                    return Lookup<TKey, TSource>.CreateEmpty();
+                }
+                else
+                {
+                    return await Lookup<TKey, TSource>.CreateAsync(new ArraySegment<TSource>(array, 0, i), keySelector, comparer);
+                }
+            }
+            finally
+            {
+                pool.Return(array, clearArray: !RuntimeHelpersAbstraction.IsWellKnownNoReferenceContainsType<TSource>());
+
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+        }
+
+        internal static async UniTask<ILookup<TKey, TElement>> ToLookupAwaitAsync<TSource, TKey, TElement>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<TKey>> keySelector, Func<TSource, UniTask<TElement>> elementSelector, IEqualityComparer<TKey> comparer, CancellationToken cancellationToken)
+        {
+            var pool = ArrayPool<TSource>.Shared;
+            var array = pool.Rent(16);
+
+            IUniTaskAsyncEnumerator<TSource> e = default;
+            try
+            {
+                e = source.GetAsyncEnumerator(cancellationToken);
+                var i = 0;
+                while (await e.MoveNextAsync())
+                {
+                    ArrayPoolUtil.EnsureCapacity(ref array, i, pool);
+                    array[i++] = e.Current;
+                }
+
+                if (i == 0)
+                {
+                    return Lookup<TKey, TElement>.CreateEmpty();
+                }
+                else
+                {
+                    return await Lookup<TKey, TElement>.CreateAsync(new ArraySegment<TSource>(array, 0, i), keySelector, elementSelector, comparer);
+                }
+            }
+            finally
+            {
+                pool.Return(array, clearArray: !RuntimeHelpersAbstraction.IsWellKnownNoReferenceContainsType<TSource>());
+
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+        }
+
+        // with cancellation
+
+        internal static async UniTask<ILookup<TKey, TSource>> ToLookupAwaitWithCancellationAsync<TSource, TKey>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<TKey>> keySelector, IEqualityComparer<TKey> comparer, CancellationToken cancellationToken)
+        {
+            var pool = ArrayPool<TSource>.Shared;
+            var array = pool.Rent(16);
+
+            IUniTaskAsyncEnumerator<TSource> e = default;
+            try
+            {
+                e = source.GetAsyncEnumerator(cancellationToken);
+                var i = 0;
+                while (await e.MoveNextAsync())
+                {
+                    ArrayPoolUtil.EnsureCapacity(ref array, i, pool);
+                    array[i++] = e.Current;
+                }
+
+                if (i == 0)
+                {
+                    return Lookup<TKey, TSource>.CreateEmpty();
+                }
+                else
+                {
+                    return await Lookup<TKey, TSource>.CreateAsync(new ArraySegment<TSource>(array, 0, i), keySelector, comparer, cancellationToken);
+                }
+            }
+            finally
+            {
+                pool.Return(array, clearArray: !RuntimeHelpersAbstraction.IsWellKnownNoReferenceContainsType<TSource>());
+
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+        }
+
+        internal static async UniTask<ILookup<TKey, TElement>> ToLookupAwaitWithCancellationAsync<TSource, TKey, TElement>(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<TKey>> keySelector, Func<TSource, CancellationToken, UniTask<TElement>> elementSelector, IEqualityComparer<TKey> comparer, CancellationToken cancellationToken)
+        {
+            var pool = ArrayPool<TSource>.Shared;
+            var array = pool.Rent(16);
+
+            IUniTaskAsyncEnumerator<TSource> e = default;
+            try
+            {
+                e = source.GetAsyncEnumerator(cancellationToken);
+                var i = 0;
+                while (await e.MoveNextAsync())
+                {
+                    ArrayPoolUtil.EnsureCapacity(ref array, i, pool);
+                    array[i++] = e.Current;
+                }
+
+                if (i == 0)
+                {
+                    return Lookup<TKey, TElement>.CreateEmpty();
+                }
+                else
+                {
+                    return await Lookup<TKey, TElement>.CreateAsync(new ArraySegment<TSource>(array, 0, i), keySelector, elementSelector, comparer, cancellationToken);
+                }
+            }
+            finally
+            {
+                pool.Return(array, clearArray: !RuntimeHelpersAbstraction.IsWellKnownNoReferenceContainsType<TSource>());
+
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+        }
+
+        // Lookup
+
+        class Lookup<TKey, TElement> : ILookup<TKey, TElement>
+        {
+            static readonly Lookup<TKey, TElement> empty = new Lookup<TKey, TElement>(new Dictionary<TKey, Grouping<TKey, TElement>>());
+
+            // original lookup keeps order but this impl does not(dictionary not guarantee)
+            readonly Dictionary<TKey, Grouping<TKey, TElement>> dict;
+
+            Lookup(Dictionary<TKey, Grouping<TKey, TElement>> dict)
+            {
+                this.dict = dict;
+            }
+
+            public static Lookup<TKey, TElement> CreateEmpty()
+            {
+                return empty;
+            }
+
+            public static Lookup<TKey, TElement> Create(ArraySegment<TElement> source, Func<TElement, TKey> keySelector, IEqualityComparer<TKey> comparer)
+            {
+                var dict = new Dictionary<TKey, Grouping<TKey, TElement>>(comparer);
+
+                var arr = source.Array;
+                var c = source.Count;
+                for (int i = source.Offset; i < c; i++)
+                {
+                    var key = keySelector(arr[i]);
+
+                    if (!dict.TryGetValue(key, out var list))
+                    {
+                        list = new Grouping<TKey, TElement>(key);
+                        dict[key] = list;
+                    }
+
+                    list.Add(arr[i]);
+                }
+
+                return new Lookup<TKey, TElement>(dict);
+            }
+
+            public static Lookup<TKey, TElement> Create<TSource>(ArraySegment<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer)
+            {
+                var dict = new Dictionary<TKey, Grouping<TKey, TElement>>(comparer);
+
+                var arr = source.Array;
+                var c = source.Count;
+                for (int i = source.Offset; i < c; i++)
+                {
+                    var key = keySelector(arr[i]);
+                    var elem = elementSelector(arr[i]);
+
+                    if (!dict.TryGetValue(key, out var list))
+                    {
+                        list = new Grouping<TKey, TElement>(key);
+                        dict[key] = list;
+                    }
+
+                    list.Add(elem);
+                }
+
+                return new Lookup<TKey, TElement>(dict);
+            }
+
+            public static async UniTask<Lookup<TKey, TElement>> CreateAsync(ArraySegment<TElement> source, Func<TElement, UniTask<TKey>> keySelector, IEqualityComparer<TKey> comparer)
+            {
+                var dict = new Dictionary<TKey, Grouping<TKey, TElement>>(comparer);
+
+                var arr = source.Array;
+                var c = source.Count;
+                for (int i = source.Offset; i < c; i++)
+                {
+                    var key = await keySelector(arr[i]);
+
+                    if (!dict.TryGetValue(key, out var list))
+                    {
+                        list = new Grouping<TKey, TElement>(key);
+                        dict[key] = list;
+                    }
+
+                    list.Add(arr[i]);
+                }
+
+                return new Lookup<TKey, TElement>(dict);
+            }
+
+            public static async UniTask<Lookup<TKey, TElement>> CreateAsync<TSource>(ArraySegment<TSource> source, Func<TSource, UniTask<TKey>> keySelector, Func<TSource, UniTask<TElement>> elementSelector, IEqualityComparer<TKey> comparer)
+            {
+                var dict = new Dictionary<TKey, Grouping<TKey, TElement>>(comparer);
+
+                var arr = source.Array;
+                var c = source.Count;
+                for (int i = source.Offset; i < c; i++)
+                {
+                    var key = await keySelector(arr[i]);
+                    var elem = await elementSelector(arr[i]);
+
+                    if (!dict.TryGetValue(key, out var list))
+                    {
+                        list = new Grouping<TKey, TElement>(key);
+                        dict[key] = list;
+                    }
+
+                    list.Add(elem);
+                }
+
+                return new Lookup<TKey, TElement>(dict);
+            }
+
+            public static async UniTask<Lookup<TKey, TElement>> CreateAsync(ArraySegment<TElement> source, Func<TElement, CancellationToken, UniTask<TKey>> keySelector, IEqualityComparer<TKey> comparer, CancellationToken cancellationToken)
+            {
+                var dict = new Dictionary<TKey, Grouping<TKey, TElement>>(comparer);
+
+                var arr = source.Array;
+                var c = source.Count;
+                for (int i = source.Offset; i < c; i++)
+                {
+                    var key = await keySelector(arr[i], cancellationToken);
+
+                    if (!dict.TryGetValue(key, out var list))
+                    {
+                        list = new Grouping<TKey, TElement>(key);
+                        dict[key] = list;
+                    }
+
+                    list.Add(arr[i]);
+                }
+
+                return new Lookup<TKey, TElement>(dict);
+            }
+
+            public static async UniTask<Lookup<TKey, TElement>> CreateAsync<TSource>(ArraySegment<TSource> source, Func<TSource, CancellationToken, UniTask<TKey>> keySelector, Func<TSource, CancellationToken, UniTask<TElement>> elementSelector, IEqualityComparer<TKey> comparer, CancellationToken cancellationToken)
+            {
+                var dict = new Dictionary<TKey, Grouping<TKey, TElement>>(comparer);
+
+                var arr = source.Array;
+                var c = source.Count;
+                for (int i = source.Offset; i < c; i++)
+                {
+                    var key = await keySelector(arr[i], cancellationToken);
+                    var elem = await elementSelector(arr[i], cancellationToken);
+
+                    if (!dict.TryGetValue(key, out var list))
+                    {
+                        list = new Grouping<TKey, TElement>(key);
+                        dict[key] = list;
+                    }
+
+                    list.Add(elem);
+                }
+
+                return new Lookup<TKey, TElement>(dict);
+            }
+
+            public IEnumerable<TElement> this[TKey key] => dict.TryGetValue(key, out var g) ? g : Enumerable.Empty<TElement>();
+
+            public int Count => dict.Count;
+
+            public bool Contains(TKey key)
+            {
+                return dict.ContainsKey(key);
+            }
+
+            public IEnumerator<IGrouping<TKey, TElement>> GetEnumerator()
+            {
+                return dict.Values.GetEnumerator();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return dict.Values.GetEnumerator();
+            }
+        }
+
+        class Grouping<TKey, TElement> : IGrouping<TKey, TElement> // , IUniTaskAsyncGrouping<TKey, TElement>
+        {
+            readonly List<TElement> elements;
+
+            public TKey Key { get; private set; }
+
+            public Grouping(TKey key)
+            {
+                this.Key = key;
+                this.elements = new List<TElement>();
+            }
+
+            public void Add(TElement value)
+            {
+                elements.Add(value);
+            }
+            public IEnumerator<TElement> GetEnumerator()
+            {
+                return elements.GetEnumerator();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return elements.GetEnumerator();
+            }
+
+            public IUniTaskAsyncEnumerator<TElement> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+            {
+                return this.ToUniTaskAsyncEnumerable().GetAsyncEnumerator(cancellationToken);
+            }
+
+            public override string ToString()
+            {
+                return "Key: " + Key + ", Count: " + elements.Count;
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/ToLookup.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/ToLookup.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 57da22563bcd6ca4aaf256d941de5cb0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/ToObservable.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/ToObservable.cs
@@ -1,0 +1,97 @@
+﻿using Cysharp.Threading.Tasks.Internal;
+using System;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static IObservable<TSource> ToObservable<TSource>(this IUniTaskAsyncEnumerable<TSource> source)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return new ToObservable<TSource>(source);
+        }
+    }
+
+    internal sealed class ToObservable<T> : IObservable<T>
+    {
+        readonly IUniTaskAsyncEnumerable<T> source;
+
+        public ToObservable(IUniTaskAsyncEnumerable<T> source)
+        {
+            this.source = source;
+        }
+
+        public IDisposable Subscribe(IObserver<T> observer)
+        {
+            var ctd = new CancellationTokenDisposable();
+
+            RunAsync(source, observer, ctd.Token).Forget();
+
+            return ctd;
+        }
+
+        static async UniTaskVoid RunAsync(IUniTaskAsyncEnumerable<T> src, IObserver<T> observer, CancellationToken cancellationToken)
+        {
+            // cancellationToken.IsCancellationRequested is called when Rx's Disposed.
+            // when disposed, finish silently.
+
+            var e = src.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                bool hasNext;
+
+                do
+                {
+                    try
+                    {
+                        hasNext = await e.MoveNextAsync();
+                    }
+                    catch (Exception ex)
+                    {
+                        if (cancellationToken.IsCancellationRequested)
+                        {
+                            return;
+                        }
+
+                        observer.OnError(ex);
+                        return;
+                    }
+
+                    if (hasNext)
+                    {
+                        observer.OnNext(e.Current);
+                    }
+                    else
+                    {
+                        observer.OnCompleted();
+                        return;
+                    }
+                } while (!cancellationToken.IsCancellationRequested);
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+        }
+
+        internal sealed class CancellationTokenDisposable : IDisposable
+        {
+            readonly CancellationTokenSource cts = new CancellationTokenSource();
+
+            public CancellationToken Token => cts.Token;
+
+            public void Dispose()
+            {
+                if (!cts.IsCancellationRequested)
+                {
+                    cts.Cancel();
+                }
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/ToObservable.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/ToObservable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b4f6f48a532188e4c80b7ebe69aea3a8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/ToUniTaskAsyncEnumerable.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/ToUniTaskAsyncEnumerable.cs
@@ -1,0 +1,1115 @@
+﻿using Cysharp.Threading.Tasks.Internal;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static IUniTaskAsyncEnumerable<TSource> ToUniTaskAsyncEnumerable<TSource>(this IEnumerable<TSource> source)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return new ToUniTaskAsyncEnumerable<TSource>(source);
+        }
+
+        public static IUniTaskAsyncEnumerable<TSource> ToUniTaskAsyncEnumerable<TSource>(this Task<TSource> source)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return new ToUniTaskAsyncEnumerableTask<TSource>(source);
+        }
+
+        public static IUniTaskAsyncEnumerable<TSource> ToUniTaskAsyncEnumerable<TSource>(this UniTask<TSource> source)
+        {
+            return new ToUniTaskAsyncEnumerableUniTask<TSource>(source);
+        }
+
+        public static IUniTaskAsyncEnumerable<TSource> ToUniTaskAsyncEnumerable<TSource>(this IObservable<TSource> source)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+
+            return new ToUniTaskAsyncEnumerableObservable<TSource>(source);
+        }
+    }
+
+    internal class ToUniTaskAsyncEnumerable<T> : IUniTaskAsyncEnumerable<T>
+    {
+        readonly IEnumerable<T> source;
+
+        public ToUniTaskAsyncEnumerable(IEnumerable<T> source)
+        {
+            this.source = source;
+        }
+
+        public IUniTaskAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _ToUniTaskAsyncEnumerable(source, cancellationToken);
+        }
+
+        class _ToUniTaskAsyncEnumerable : IUniTaskAsyncEnumerator<T>
+        {
+            readonly IEnumerable<T> source;
+            CancellationToken cancellationToken;
+
+            IEnumerator<T> enumerator;
+
+            public _ToUniTaskAsyncEnumerable(IEnumerable<T> source, CancellationToken cancellationToken)
+            {
+                this.source = source;
+                this.cancellationToken = cancellationToken;
+            }
+
+            public T Current => enumerator.Current;
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (enumerator == null)
+                {
+                    enumerator = source.GetEnumerator();
+                }
+
+                if (enumerator.MoveNext())
+                {
+                    return CompletedTasks.True;
+                }
+
+                return CompletedTasks.False;
+            }
+
+            public UniTask DisposeAsync()
+            {
+                enumerator.Dispose();
+                return default;
+            }
+        }
+    }
+
+    internal class ToUniTaskAsyncEnumerableTask<T> : IUniTaskAsyncEnumerable<T>
+    {
+        readonly Task<T> source;
+
+        public ToUniTaskAsyncEnumerableTask(Task<T> source)
+        {
+            this.source = source;
+        }
+
+        public IUniTaskAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _ToUniTaskAsyncEnumerableTask(source, cancellationToken);
+        }
+
+        class _ToUniTaskAsyncEnumerableTask : IUniTaskAsyncEnumerator<T>
+        {
+            readonly Task<T> source;
+            CancellationToken cancellationToken;
+
+            T current;
+            bool called;
+
+            public _ToUniTaskAsyncEnumerableTask(Task<T> source, CancellationToken cancellationToken)
+            {
+                this.source = source;
+                this.cancellationToken = cancellationToken;
+
+                this.called = false;
+            }
+
+            public T Current => current;
+
+            public async UniTask<bool> MoveNextAsync()
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (called)
+                {
+                    return false;
+                }
+                called = true;
+
+                current = await source;
+                return true;
+            }
+
+            public UniTask DisposeAsync()
+            {
+                return default;
+            }
+        }
+    }
+
+    internal class ToUniTaskAsyncEnumerableUniTask<T> : IUniTaskAsyncEnumerable<T>
+    {
+        readonly UniTask<T> source;
+
+        public ToUniTaskAsyncEnumerableUniTask(UniTask<T> source)
+        {
+            this.source = source;
+        }
+
+        public IUniTaskAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _ToUniTaskAsyncEnumerableUniTask(source, cancellationToken);
+        }
+
+        class _ToUniTaskAsyncEnumerableUniTask : IUniTaskAsyncEnumerator<T>
+        {
+            readonly UniTask<T> source;
+            CancellationToken cancellationToken;
+
+            T current;
+            bool called;
+
+            public _ToUniTaskAsyncEnumerableUniTask(UniTask<T> source, CancellationToken cancellationToken)
+            {
+                this.source = source;
+                this.cancellationToken = cancellationToken;
+
+                this.called = false;
+            }
+
+            public T Current => current;
+
+            public async UniTask<bool> MoveNextAsync()
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (called)
+                {
+                    return false;
+                }
+                called = true;
+
+                current = await source;
+                return true;
+            }
+
+            public UniTask DisposeAsync()
+            {
+                return default;
+            }
+        }
+    }
+
+    internal class ToUniTaskAsyncEnumerableObservable<T> : IUniTaskAsyncEnumerable<T>
+    {
+        readonly IObservable<T> source;
+
+        public ToUniTaskAsyncEnumerableObservable(IObservable<T> source)
+        {
+            this.source = source;
+        }
+
+        public IUniTaskAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _ToUniTaskAsyncEnumerableObservable(source, cancellationToken);
+        }
+
+        class _ToUniTaskAsyncEnumerableObservable : MoveNextSource, IUniTaskAsyncEnumerator<T>, IObserver<T>
+        {
+            static readonly Action<object> OnCanceledDelegate = OnCanceled;
+
+            readonly IObservable<T> source;
+            CancellationToken cancellationToken;
+
+
+            bool useCachedCurrent;
+            T current;
+            bool subscribeCompleted;
+            readonly Queue<T> queuedResult;
+            Exception error;
+            IDisposable subscription;
+            CancellationTokenRegistration cancellationTokenRegistration;
+
+            public _ToUniTaskAsyncEnumerableObservable(IObservable<T> source, CancellationToken cancellationToken)
+            {
+                this.source = source;
+                this.cancellationToken = cancellationToken;
+                this.queuedResult = new Queue<T>();
+
+                if (cancellationToken.CanBeCanceled)
+                {
+                    cancellationTokenRegistration = cancellationToken.RegisterWithoutCaptureExecutionContext(OnCanceledDelegate, this);
+                }
+            }
+
+            public T Current
+            {
+                get
+                {
+                    if (useCachedCurrent)
+                    {
+                        return current;
+                    }
+
+                    lock (queuedResult)
+                    {
+                        if (queuedResult.Count != 0)
+                        {
+                            current = queuedResult.Dequeue();
+                            useCachedCurrent = true;
+                            return current;
+                        }
+                        else
+                        {
+                            return default; // undefined.
+                        }
+                    }
+                }
+            }
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                lock (queuedResult)
+                {
+                    useCachedCurrent = false;
+
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        return UniTask.FromCanceled<bool>(cancellationToken);
+                    }
+
+                    if (subscription == null)
+                    {
+                        subscription = source.Subscribe(this);
+                    }
+
+                    if (error != null)
+                    {
+                        return UniTask.FromException<bool>(error);
+                    }
+
+                    if (queuedResult.Count != 0)
+                    {
+                        return CompletedTasks.True;
+                    }
+
+                    if (subscribeCompleted)
+                    {
+                        return CompletedTasks.False;
+                    }
+
+                    completionSource.Reset();
+                    return new UniTask<bool>(this, completionSource.Version);
+                }
+            }
+
+            public UniTask DisposeAsync()
+            {
+                subscription.Dispose();
+                cancellationTokenRegistration.Dispose();
+                completionSource.Reset();
+                return default;
+            }
+
+            public void OnCompleted()
+            {
+                lock (queuedResult)
+                {
+                    subscribeCompleted = true;
+                    completionSource.TrySetResult(false);
+                }
+            }
+
+            public void OnError(Exception error)
+            {
+                lock (queuedResult)
+                {
+                    this.error = error;
+                    completionSource.TrySetException(error);
+                }
+            }
+
+            public void OnNext(T value)
+            {
+                lock (queuedResult)
+                {
+                    queuedResult.Enqueue(value);
+                    completionSource.TrySetResult(true); // include callback execution, too long lock?
+                }
+            }
+
+            static void OnCanceled(object state)
+            {
+                var self = (_ToUniTaskAsyncEnumerableObservable)state;
+                lock (self.queuedResult)
+                {
+                    self.completionSource.TrySetCanceled(self.cancellationToken);
+                }
+            }
+        }
+    }
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/ToUniTaskAsyncEnumerable.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/ToUniTaskAsyncEnumerable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d7192de2a0581ec4db62962cc1404af5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/UniTask.Linq.asmdef
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/UniTask.Linq.asmdef
@@ -1,0 +1,15 @@
+{
+    "name": "UniTask.Linq",
+    "references": [
+        "UniTask"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/UniTask.Linq.asmdef.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/UniTask.Linq.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5c01796d064528144a599661eaab93a6
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Union.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Union.cs
@@ -1,0 +1,26 @@
+﻿using Cysharp.Threading.Tasks.Internal;
+using System.Collections.Generic;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static IUniTaskAsyncEnumerable<TSource> Union<TSource>(this IUniTaskAsyncEnumerable<TSource> first, IUniTaskAsyncEnumerable<TSource> second)
+        {
+            Error.ThrowArgumentNullException(first, nameof(first));
+            Error.ThrowArgumentNullException(second, nameof(second));
+
+            return Union<TSource>(first, second, EqualityComparer<TSource>.Default);
+        }
+
+        public static IUniTaskAsyncEnumerable<TSource> Union<TSource>(this IUniTaskAsyncEnumerable<TSource> first, IUniTaskAsyncEnumerable<TSource> second, IEqualityComparer<TSource> comparer)
+        {
+            Error.ThrowArgumentNullException(first, nameof(first));
+            Error.ThrowArgumentNullException(second, nameof(second));
+            Error.ThrowArgumentNullException(comparer, nameof(comparer));
+
+            // improv without combinate?
+            return first.Concat(second).Distinct(comparer);
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Union.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Union.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ae57a55bdeba98b4f8ff234d98d7dd76
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/UnityExtensions.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/UnityExtensions.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: eb1823fbb4e6ca54bb3c0744e25aadc4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/UnityExtensions/EveryUpdate.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/UnityExtensions/EveryUpdate.cs
@@ -1,0 +1,77 @@
+﻿using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static IUniTaskAsyncEnumerable<AsyncUnit> EveryUpdate(PlayerLoopTiming updateTiming = PlayerLoopTiming.Update)
+        {
+            return new EveryUpdate(updateTiming);
+        }
+    }
+
+    internal class EveryUpdate : IUniTaskAsyncEnumerable<AsyncUnit>
+    {
+        readonly PlayerLoopTiming updateTiming;
+
+        public EveryUpdate(PlayerLoopTiming updateTiming)
+        {
+            this.updateTiming = updateTiming;
+        }
+
+        public IUniTaskAsyncEnumerator<AsyncUnit> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _EveryUpdate(updateTiming, cancellationToken);
+        }
+
+        class _EveryUpdate : MoveNextSource, IUniTaskAsyncEnumerator<AsyncUnit>, IPlayerLoopItem
+        {
+            readonly PlayerLoopTiming updateTiming;
+            CancellationToken cancellationToken;
+
+            bool disposed;
+
+            public _EveryUpdate(PlayerLoopTiming updateTiming, CancellationToken cancellationToken)
+            {
+                this.updateTiming = updateTiming;
+                this.cancellationToken = cancellationToken;
+
+                TaskTracker.TrackActiveTask(this, 2);
+                PlayerLoopHelper.AddAction(updateTiming, this);
+            }
+
+            public AsyncUnit Current => default;
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                // return false instead of throw
+                if (disposed || cancellationToken.IsCancellationRequested) return CompletedTasks.False;
+
+                completionSource.Reset();
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            public UniTask DisposeAsync()
+            {
+                if (!disposed)
+                {
+                    disposed = true;
+                    TaskTracker.RemoveTracking(this);
+                }
+                return default;
+            }
+
+            public bool MoveNext()
+            {
+                if (disposed || cancellationToken.IsCancellationRequested)
+                {
+                    completionSource.TrySetResult(false);
+                    return false;
+                }
+
+                completionSource.TrySetResult(true);
+                return true;
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/UnityExtensions/EveryUpdate.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/UnityExtensions/EveryUpdate.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 00520eb52e49b5b4e8d9870d6ff1aced
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/UnityExtensions/EveryValueChanged.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/UnityExtensions/EveryValueChanged.cs
@@ -1,0 +1,240 @@
+﻿using Cysharp.Threading.Tasks.Internal;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static IUniTaskAsyncEnumerable<TProperty> EveryValueChanged<TTarget, TProperty>(TTarget target, Func<TTarget, TProperty> propertySelector, PlayerLoopTiming monitorTiming = PlayerLoopTiming.Update, IEqualityComparer<TProperty> equalityComparer = null)
+            where TTarget : class
+        {
+            var unityObject = target as UnityEngine.Object;
+            var isUnityObject = target is UnityEngine.Object; // don't use (unityObject == null)
+
+            if (isUnityObject)
+            {
+                return new EveryValueChangedUnityObject<TTarget, TProperty>(target, propertySelector, equalityComparer ?? UnityEqualityComparer.GetDefault<TProperty>(), monitorTiming);
+            }
+            else
+            {
+                return new EveryValueChangedStandardObject<TTarget, TProperty>(target, propertySelector, equalityComparer ?? UnityEqualityComparer.GetDefault<TProperty>(), monitorTiming);
+            }
+        }
+    }
+
+    internal sealed class EveryValueChangedUnityObject<TTarget, TProperty> : IUniTaskAsyncEnumerable<TProperty>
+    {
+        readonly TTarget target;
+        readonly Func<TTarget, TProperty> propertySelector;
+        readonly IEqualityComparer<TProperty> equalityComparer;
+        readonly PlayerLoopTiming monitorTiming;
+
+        public EveryValueChangedUnityObject(TTarget target, Func<TTarget, TProperty> propertySelector, IEqualityComparer<TProperty> equalityComparer, PlayerLoopTiming monitorTiming)
+        {
+            this.target = target;
+            this.propertySelector = propertySelector;
+            this.equalityComparer = equalityComparer;
+            this.monitorTiming = monitorTiming;
+        }
+
+        public IUniTaskAsyncEnumerator<TProperty> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _EveryValueChanged(target, propertySelector, equalityComparer, monitorTiming, cancellationToken);
+        }
+
+        sealed class _EveryValueChanged : MoveNextSource, IUniTaskAsyncEnumerator<TProperty>, IPlayerLoopItem
+        {
+            readonly TTarget target;
+            readonly UnityEngine.Object targetAsUnityObject;
+            readonly IEqualityComparer<TProperty> equalityComparer;
+            readonly Func<TTarget, TProperty> propertySelector;
+            CancellationToken cancellationToken;
+
+            bool first;
+            TProperty currentValue;
+            bool disposed;
+
+            public _EveryValueChanged(TTarget target, Func<TTarget, TProperty> propertySelector, IEqualityComparer<TProperty> equalityComparer, PlayerLoopTiming monitorTiming, CancellationToken cancellationToken)
+            {
+                this.target = target;
+                this.targetAsUnityObject = target as UnityEngine.Object;
+                this.propertySelector = propertySelector;
+                this.equalityComparer = equalityComparer;
+                this.cancellationToken = cancellationToken;
+                this.first = true;
+                TaskTracker.TrackActiveTask(this, 2);
+                PlayerLoopHelper.AddAction(monitorTiming, this);
+            }
+
+            public TProperty Current => currentValue;
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                // return false instead of throw
+                if (disposed || cancellationToken.IsCancellationRequested) return CompletedTasks.False;
+
+                if (first)
+                {
+                    first = false;
+                    if (targetAsUnityObject == null)
+                    {
+                        return CompletedTasks.False;
+                    }
+                    this.currentValue = propertySelector(target);
+                    return CompletedTasks.True;
+                }
+
+                completionSource.Reset();
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            public UniTask DisposeAsync()
+            {
+                if (!disposed)
+                {
+                    disposed = true;
+                    TaskTracker.RemoveTracking(this);
+                }
+                return default;
+            }
+
+            public bool MoveNext()
+            {
+                if (disposed || cancellationToken.IsCancellationRequested || targetAsUnityObject == null) // destroyed = cancel.
+                {
+                    completionSource.TrySetResult(false);
+                    DisposeAsync().Forget();
+                    return false;
+                }
+
+                TProperty nextValue = default(TProperty);
+                try
+                {
+                    nextValue = propertySelector(target);
+                    if (equalityComparer.Equals(currentValue, nextValue))
+                    {
+                        return true;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    completionSource.TrySetException(ex);
+                    DisposeAsync().Forget();
+                    return false;
+                }
+
+                currentValue = nextValue;
+                completionSource.TrySetResult(true);
+                return true;
+            }
+        }
+    }
+
+    internal sealed class EveryValueChangedStandardObject<TTarget, TProperty> : IUniTaskAsyncEnumerable<TProperty>
+        where TTarget : class
+    {
+        readonly WeakReference<TTarget> target;
+        readonly Func<TTarget, TProperty> propertySelector;
+        readonly IEqualityComparer<TProperty> equalityComparer;
+        readonly PlayerLoopTiming monitorTiming;
+
+        public EveryValueChangedStandardObject(TTarget target, Func<TTarget, TProperty> propertySelector, IEqualityComparer<TProperty> equalityComparer, PlayerLoopTiming monitorTiming)
+        {
+            this.target = new WeakReference<TTarget>(target, false);
+            this.propertySelector = propertySelector;
+            this.equalityComparer = equalityComparer;
+            this.monitorTiming = monitorTiming;
+        }
+
+        public IUniTaskAsyncEnumerator<TProperty> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _EveryValueChanged(target, propertySelector, equalityComparer, monitorTiming, cancellationToken);
+        }
+
+        sealed class _EveryValueChanged : MoveNextSource, IUniTaskAsyncEnumerator<TProperty>, IPlayerLoopItem
+        {
+            readonly WeakReference<TTarget> target;
+            readonly IEqualityComparer<TProperty> equalityComparer;
+            readonly Func<TTarget, TProperty> propertySelector;
+            CancellationToken cancellationToken;
+
+            bool first;
+            TProperty currentValue;
+            bool disposed;
+
+            public _EveryValueChanged(WeakReference<TTarget> target, Func<TTarget, TProperty> propertySelector, IEqualityComparer<TProperty> equalityComparer, PlayerLoopTiming monitorTiming, CancellationToken cancellationToken)
+            {
+                this.target = target;
+                this.propertySelector = propertySelector;
+                this.equalityComparer = equalityComparer;
+                this.cancellationToken = cancellationToken;
+                this.first = true;
+                TaskTracker.TrackActiveTask(this, 2);
+                PlayerLoopHelper.AddAction(monitorTiming, this);
+            }
+
+            public TProperty Current => currentValue;
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                if (disposed || cancellationToken.IsCancellationRequested) return CompletedTasks.False;
+
+                if (first)
+                {
+                    first = false;
+                    if (!target.TryGetTarget(out var t))
+                    {
+                        return CompletedTasks.False;
+                    }
+                    this.currentValue = propertySelector(t);
+                    return CompletedTasks.True;
+                }
+
+                completionSource.Reset();
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            public UniTask DisposeAsync()
+            {
+                if (!disposed)
+                {
+                    disposed = true;
+                    TaskTracker.RemoveTracking(this);
+                }
+                return default;
+            }
+
+            public bool MoveNext()
+            {
+                if (disposed || cancellationToken.IsCancellationRequested || !target.TryGetTarget(out var t))
+                {
+                    completionSource.TrySetResult(false);
+                    DisposeAsync().Forget();
+                    return false;
+                }
+
+                TProperty nextValue = default(TProperty);
+                try
+                {
+                    nextValue = propertySelector(t);
+                    if (equalityComparer.Equals(currentValue, nextValue))
+                    {
+                        return true;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    completionSource.TrySetException(ex);
+                    DisposeAsync().Forget();
+                    return false;
+                }
+
+                currentValue = nextValue;
+                completionSource.TrySetResult(true);
+                return true;
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/UnityExtensions/EveryValueChanged.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/UnityExtensions/EveryValueChanged.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1ec39f1c41c305344854782c935ad354
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/UnityExtensions/Timer.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/UnityExtensions/Timer.cs
@@ -1,0 +1,312 @@
+﻿using System;
+using System.Threading;
+using UnityEngine;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static IUniTaskAsyncEnumerable<AsyncUnit> Timer(TimeSpan dueTime, PlayerLoopTiming updateTiming = PlayerLoopTiming.Update, bool ignoreTimeScale = false)
+        {
+            return new Timer(dueTime, null, updateTiming, ignoreTimeScale);
+        }
+
+        public static IUniTaskAsyncEnumerable<AsyncUnit> Timer(TimeSpan dueTime, TimeSpan period, PlayerLoopTiming updateTiming = PlayerLoopTiming.Update, bool ignoreTimeScale = false)
+        {
+            return new Timer(dueTime, period, updateTiming, ignoreTimeScale);
+        }
+
+        public static IUniTaskAsyncEnumerable<AsyncUnit> Interval(TimeSpan period, PlayerLoopTiming updateTiming = PlayerLoopTiming.Update, bool ignoreTimeScale = false)
+        {
+            return new Timer(period, period, updateTiming, ignoreTimeScale);
+        }
+
+        public static IUniTaskAsyncEnumerable<AsyncUnit> TimerFrame(int dueTimeFrameCount, PlayerLoopTiming updateTiming = PlayerLoopTiming.Update)
+        {
+            if (dueTimeFrameCount < 0)
+            {
+                throw new ArgumentOutOfRangeException("Delay does not allow minus delayFrameCount. dueTimeFrameCount:" + dueTimeFrameCount);
+            }
+
+            return new TimerFrame(dueTimeFrameCount, null, updateTiming);
+        }
+
+        public static IUniTaskAsyncEnumerable<AsyncUnit> TimerFrame(int dueTimeFrameCount, int periodFrameCount, PlayerLoopTiming updateTiming = PlayerLoopTiming.Update)
+        {
+            if (dueTimeFrameCount < 0)
+            {
+                throw new ArgumentOutOfRangeException("Delay does not allow minus delayFrameCount. dueTimeFrameCount:" + dueTimeFrameCount);
+            }
+            if (periodFrameCount < 0)
+            {
+                throw new ArgumentOutOfRangeException("Delay does not allow minus periodFrameCount. periodFrameCount:" + dueTimeFrameCount);
+            }
+
+            return new TimerFrame(dueTimeFrameCount, periodFrameCount, updateTiming);
+        }
+
+        public static IUniTaskAsyncEnumerable<AsyncUnit> IntervalFrame(int intervalFrameCount, PlayerLoopTiming updateTiming = PlayerLoopTiming.Update)
+        {
+            if (intervalFrameCount < 0)
+            {
+                throw new ArgumentOutOfRangeException("Delay does not allow minus intervalFrameCount. intervalFrameCount:" + intervalFrameCount);
+            }
+            return new TimerFrame(intervalFrameCount, intervalFrameCount, updateTiming);
+        }
+    }
+
+    internal class Timer : IUniTaskAsyncEnumerable<AsyncUnit>
+    {
+        readonly PlayerLoopTiming updateTiming;
+        readonly TimeSpan dueTime;
+        readonly TimeSpan? period;
+        readonly bool ignoreTimeScale;
+
+        public Timer(TimeSpan dueTime, TimeSpan? period, PlayerLoopTiming updateTiming, bool ignoreTimeScale)
+        {
+            this.updateTiming = updateTiming;
+            this.dueTime = dueTime;
+            this.period = period;
+            this.ignoreTimeScale = ignoreTimeScale;
+        }
+
+        public IUniTaskAsyncEnumerator<AsyncUnit> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _Timer(dueTime, period, updateTiming, ignoreTimeScale, cancellationToken);
+        }
+
+        class _Timer : MoveNextSource, IUniTaskAsyncEnumerator<AsyncUnit>, IPlayerLoopItem
+        {
+            readonly float dueTime;
+            readonly float? period;
+            readonly PlayerLoopTiming updateTiming;
+            readonly bool ignoreTimeScale;
+            CancellationToken cancellationToken;
+
+            int initialFrame;
+            float elapsed;
+            bool dueTimePhase;
+            bool completed;
+            bool disposed;
+
+            public _Timer(TimeSpan dueTime, TimeSpan? period, PlayerLoopTiming updateTiming, bool ignoreTimeScale, CancellationToken cancellationToken)
+            {
+                this.dueTime = (float)dueTime.TotalSeconds;
+                this.period = (period == null) ? null : (float?)period.Value.TotalSeconds;
+
+                if (this.dueTime <= 0) this.dueTime = 0;
+                if (this.period != null)
+                {
+                    if (this.period <= 0) this.period = 1;
+                }
+
+                this.initialFrame = PlayerLoopHelper.IsMainThread ? Time.frameCount : -1;
+                this.dueTimePhase = true;
+                this.updateTiming = updateTiming;
+                this.ignoreTimeScale = ignoreTimeScale;
+                this.cancellationToken = cancellationToken;
+                TaskTracker.TrackActiveTask(this, 2);
+                PlayerLoopHelper.AddAction(updateTiming, this);
+            }
+
+            public AsyncUnit Current => default;
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                // return false instead of throw
+                if (disposed || cancellationToken.IsCancellationRequested || completed) return CompletedTasks.False;
+
+                // reset value here.
+                this.elapsed = 0;
+
+                completionSource.Reset();
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            public UniTask DisposeAsync()
+            {
+                if (!disposed)
+                {
+                    disposed = true;
+                    TaskTracker.RemoveTracking(this);
+                }
+                return default;
+            }
+
+            public bool MoveNext()
+            {
+                if (disposed || cancellationToken.IsCancellationRequested)
+                {
+                    completionSource.TrySetResult(false);
+                    return false;
+                }
+
+                if (dueTimePhase)
+                {
+                    if (elapsed == 0)
+                    {
+                        // skip in initial frame.
+                        if (initialFrame == Time.frameCount)
+                        {
+                            return true;
+                        }
+                    }
+
+                    elapsed += (ignoreTimeScale) ? UnityEngine.Time.unscaledDeltaTime : UnityEngine.Time.deltaTime;
+
+                    if (elapsed >= dueTime)
+                    {
+                        dueTimePhase = false;
+                        completionSource.TrySetResult(true);
+                    }
+                }
+                else
+                {
+                    if (period == null)
+                    {
+                        completed = true;
+                        completionSource.TrySetResult(false);
+                        return false;
+                    }
+
+                    elapsed += (ignoreTimeScale) ? UnityEngine.Time.unscaledDeltaTime : UnityEngine.Time.deltaTime;
+
+                    if (elapsed >= period)
+                    {
+                        completionSource.TrySetResult(true);
+                    }
+                }
+
+                return true;
+            }
+        }
+    }
+
+    internal class TimerFrame : IUniTaskAsyncEnumerable<AsyncUnit>
+    {
+        readonly PlayerLoopTiming updateTiming;
+        readonly int dueTimeFrameCount;
+        readonly int? periodFrameCount;
+
+        public TimerFrame(int dueTimeFrameCount, int? periodFrameCount, PlayerLoopTiming updateTiming)
+        {
+            this.updateTiming = updateTiming;
+            this.dueTimeFrameCount = dueTimeFrameCount;
+            this.periodFrameCount = periodFrameCount;
+        }
+
+        public IUniTaskAsyncEnumerator<AsyncUnit> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _TimerFrame(dueTimeFrameCount, periodFrameCount, updateTiming, cancellationToken);
+        }
+
+        class _TimerFrame : MoveNextSource, IUniTaskAsyncEnumerator<AsyncUnit>, IPlayerLoopItem
+        {
+            readonly int dueTimeFrameCount;
+            readonly int? periodFrameCount;
+            CancellationToken cancellationToken;
+
+            int initialFrame;
+            int currentFrame;
+            bool dueTimePhase;
+            bool completed;
+            bool disposed;
+
+            public _TimerFrame(int dueTimeFrameCount, int? periodFrameCount, PlayerLoopTiming updateTiming, CancellationToken cancellationToken)
+            {
+                if (dueTimeFrameCount <= 0) dueTimeFrameCount = 0;
+                if (periodFrameCount != null)
+                {
+                    if (periodFrameCount <= 0) periodFrameCount = 1;
+                }
+
+                this.initialFrame = PlayerLoopHelper.IsMainThread ? Time.frameCount : -1;
+                this.dueTimePhase = true;
+                this.dueTimeFrameCount = dueTimeFrameCount;
+                this.periodFrameCount = periodFrameCount;
+                this.cancellationToken = cancellationToken;
+
+                TaskTracker.TrackActiveTask(this, 2);
+                PlayerLoopHelper.AddAction(updateTiming, this);
+            }
+
+            public AsyncUnit Current => default;
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                // return false instead of throw
+                if (disposed || cancellationToken.IsCancellationRequested || completed) return CompletedTasks.False;
+
+
+                // reset value here.
+                this.currentFrame = 0;
+
+                completionSource.Reset();
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            public UniTask DisposeAsync()
+            {
+                if (!disposed)
+                {
+                    disposed = true;
+                    TaskTracker.RemoveTracking(this);
+                }
+                return default;
+            }
+
+            public bool MoveNext()
+            {
+                if (disposed || cancellationToken.IsCancellationRequested)
+                {
+                    completionSource.TrySetResult(false);
+                    return false;
+                }
+
+                if (dueTimePhase)
+                {
+                    if (currentFrame == 0)
+                    {
+                        if (dueTimeFrameCount == 0)
+                        {
+                            dueTimePhase = false;
+                            completionSource.TrySetResult(true);
+                            return true;
+                        }
+
+                        // skip in initial frame.
+                        if (initialFrame == Time.frameCount)
+                        {
+                            return true;
+                        }
+                    }
+
+                    if (++currentFrame >= dueTimeFrameCount)
+                    {
+                        dueTimePhase = false;
+                        completionSource.TrySetResult(true);
+                    }
+                    else
+                    {
+                    }
+                }
+                else
+                {
+                    if (periodFrameCount == null)
+                    {
+                        completed = true;
+                        completionSource.TrySetResult(false);
+                        return false;
+                    }
+
+                    if (++currentFrame >= periodFrameCount)
+                    {
+                        completionSource.TrySetResult(true);
+                    }
+                }
+
+                return true;
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/UnityExtensions/Timer.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/UnityExtensions/Timer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 382caacde439855418709c641e4d7b04
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Where.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Where.cs
@@ -1,0 +1,818 @@
+﻿using Cysharp.Threading.Tasks.Internal;
+using System;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+        public static IUniTaskAsyncEnumerable<TSource> Where<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Boolean> predicate)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(predicate, nameof(predicate));
+
+            return new Where<TSource>(source, predicate);
+        }
+
+        public static IUniTaskAsyncEnumerable<TSource> Where<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Int32, Boolean> predicate)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(predicate, nameof(predicate));
+
+            return new WhereInt<TSource>(source, predicate);
+        }
+
+        public static IUniTaskAsyncEnumerable<TSource> WhereAwait<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<Boolean>> predicate)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(predicate, nameof(predicate));
+
+            return new WhereAwait<TSource>(source, predicate);
+        }
+
+        public static IUniTaskAsyncEnumerable<TSource> WhereAwait<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Int32, UniTask<Boolean>> predicate)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(predicate, nameof(predicate));
+
+            return new WhereIntAwait<TSource>(source, predicate);
+        }
+
+        public static IUniTaskAsyncEnumerable<TSource> WhereAwaitWithCancellation<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<Boolean>> predicate)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(predicate, nameof(predicate));
+
+            return new WhereAwaitWithCancellation<TSource>(source, predicate);
+        }
+
+        public static IUniTaskAsyncEnumerable<TSource> WhereAwaitWithCancellation<TSource>(this IUniTaskAsyncEnumerable<TSource> source, Func<TSource, Int32, CancellationToken, UniTask<Boolean>> predicate)
+        {
+            Error.ThrowArgumentNullException(source, nameof(source));
+            Error.ThrowArgumentNullException(predicate, nameof(predicate));
+
+            return new WhereIntAwaitWithCancellation<TSource>(source, predicate);
+        }
+    }
+
+    internal sealed class Where<TSource> : IUniTaskAsyncEnumerable<TSource>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+        readonly Func<TSource, bool> predicate;
+
+        public Where(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, bool> predicate)
+        {
+            this.source = source;
+            this.predicate = predicate;
+        }
+
+        public IUniTaskAsyncEnumerator<TSource> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _Where(source, predicate, cancellationToken);
+        }
+
+        sealed class _Where : MoveNextSource, IUniTaskAsyncEnumerator<TSource>
+        {
+            readonly IUniTaskAsyncEnumerable<TSource> source;
+            readonly Func<TSource, bool> predicate;
+            readonly CancellationToken cancellationToken;
+
+            int state = -1;
+            IUniTaskAsyncEnumerator<TSource> enumerator;
+            UniTask<bool>.Awaiter awaiter;
+            Action moveNextAction;
+
+            public _Where(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, bool> predicate, CancellationToken cancellationToken)
+            {
+                this.source = source;
+                this.predicate = predicate;
+                this.cancellationToken = cancellationToken;
+                this.moveNextAction = MoveNext;
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public TSource Current { get; private set; }
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                if (state == -2) return default;
+
+                completionSource.Reset();
+                MoveNext();
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            void MoveNext()
+            {
+                REPEAT:
+                try
+                {
+                    switch (state)
+                    {
+                        case -1: // init
+                            enumerator = source.GetAsyncEnumerator(cancellationToken);
+                            goto case 0;
+                        case 0:
+                            awaiter = enumerator.MoveNextAsync().GetAwaiter();
+                            if (awaiter.IsCompleted)
+                            {
+                                goto case 1;
+                            }
+                            else
+                            {
+                                state = 1;
+                                awaiter.UnsafeOnCompleted(moveNextAction);
+                                return;
+                            }
+                        case 1:
+                            if (awaiter.GetResult())
+                            {
+                                Current = enumerator.Current;
+                                if (predicate(Current))
+                                {
+                                    goto CONTINUE;
+                                }
+                                else
+                                {
+                                    state = 0;
+                                    goto REPEAT;
+                                }
+                            }
+                            else
+                            {
+                                goto DONE;
+                            }
+                        default:
+                            goto DONE;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    state = -2;
+                    completionSource.TrySetException(ex);
+                    return;
+                }
+
+                DONE:
+                state = -2;
+                completionSource.TrySetResult(false);
+                return;
+
+                CONTINUE:
+                state = 0;
+                completionSource.TrySetResult(true);
+                return;
+            }
+
+            public UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                return enumerator.DisposeAsync();
+            }
+        }
+    }
+
+    internal sealed class WhereInt<TSource> : IUniTaskAsyncEnumerable<TSource>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+        readonly Func<TSource, int, bool> predicate;
+
+        public WhereInt(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, int, bool> predicate)
+        {
+            this.source = source;
+            this.predicate = predicate;
+        }
+
+        public IUniTaskAsyncEnumerator<TSource> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _Where(source, predicate, cancellationToken);
+        }
+
+        sealed class _Where : MoveNextSource, IUniTaskAsyncEnumerator<TSource>
+        {
+            readonly IUniTaskAsyncEnumerable<TSource> source;
+            readonly Func<TSource, int, bool> predicate;
+            readonly CancellationToken cancellationToken;
+
+            int state = -1;
+            IUniTaskAsyncEnumerator<TSource> enumerator;
+            UniTask<bool>.Awaiter awaiter;
+            Action moveNextAction;
+            int index;
+
+            public _Where(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, int, bool> predicate, CancellationToken cancellationToken)
+            {
+                this.source = source;
+                this.predicate = predicate;
+                this.cancellationToken = cancellationToken;
+                this.moveNextAction = MoveNext;
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public TSource Current { get; private set; }
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                if (state == -2) return default;
+
+                completionSource.Reset();
+                MoveNext();
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            void MoveNext()
+            {
+                REPEAT:
+                try
+                {
+                    switch (state)
+                    {
+                        case -1: // init
+                            enumerator = source.GetAsyncEnumerator(cancellationToken);
+                            goto case 0;
+                        case 0:
+                            awaiter = enumerator.MoveNextAsync().GetAwaiter();
+                            if (awaiter.IsCompleted)
+                            {
+                                goto case 1;
+                            }
+                            else
+                            {
+                                state = 1;
+                                awaiter.UnsafeOnCompleted(moveNextAction);
+                                return;
+                            }
+                        case 1:
+                            if (awaiter.GetResult())
+                            {
+                                Current = enumerator.Current;
+                                if (predicate(Current, checked(index++)))
+                                {
+                                    goto CONTINUE;
+                                }
+                                else
+                                {
+                                    state = 0;
+                                    goto REPEAT;
+                                }
+                            }
+                            else
+                            {
+                                goto DONE;
+                            }
+                        default:
+                            goto DONE;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    state = -2;
+                    completionSource.TrySetException(ex);
+                    return;
+                }
+
+                DONE:
+                state = -2;
+                completionSource.TrySetResult(false);
+                return;
+
+                CONTINUE:
+                state = 0;
+                completionSource.TrySetResult(true);
+                return;
+            }
+
+            public UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                return enumerator.DisposeAsync();
+            }
+        }
+    }
+
+    internal sealed class WhereAwait<TSource> : IUniTaskAsyncEnumerable<TSource>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+        readonly Func<TSource, UniTask<bool>> predicate;
+
+        public WhereAwait(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<bool>> predicate)
+        {
+            this.source = source;
+            this.predicate = predicate;
+        }
+
+        public IUniTaskAsyncEnumerator<TSource> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _WhereAwait(source, predicate, cancellationToken);
+        }
+
+        sealed class _WhereAwait : MoveNextSource, IUniTaskAsyncEnumerator<TSource>
+        {
+            readonly IUniTaskAsyncEnumerable<TSource> source;
+            readonly Func<TSource, UniTask<bool>> predicate;
+            readonly CancellationToken cancellationToken;
+
+            int state = -1;
+            IUniTaskAsyncEnumerator<TSource> enumerator;
+            UniTask<bool>.Awaiter awaiter;
+            UniTask<bool>.Awaiter awaiter2;
+            Action moveNextAction;
+
+            public _WhereAwait(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, UniTask<bool>> predicate, CancellationToken cancellationToken)
+            {
+                this.source = source;
+                this.predicate = predicate;
+                this.cancellationToken = cancellationToken;
+                this.moveNextAction = MoveNext;
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public TSource Current { get; private set; }
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                if (state == -2) return default;
+
+                completionSource.Reset();
+                MoveNext();
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            void MoveNext()
+            {
+                REPEAT:
+                try
+                {
+                    switch (state)
+                    {
+                        case -1: // init
+                            enumerator = source.GetAsyncEnumerator(cancellationToken);
+                            goto case 0;
+                        case 0:
+                            awaiter = enumerator.MoveNextAsync().GetAwaiter();
+                            if (awaiter.IsCompleted)
+                            {
+                                goto case 1;
+                            }
+                            else
+                            {
+                                state = 1;
+                                awaiter.UnsafeOnCompleted(moveNextAction);
+                                return;
+                            }
+                        case 1:
+                            if (awaiter.GetResult())
+                            {
+                                Current = enumerator.Current;
+
+                                awaiter2 = predicate(Current).GetAwaiter();
+                                if (awaiter2.IsCompleted)
+                                {
+                                    goto case 2;
+                                }
+                                else
+                                {
+                                    state = 2;
+                                    awaiter2.UnsafeOnCompleted(moveNextAction);
+                                    return;
+                                }
+                            }
+                            else
+                            {
+                                goto DONE;
+                            }
+                        case 2:
+                            if (awaiter2.GetResult())
+                            {
+                                goto CONTINUE;
+                            }
+                            else
+                            {
+                                state = 0;
+                                goto REPEAT;
+                            }
+                        default:
+                            goto DONE;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    state = -2;
+                    completionSource.TrySetException(ex);
+                    return;
+                }
+
+                DONE:
+                state = -2;
+                completionSource.TrySetResult(false);
+                return;
+
+                CONTINUE:
+                state = 0;
+                completionSource.TrySetResult(true);
+                return;
+            }
+
+            public UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                return enumerator.DisposeAsync();
+            }
+        }
+    }
+
+    internal sealed class WhereIntAwait<TSource> : IUniTaskAsyncEnumerable<TSource>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+        readonly Func<TSource, int, UniTask<bool>> predicate;
+
+        public WhereIntAwait(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, int, UniTask<bool>> predicate)
+        {
+            this.source = source;
+            this.predicate = predicate;
+        }
+
+        public IUniTaskAsyncEnumerator<TSource> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _WhereAwait(source, predicate, cancellationToken);
+        }
+
+        sealed class _WhereAwait : MoveNextSource, IUniTaskAsyncEnumerator<TSource>
+        {
+            readonly IUniTaskAsyncEnumerable<TSource> source;
+            readonly Func<TSource, int, UniTask<bool>> predicate;
+            readonly CancellationToken cancellationToken;
+
+            int state = -1;
+            IUniTaskAsyncEnumerator<TSource> enumerator;
+            UniTask<bool>.Awaiter awaiter;
+            UniTask<bool>.Awaiter awaiter2;
+            Action moveNextAction;
+            int index;
+
+            public _WhereAwait(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, int, UniTask<bool>> predicate, CancellationToken cancellationToken)
+            {
+                this.source = source;
+                this.predicate = predicate;
+                this.cancellationToken = cancellationToken;
+                this.moveNextAction = MoveNext;
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public TSource Current { get; private set; }
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                if (state == -2) return default;
+
+                completionSource.Reset();
+                MoveNext();
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            void MoveNext()
+            {
+                REPEAT:
+                try
+                {
+                    switch (state)
+                    {
+                        case -1: // init
+                            enumerator = source.GetAsyncEnumerator(cancellationToken);
+                            goto case 0;
+                        case 0:
+                            awaiter = enumerator.MoveNextAsync().GetAwaiter();
+                            if (awaiter.IsCompleted)
+                            {
+                                goto case 1;
+                            }
+                            else
+                            {
+                                state = 1;
+                                awaiter.UnsafeOnCompleted(moveNextAction);
+                                return;
+                            }
+                        case 1:
+                            if (awaiter.GetResult())
+                            {
+                                Current = enumerator.Current;
+
+                                awaiter2 = predicate(Current, checked(index++)).GetAwaiter();
+                                if (awaiter2.IsCompleted)
+                                {
+                                    goto case 2;
+                                }
+                                else
+                                {
+                                    state = 2;
+                                    awaiter2.UnsafeOnCompleted(moveNextAction);
+                                    return;
+                                }
+                            }
+                            else
+                            {
+                                goto DONE;
+                            }
+                        case 2:
+                            if (awaiter2.GetResult())
+                            {
+                                goto CONTINUE;
+                            }
+                            else
+                            {
+                                state = 0;
+                                goto REPEAT;
+                            }
+                        default:
+                            goto DONE;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    state = -2;
+                    completionSource.TrySetException(ex);
+                    return;
+                }
+
+                DONE:
+                state = -2;
+                completionSource.TrySetResult(false);
+                return;
+
+                CONTINUE:
+                state = 0;
+                completionSource.TrySetResult(true);
+                return;
+            }
+
+            public UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                return enumerator.DisposeAsync();
+            }
+        }
+    }
+
+    internal sealed class WhereAwaitWithCancellation<TSource> : IUniTaskAsyncEnumerable<TSource>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+        readonly Func<TSource, CancellationToken, UniTask<bool>> predicate;
+
+        public WhereAwaitWithCancellation(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<bool>> predicate)
+        {
+            this.source = source;
+            this.predicate = predicate;
+        }
+
+        public IUniTaskAsyncEnumerator<TSource> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _WhereAwaitWithCancellation(source, predicate, cancellationToken);
+        }
+
+        sealed class _WhereAwaitWithCancellation : MoveNextSource, IUniTaskAsyncEnumerator<TSource>
+        {
+            readonly IUniTaskAsyncEnumerable<TSource> source;
+            readonly Func<TSource, CancellationToken, UniTask<bool>> predicate;
+            readonly CancellationToken cancellationToken;
+
+            int state = -1;
+            IUniTaskAsyncEnumerator<TSource> enumerator;
+            UniTask<bool>.Awaiter awaiter;
+            UniTask<bool>.Awaiter awaiter2;
+            Action moveNextAction;
+
+            public _WhereAwaitWithCancellation(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, UniTask<bool>> predicate, CancellationToken cancellationToken)
+            {
+                this.source = source;
+                this.predicate = predicate;
+                this.cancellationToken = cancellationToken;
+                this.moveNextAction = MoveNext;
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public TSource Current { get; private set; }
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                if (state == -2) return default;
+
+                completionSource.Reset();
+                MoveNext();
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            void MoveNext()
+            {
+                REPEAT:
+                try
+                {
+                    switch (state)
+                    {
+                        case -1: // init
+                            enumerator = source.GetAsyncEnumerator(cancellationToken);
+                            goto case 0;
+                        case 0:
+                            awaiter = enumerator.MoveNextAsync().GetAwaiter();
+                            if (awaiter.IsCompleted)
+                            {
+                                goto case 1;
+                            }
+                            else
+                            {
+                                state = 1;
+                                awaiter.UnsafeOnCompleted(moveNextAction);
+                                return;
+                            }
+                        case 1:
+                            if (awaiter.GetResult())
+                            {
+                                Current = enumerator.Current;
+
+                                awaiter2 = predicate(Current, cancellationToken).GetAwaiter();
+                                if (awaiter2.IsCompleted)
+                                {
+                                    goto case 2;
+                                }
+                                else
+                                {
+                                    state = 2;
+                                    awaiter2.UnsafeOnCompleted(moveNextAction);
+                                    return;
+                                }
+                            }
+                            else
+                            {
+                                goto DONE;
+                            }
+                        case 2:
+                            if (awaiter2.GetResult())
+                            {
+                                goto CONTINUE;
+                            }
+                            else
+                            {
+                                state = 0;
+                                goto REPEAT;
+                            }
+                        default:
+                            goto DONE;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    state = -2;
+                    completionSource.TrySetException(ex);
+                    return;
+                }
+
+                DONE:
+                state = -2;
+                completionSource.TrySetResult(false);
+                return;
+
+                CONTINUE:
+                state = 0;
+                completionSource.TrySetResult(true);
+                return;
+            }
+
+            public UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                return enumerator.DisposeAsync();
+            }
+        }
+    }
+
+    internal sealed class WhereIntAwaitWithCancellation<TSource> : IUniTaskAsyncEnumerable<TSource>
+    {
+        readonly IUniTaskAsyncEnumerable<TSource> source;
+        readonly Func<TSource, int, CancellationToken, UniTask<bool>> predicate;
+
+        public WhereIntAwaitWithCancellation(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, int, CancellationToken, UniTask<bool>> predicate)
+        {
+            this.source = source;
+            this.predicate = predicate;
+        }
+
+        public IUniTaskAsyncEnumerator<TSource> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _WhereAwaitWithCancellation(source, predicate, cancellationToken);
+        }
+
+        sealed class _WhereAwaitWithCancellation : MoveNextSource, IUniTaskAsyncEnumerator<TSource>
+        {
+            readonly IUniTaskAsyncEnumerable<TSource> source;
+            readonly Func<TSource, int, CancellationToken, UniTask<bool>> predicate;
+            readonly CancellationToken cancellationToken;
+
+            int state = -1;
+            IUniTaskAsyncEnumerator<TSource> enumerator;
+            UniTask<bool>.Awaiter awaiter;
+            UniTask<bool>.Awaiter awaiter2;
+            Action moveNextAction;
+            int index;
+
+            public _WhereAwaitWithCancellation(IUniTaskAsyncEnumerable<TSource> source, Func<TSource, int, CancellationToken, UniTask<bool>> predicate, CancellationToken cancellationToken)
+            {
+                this.source = source;
+                this.predicate = predicate;
+                this.cancellationToken = cancellationToken;
+                this.moveNextAction = MoveNext;
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public TSource Current { get; private set; }
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                if (state == -2) return default;
+
+                completionSource.Reset();
+                MoveNext();
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            void MoveNext()
+            {
+                REPEAT:
+                try
+                {
+                    switch (state)
+                    {
+                        case -1: // init
+                            enumerator = source.GetAsyncEnumerator(cancellationToken);
+                            goto case 0;
+                        case 0:
+                            awaiter = enumerator.MoveNextAsync().GetAwaiter();
+                            if (awaiter.IsCompleted)
+                            {
+                                goto case 1;
+                            }
+                            else
+                            {
+                                state = 1;
+                                awaiter.UnsafeOnCompleted(moveNextAction);
+                                return;
+                            }
+                        case 1:
+                            if (awaiter.GetResult())
+                            {
+                                Current = enumerator.Current;
+
+                                awaiter2 = predicate(Current, checked(index++), cancellationToken).GetAwaiter();
+                                if (awaiter2.IsCompleted)
+                                {
+                                    goto case 2;
+                                }
+                                else
+                                {
+                                    state = 2;
+                                    awaiter2.UnsafeOnCompleted(moveNextAction);
+                                    return;
+                                }
+                            }
+                            else
+                            {
+                                goto DONE;
+                            }
+                        case 2:
+                            if (awaiter2.GetResult())
+                            {
+                                goto CONTINUE;
+                            }
+                            else
+                            {
+                                state = 0;
+                                goto REPEAT;
+                            }
+                        default:
+                            goto DONE;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    state = -2;
+                    completionSource.TrySetException(ex);
+                    return;
+                }
+
+                DONE:
+                state = -2;
+                completionSource.TrySetResult(false);
+                return;
+
+                CONTINUE:
+                state = 0;
+                completionSource.TrySetResult(true);
+                return;
+            }
+
+            public UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                return enumerator.DisposeAsync();
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Where.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Where.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d882a3238d9535e4e8ce1ad3291eb7fb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Zip.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Zip.cs
@@ -1,0 +1,541 @@
+﻿using Cysharp.Threading.Tasks.Internal;
+using System;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks.Linq
+{
+    public static partial class UniTaskAsyncEnumerable
+    {
+
+        public static IUniTaskAsyncEnumerable<(TFirst First, TSecond Second)> Zip<TFirst, TSecond>(this IUniTaskAsyncEnumerable<TFirst> first, IUniTaskAsyncEnumerable<TSecond> second)
+        {
+            Error.ThrowArgumentNullException(first, nameof(first));
+            Error.ThrowArgumentNullException(second, nameof(second));
+
+            return Zip(first, second, (x, y) => (x, y));
+        }
+
+        public static IUniTaskAsyncEnumerable<TResult> Zip<TFirst, TSecond, TResult>(this IUniTaskAsyncEnumerable<TFirst> first, IUniTaskAsyncEnumerable<TSecond> second, Func<TFirst, TSecond, TResult> resultSelector)
+        {
+            Error.ThrowArgumentNullException(first, nameof(first));
+            Error.ThrowArgumentNullException(second, nameof(second));
+            Error.ThrowArgumentNullException(resultSelector, nameof(resultSelector));
+
+            return new Zip<TFirst, TSecond, TResult>(first, second, resultSelector);
+        }
+
+        public static IUniTaskAsyncEnumerable<TResult> ZipAwait<TFirst, TSecond, TResult>(this IUniTaskAsyncEnumerable<TFirst> first, IUniTaskAsyncEnumerable<TSecond> second, Func<TFirst, TSecond, UniTask<TResult>> selector)
+        {
+            Error.ThrowArgumentNullException(first, nameof(first));
+            Error.ThrowArgumentNullException(second, nameof(second));
+            Error.ThrowArgumentNullException(selector, nameof(selector));
+
+            return new ZipAwait<TFirst, TSecond, TResult>(first, second, selector);
+        }
+
+        public static IUniTaskAsyncEnumerable<TResult> ZipAwaitWithCancellation<TFirst, TSecond, TResult>(this IUniTaskAsyncEnumerable<TFirst> first, IUniTaskAsyncEnumerable<TSecond> second, Func<TFirst, TSecond, CancellationToken, UniTask<TResult>> selector)
+        {
+            Error.ThrowArgumentNullException(first, nameof(first));
+            Error.ThrowArgumentNullException(second, nameof(second));
+            Error.ThrowArgumentNullException(selector, nameof(selector));
+
+            return new ZipAwaitWithCancellation<TFirst, TSecond, TResult>(first, second, selector);
+        }
+    }
+
+    internal sealed class Zip<TFirst, TSecond, TResult> : IUniTaskAsyncEnumerable<TResult>
+    {
+        readonly IUniTaskAsyncEnumerable<TFirst> first;
+        readonly IUniTaskAsyncEnumerable<TSecond> second;
+        readonly Func<TFirst, TSecond, TResult> resultSelector;
+
+        public Zip(IUniTaskAsyncEnumerable<TFirst> first, IUniTaskAsyncEnumerable<TSecond> second, Func<TFirst, TSecond, TResult> resultSelector)
+        {
+            this.first = first;
+            this.second = second;
+            this.resultSelector = resultSelector;
+        }
+
+        public IUniTaskAsyncEnumerator<TResult> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _Zip(first, second, resultSelector, cancellationToken);
+        }
+
+        sealed class _Zip : MoveNextSource, IUniTaskAsyncEnumerator<TResult>
+        {
+            static readonly Action<object> firstMoveNextCoreDelegate = FirstMoveNextCore;
+            static readonly Action<object> secondMoveNextCoreDelegate = SecondMoveNextCore;
+
+            readonly IUniTaskAsyncEnumerable<TFirst> first;
+            readonly IUniTaskAsyncEnumerable<TSecond> second;
+            readonly Func<TFirst, TSecond, TResult> resultSelector;
+
+            CancellationToken cancellationToken;
+
+            IUniTaskAsyncEnumerator<TFirst> firstEnumerator;
+            IUniTaskAsyncEnumerator<TSecond> secondEnumerator;
+
+            UniTask<bool>.Awaiter firstAwaiter;
+            UniTask<bool>.Awaiter secondAwaiter;
+
+            public _Zip(IUniTaskAsyncEnumerable<TFirst> first, IUniTaskAsyncEnumerable<TSecond> second, Func<TFirst, TSecond, TResult> resultSelector, CancellationToken cancellationToken)
+            {
+                this.first = first;
+                this.second = second;
+                this.resultSelector = resultSelector;
+                this.cancellationToken = cancellationToken;
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public TResult Current { get; private set; }
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                completionSource.Reset();
+
+                if (firstEnumerator == null)
+                {
+                    firstEnumerator = first.GetAsyncEnumerator(cancellationToken);
+                    secondEnumerator = second.GetAsyncEnumerator(cancellationToken);
+                }
+
+                firstAwaiter = firstEnumerator.MoveNextAsync().GetAwaiter();
+
+                if (firstAwaiter.IsCompleted)
+                {
+                    FirstMoveNextCore(this);
+                }
+                else
+                {
+                    firstAwaiter.SourceOnCompleted(firstMoveNextCoreDelegate, this);
+                }
+
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            static void FirstMoveNextCore(object state)
+            {
+                var self = (_Zip)state;
+
+                if (self.TryGetResult(self.firstAwaiter, out var result))
+                {
+                    if (result)
+                    {
+                        try
+                        {
+                            self.secondAwaiter = self.secondEnumerator.MoveNextAsync().GetAwaiter();
+                        }
+                        catch (Exception ex)
+                        {
+                            self.completionSource.TrySetException(ex);
+                            return;
+                        }
+
+                        if (self.secondAwaiter.IsCompleted)
+                        {
+                            SecondMoveNextCore(self);
+                        }
+                        else
+                        {
+                            self.secondAwaiter.SourceOnCompleted(secondMoveNextCoreDelegate, self);
+                        }
+                    }
+                    else
+                    {
+                        self.completionSource.TrySetResult(false);
+                    }
+                }
+            }
+
+            static void SecondMoveNextCore(object state)
+            {
+                var self = (_Zip)state;
+
+                if (self.TryGetResult(self.secondAwaiter, out var result))
+                {
+                    if (result)
+                    {
+                        try
+                        {
+                            self.Current = self.resultSelector(self.firstEnumerator.Current, self.secondEnumerator.Current);
+                        }
+                        catch (Exception ex)
+                        {
+                            self.completionSource.TrySetException(ex);
+                        }
+
+                        if (self.cancellationToken.IsCancellationRequested)
+                        {
+                            self.completionSource.TrySetCanceled(self.cancellationToken);
+                        }
+                        else
+                        {
+                            self.completionSource.TrySetResult(true);
+                        }
+                    }
+                    else
+                    {
+                        self.completionSource.TrySetResult(false);
+                    }
+                }
+            }
+
+            public async UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                if (firstEnumerator != null)
+                {
+                    await firstEnumerator.DisposeAsync();
+                }
+                if (secondEnumerator != null)
+                {
+                    await secondEnumerator.DisposeAsync();
+                }
+            }
+        }
+    }
+
+    internal sealed class ZipAwait<TFirst, TSecond, TResult> : IUniTaskAsyncEnumerable<TResult>
+    {
+        readonly IUniTaskAsyncEnumerable<TFirst> first;
+        readonly IUniTaskAsyncEnumerable<TSecond> second;
+        readonly Func<TFirst, TSecond, UniTask<TResult>> resultSelector;
+
+        public ZipAwait(IUniTaskAsyncEnumerable<TFirst> first, IUniTaskAsyncEnumerable<TSecond> second, Func<TFirst, TSecond, UniTask<TResult>> resultSelector)
+        {
+            this.first = first;
+            this.second = second;
+            this.resultSelector = resultSelector;
+        }
+
+        public IUniTaskAsyncEnumerator<TResult> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _ZipAwait(first, second, resultSelector, cancellationToken);
+        }
+
+        sealed class _ZipAwait : MoveNextSource, IUniTaskAsyncEnumerator<TResult>
+        {
+            static readonly Action<object> firstMoveNextCoreDelegate = FirstMoveNextCore;
+            static readonly Action<object> secondMoveNextCoreDelegate = SecondMoveNextCore;
+            static readonly Action<object> resultAwaitCoreDelegate = ResultAwaitCore;
+
+            readonly IUniTaskAsyncEnumerable<TFirst> first;
+            readonly IUniTaskAsyncEnumerable<TSecond> second;
+            readonly Func<TFirst, TSecond, UniTask<TResult>> resultSelector;
+
+            CancellationToken cancellationToken;
+
+            IUniTaskAsyncEnumerator<TFirst> firstEnumerator;
+            IUniTaskAsyncEnumerator<TSecond> secondEnumerator;
+
+            UniTask<bool>.Awaiter firstAwaiter;
+            UniTask<bool>.Awaiter secondAwaiter;
+            UniTask<TResult>.Awaiter resultAwaiter;
+
+            public _ZipAwait(IUniTaskAsyncEnumerable<TFirst> first, IUniTaskAsyncEnumerable<TSecond> second, Func<TFirst, TSecond, UniTask<TResult>> resultSelector, CancellationToken cancellationToken)
+            {
+                this.first = first;
+                this.second = second;
+                this.resultSelector = resultSelector;
+                this.cancellationToken = cancellationToken;
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public TResult Current { get; private set; }
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                completionSource.Reset();
+
+                if (firstEnumerator == null)
+                {
+                    firstEnumerator = first.GetAsyncEnumerator(cancellationToken);
+                    secondEnumerator = second.GetAsyncEnumerator(cancellationToken);
+                }
+
+                firstAwaiter = firstEnumerator.MoveNextAsync().GetAwaiter();
+
+                if (firstAwaiter.IsCompleted)
+                {
+                    FirstMoveNextCore(this);
+                }
+                else
+                {
+                    firstAwaiter.SourceOnCompleted(firstMoveNextCoreDelegate, this);
+                }
+
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            static void FirstMoveNextCore(object state)
+            {
+                var self = (_ZipAwait)state;
+
+                if (self.TryGetResult(self.firstAwaiter, out var result))
+                {
+                    if (result)
+                    {
+                        try
+                        {
+                            self.secondAwaiter = self.secondEnumerator.MoveNextAsync().GetAwaiter();
+                        }
+                        catch (Exception ex)
+                        {
+                            self.completionSource.TrySetException(ex);
+                            return;
+                        }
+
+                        if (self.secondAwaiter.IsCompleted)
+                        {
+                            SecondMoveNextCore(self);
+                        }
+                        else
+                        {
+                            self.secondAwaiter.SourceOnCompleted(secondMoveNextCoreDelegate, self);
+                        }
+                    }
+                    else
+                    {
+                        self.completionSource.TrySetResult(false);
+                    }
+                }
+            }
+
+            static void SecondMoveNextCore(object state)
+            {
+                var self = (_ZipAwait)state;
+
+                if (self.TryGetResult(self.secondAwaiter, out var result))
+                {
+                    if (result)
+                    {
+                        try
+                        {
+                            self.resultAwaiter = self.resultSelector(self.firstEnumerator.Current, self.secondEnumerator.Current).GetAwaiter();
+                            if (self.resultAwaiter.IsCompleted)
+                            {
+                                ResultAwaitCore(self);
+                            }
+                            else
+                            {
+                                self.resultAwaiter.SourceOnCompleted(resultAwaitCoreDelegate, self);
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            self.completionSource.TrySetException(ex);
+                        }
+                    }
+                    else
+                    {
+                        self.completionSource.TrySetResult(false);
+                    }
+                }
+            }
+
+            static void ResultAwaitCore(object state)
+            {
+                var self = (_ZipAwait)state;
+
+                if (self.TryGetResult(self.resultAwaiter, out var result))
+                {
+                    self.Current = result;
+
+                    if (self.cancellationToken.IsCancellationRequested)
+                    {
+                        self.completionSource.TrySetCanceled(self.cancellationToken);
+                    }
+                    else
+                    {
+                        self.completionSource.TrySetResult(true);
+                    }
+                }
+            }
+
+            public async UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                if (firstEnumerator != null)
+                {
+                    await firstEnumerator.DisposeAsync();
+                }
+                if (secondEnumerator != null)
+                {
+                    await secondEnumerator.DisposeAsync();
+                }
+            }
+        }
+    }
+
+    internal sealed class ZipAwaitWithCancellation<TFirst, TSecond, TResult> : IUniTaskAsyncEnumerable<TResult>
+    {
+        readonly IUniTaskAsyncEnumerable<TFirst> first;
+        readonly IUniTaskAsyncEnumerable<TSecond> second;
+        readonly Func<TFirst, TSecond, CancellationToken, UniTask<TResult>> resultSelector;
+
+        public ZipAwaitWithCancellation(IUniTaskAsyncEnumerable<TFirst> first, IUniTaskAsyncEnumerable<TSecond> second, Func<TFirst, TSecond, CancellationToken, UniTask<TResult>> resultSelector)
+        {
+            this.first = first;
+            this.second = second;
+            this.resultSelector = resultSelector;
+        }
+
+        public IUniTaskAsyncEnumerator<TResult> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new _ZipAwaitWithCancellation(first, second, resultSelector, cancellationToken);
+        }
+
+        sealed class _ZipAwaitWithCancellation : MoveNextSource, IUniTaskAsyncEnumerator<TResult>
+        {
+            static readonly Action<object> firstMoveNextCoreDelegate = FirstMoveNextCore;
+            static readonly Action<object> secondMoveNextCoreDelegate = SecondMoveNextCore;
+            static readonly Action<object> resultAwaitCoreDelegate = ResultAwaitCore;
+
+            readonly IUniTaskAsyncEnumerable<TFirst> first;
+            readonly IUniTaskAsyncEnumerable<TSecond> second;
+            readonly Func<TFirst, TSecond, CancellationToken, UniTask<TResult>> resultSelector;
+
+            CancellationToken cancellationToken;
+
+            IUniTaskAsyncEnumerator<TFirst> firstEnumerator;
+            IUniTaskAsyncEnumerator<TSecond> secondEnumerator;
+
+            UniTask<bool>.Awaiter firstAwaiter;
+            UniTask<bool>.Awaiter secondAwaiter;
+            UniTask<TResult>.Awaiter resultAwaiter;
+
+            public _ZipAwaitWithCancellation(IUniTaskAsyncEnumerable<TFirst> first, IUniTaskAsyncEnumerable<TSecond> second, Func<TFirst, TSecond, CancellationToken, UniTask<TResult>> resultSelector, CancellationToken cancellationToken)
+            {
+                this.first = first;
+                this.second = second;
+                this.resultSelector = resultSelector;
+                this.cancellationToken = cancellationToken;
+                TaskTracker.TrackActiveTask(this, 3);
+            }
+
+            public TResult Current { get; private set; }
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                completionSource.Reset();
+
+                if (firstEnumerator == null)
+                {
+                    firstEnumerator = first.GetAsyncEnumerator(cancellationToken);
+                    secondEnumerator = second.GetAsyncEnumerator(cancellationToken);
+                }
+
+                firstAwaiter = firstEnumerator.MoveNextAsync().GetAwaiter();
+
+                if (firstAwaiter.IsCompleted)
+                {
+                    FirstMoveNextCore(this);
+                }
+                else
+                {
+                    firstAwaiter.SourceOnCompleted(firstMoveNextCoreDelegate, this);
+                }
+
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            static void FirstMoveNextCore(object state)
+            {
+                var self = (_ZipAwaitWithCancellation)state;
+
+                if (self.TryGetResult(self.firstAwaiter, out var result))
+                {
+                    if (result)
+                    {
+                        try
+                        {
+                            self.secondAwaiter = self.secondEnumerator.MoveNextAsync().GetAwaiter();
+                        }
+                        catch (Exception ex)
+                        {
+                            self.completionSource.TrySetException(ex);
+                            return;
+                        }
+
+                        if (self.secondAwaiter.IsCompleted)
+                        {
+                            SecondMoveNextCore(self);
+                        }
+                        else
+                        {
+                            self.secondAwaiter.SourceOnCompleted(secondMoveNextCoreDelegate, self);
+                        }
+                    }
+                    else
+                    {
+                        self.completionSource.TrySetResult(false);
+                    }
+                }
+            }
+
+            static void SecondMoveNextCore(object state)
+            {
+                var self = (_ZipAwaitWithCancellation)state;
+
+                if (self.TryGetResult(self.secondAwaiter, out var result))
+                {
+                    if (result)
+                    {
+                        try
+                        {
+                            self.resultAwaiter = self.resultSelector(self.firstEnumerator.Current, self.secondEnumerator.Current, self.cancellationToken).GetAwaiter();
+                            if (self.resultAwaiter.IsCompleted)
+                            {
+                                ResultAwaitCore(self);
+                            }
+                            else
+                            {
+                                self.resultAwaiter.SourceOnCompleted(resultAwaitCoreDelegate, self);
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            self.completionSource.TrySetException(ex);
+                        }
+                    }
+                    else
+                    {
+                        self.completionSource.TrySetResult(false);
+                    }
+                }
+            }
+
+            static void ResultAwaitCore(object state)
+            {
+                var self = (_ZipAwaitWithCancellation)state;
+
+                if (self.TryGetResult(self.resultAwaiter, out var result))
+                {
+                    self.Current = result;
+
+                    if (self.cancellationToken.IsCancellationRequested)
+                    {
+                        self.completionSource.TrySetCanceled(self.cancellationToken);
+                    }
+                    else
+                    {
+                        self.completionSource.TrySetResult(true);
+                    }
+                }
+            }
+
+            public async UniTask DisposeAsync()
+            {
+                TaskTracker.RemoveTracking(this);
+                if (firstEnumerator != null)
+                {
+                    await firstEnumerator.DisposeAsync();
+                }
+                if (secondEnumerator != null)
+                {
+                    await secondEnumerator.DisposeAsync();
+                }
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Zip.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Linq/Zip.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: acc1acff153e347418f0f30b1c535994
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/MoveNextSource.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/MoveNextSource.cs
@@ -1,0 +1,63 @@
+﻿using System;
+
+namespace Cysharp.Threading.Tasks
+{
+    public abstract class MoveNextSource : IUniTaskSource<bool>
+    {
+        protected UniTaskCompletionSourceCore<bool> completionSource;
+
+        public bool GetResult(short token)
+        {
+            return completionSource.GetResult(token);
+        }
+
+        public UniTaskStatus GetStatus(short token)
+        {
+            return completionSource.GetStatus(token);
+        }
+
+        public void OnCompleted(Action<object> continuation, object state, short token)
+        {
+            completionSource.OnCompleted(continuation, state, token);
+        }
+
+        public UniTaskStatus UnsafeGetStatus()
+        {
+            return completionSource.UnsafeGetStatus();
+        }
+
+        void IUniTaskSource.GetResult(short token)
+        {
+            completionSource.GetResult(token);
+        }
+
+        protected bool TryGetResult<T>(UniTask<T>.Awaiter awaiter, out T result)
+        {
+            try
+            {
+                result = awaiter.GetResult();
+                return true;
+            }
+            catch (Exception ex)
+            {
+                completionSource.TrySetException(ex);
+                result = default;
+                return false;
+            }
+        }
+
+        protected bool TryGetResult(UniTask.Awaiter awaiter)
+        {
+            try
+            {
+                awaiter.GetResult();
+                return true;
+            }
+            catch (Exception ex)
+            {
+                completionSource.TrySetException(ex);
+                return false;
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/MoveNextSource.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/MoveNextSource.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dc4c5dc2a5f246e4f8df44cab735826c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/PlayerLoopHelper.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/PlayerLoopHelper.cs
@@ -1,0 +1,577 @@
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System;
+using System.Linq;
+using UnityEngine;
+using Cysharp.Threading.Tasks.Internal;
+using System.Threading;
+
+#if UNITY_2019_3_OR_NEWER
+using UnityEngine.LowLevel;
+using PlayerLoopType = UnityEngine.PlayerLoop;
+#else
+using UnityEngine.Experimental.LowLevel;
+using PlayerLoopType = UnityEngine.Experimental.PlayerLoop;
+#endif
+
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+
+namespace Cysharp.Threading.Tasks
+{
+    public static class UniTaskLoopRunners
+    {
+        public struct UniTaskLoopRunnerInitialization { };
+        public struct UniTaskLoopRunnerEarlyUpdate { };
+        public struct UniTaskLoopRunnerFixedUpdate { };
+        public struct UniTaskLoopRunnerPreUpdate { };
+        public struct UniTaskLoopRunnerUpdate { };
+        public struct UniTaskLoopRunnerPreLateUpdate { };
+        public struct UniTaskLoopRunnerPostLateUpdate { };
+
+        // Last
+
+        public struct UniTaskLoopRunnerLastInitialization { };
+        public struct UniTaskLoopRunnerLastEarlyUpdate { };
+        public struct UniTaskLoopRunnerLastFixedUpdate { };
+        public struct UniTaskLoopRunnerLastPreUpdate { };
+        public struct UniTaskLoopRunnerLastUpdate { };
+        public struct UniTaskLoopRunnerLastPreLateUpdate { };
+        public struct UniTaskLoopRunnerLastPostLateUpdate { };
+
+        // Yield
+
+        public struct UniTaskLoopRunnerYieldInitialization { };
+        public struct UniTaskLoopRunnerYieldEarlyUpdate { };
+        public struct UniTaskLoopRunnerYieldFixedUpdate { };
+        public struct UniTaskLoopRunnerYieldPreUpdate { };
+        public struct UniTaskLoopRunnerYieldUpdate { };
+        public struct UniTaskLoopRunnerYieldPreLateUpdate { };
+        public struct UniTaskLoopRunnerYieldPostLateUpdate { };
+
+        // Yield Last
+
+        public struct UniTaskLoopRunnerLastYieldInitialization { };
+        public struct UniTaskLoopRunnerLastYieldEarlyUpdate { };
+        public struct UniTaskLoopRunnerLastYieldFixedUpdate { };
+        public struct UniTaskLoopRunnerLastYieldPreUpdate { };
+        public struct UniTaskLoopRunnerLastYieldUpdate { };
+        public struct UniTaskLoopRunnerLastYieldPreLateUpdate { };
+        public struct UniTaskLoopRunnerLastYieldPostLateUpdate { };
+
+#if UNITY_2020_2_OR_NEWER
+        public struct UniTaskLoopRunnerTimeUpdate { };
+        public struct UniTaskLoopRunnerLastTimeUpdate { };
+        public struct UniTaskLoopRunnerYieldTimeUpdate { };
+        public struct UniTaskLoopRunnerLastYieldTimeUpdate { };
+#endif
+    }
+
+    public enum PlayerLoopTiming
+    {
+        Initialization = 0,
+        LastInitialization = 1,
+
+        EarlyUpdate = 2,
+        LastEarlyUpdate = 3,
+
+        FixedUpdate = 4,
+        LastFixedUpdate = 5,
+
+        PreUpdate = 6,
+        LastPreUpdate = 7,
+
+        Update = 8,
+        LastUpdate = 9,
+
+        PreLateUpdate = 10,
+        LastPreLateUpdate = 11,
+
+        PostLateUpdate = 12,
+        LastPostLateUpdate = 13,
+
+#if UNITY_2020_2_OR_NEWER
+        // Unity 2020.2 added TimeUpdate https://docs.unity3d.com/2020.2/Documentation/ScriptReference/PlayerLoop.TimeUpdate.html
+        TimeUpdate = 14,
+        LastTimeUpdate = 15,
+#endif
+    }
+
+    [Flags]
+    public enum InjectPlayerLoopTimings
+    {
+        /// <summary>
+        /// Preset: All loops(default).
+        /// </summary>
+        All =
+            Initialization | LastInitialization |
+            EarlyUpdate | LastEarlyUpdate |
+            FixedUpdate | LastFixedUpdate |
+            PreUpdate | LastPreUpdate |
+            Update | LastUpdate |
+            PreLateUpdate | LastPreLateUpdate |
+            PostLateUpdate | LastPostLateUpdate
+#if UNITY_2020_2_OR_NEWER
+            | TimeUpdate | LastTimeUpdate,
+#else
+            ,
+#endif
+
+        /// <summary>
+        /// Preset: All without last except LastPostLateUpdate.
+        /// </summary>
+        Standard =
+            Initialization |
+            EarlyUpdate |
+            FixedUpdate |
+            PreUpdate |
+            Update |
+            PreLateUpdate |
+            PostLateUpdate | LastPostLateUpdate
+#if UNITY_2020_2_OR_NEWER
+            | TimeUpdate
+#endif
+            ,
+
+        /// <summary>
+        /// Preset: Minimum pattern, Update | FixedUpdate | LastPostLateUpdate
+        /// </summary>
+        Minimum =
+            Update | FixedUpdate | LastPostLateUpdate,
+
+        // PlayerLoopTiming
+
+        Initialization = 1,
+        LastInitialization = 2,
+
+        EarlyUpdate = 4,
+        LastEarlyUpdate = 8,
+
+        FixedUpdate = 16,
+        LastFixedUpdate = 32,
+
+        PreUpdate = 64,
+        LastPreUpdate = 128,
+
+        Update = 256,
+        LastUpdate = 512,
+
+        PreLateUpdate = 1024,
+        LastPreLateUpdate = 2048,
+
+        PostLateUpdate = 4096,
+        LastPostLateUpdate = 8192
+
+#if UNITY_2020_2_OR_NEWER
+        ,
+        // Unity 2020.2 added TimeUpdate https://docs.unity3d.com/2020.2/Documentation/ScriptReference/PlayerLoop.TimeUpdate.html
+        TimeUpdate = 16384,
+        LastTimeUpdate = 32768
+#endif
+    }
+
+    public interface IPlayerLoopItem
+    {
+        bool MoveNext();
+    }
+
+    public static class PlayerLoopHelper
+    {
+        static readonly ContinuationQueue ThrowMarkerContinuationQueue = new ContinuationQueue(PlayerLoopTiming.Initialization);
+        static readonly PlayerLoopRunner ThrowMarkerPlayerLoopRunner = new PlayerLoopRunner(PlayerLoopTiming.Initialization);
+
+        public static SynchronizationContext UnitySynchronizationContext => unitySynchronizationContext;
+        public static int MainThreadId => mainThreadId;
+        internal static string ApplicationDataPath => applicationDataPath;
+
+        public static bool IsMainThread => Thread.CurrentThread.ManagedThreadId == mainThreadId;
+
+        static int mainThreadId;
+        static string applicationDataPath;
+        static SynchronizationContext unitySynchronizationContext;
+        static ContinuationQueue[] yielders;
+        static PlayerLoopRunner[] runners;
+        internal static bool IsEditorApplicationQuitting { get; private set; }
+        static PlayerLoopSystem[] InsertRunner(PlayerLoopSystem loopSystem,
+            bool injectOnFirst,
+            Type loopRunnerYieldType, ContinuationQueue cq,
+            Type loopRunnerType, PlayerLoopRunner runner)
+        {
+
+#if UNITY_EDITOR
+            EditorApplication.playModeStateChanged += (state) =>
+            {
+                if (state == PlayModeStateChange.EnteredEditMode || state == PlayModeStateChange.ExitingEditMode)
+                {
+                    IsEditorApplicationQuitting = true;
+                    // run rest action before clear.
+                    if (runner != null)
+                    {
+                        runner.Run();
+                        runner.Clear();
+                    }
+                    if (cq != null)
+                    {
+                        cq.Run();
+                        cq.Clear();
+                    }
+                    IsEditorApplicationQuitting = false;
+                }
+            };
+#endif
+
+            var yieldLoop = new PlayerLoopSystem
+            {
+                type = loopRunnerYieldType,
+                updateDelegate = cq.Run
+            };
+
+            var runnerLoop = new PlayerLoopSystem
+            {
+                type = loopRunnerType,
+                updateDelegate = runner.Run
+            };
+
+            // Remove items from previous initializations.
+            var source = RemoveRunner(loopSystem, loopRunnerYieldType, loopRunnerType);
+            var dest = new PlayerLoopSystem[source.Length + 2];
+
+            Array.Copy(source, 0, dest, injectOnFirst ? 2 : 0, source.Length);
+            if (injectOnFirst)
+            {
+                dest[0] = yieldLoop;
+                dest[1] = runnerLoop;
+            }
+            else
+            {
+                dest[dest.Length - 2] = yieldLoop;
+                dest[dest.Length - 1] = runnerLoop;
+            }
+
+            return dest;
+        }
+
+        static PlayerLoopSystem[] RemoveRunner(PlayerLoopSystem loopSystem, Type loopRunnerYieldType, Type loopRunnerType)
+        {
+            return loopSystem.subSystemList
+                .Where(ls => ls.type != loopRunnerYieldType && ls.type != loopRunnerType)
+                .ToArray();
+        }
+
+        static PlayerLoopSystem[] InsertUniTaskSynchronizationContext(PlayerLoopSystem loopSystem)
+        {
+            var loop = new PlayerLoopSystem
+            {
+                type = typeof(UniTaskSynchronizationContext),
+                updateDelegate = UniTaskSynchronizationContext.Run
+            };
+
+            // Remove items from previous initializations.
+            var source = loopSystem.subSystemList
+                .Where(ls => ls.type != typeof(UniTaskSynchronizationContext))
+                .ToArray();
+
+            var dest = new System.Collections.Generic.List<PlayerLoopSystem>(source);
+
+            var index = dest.FindIndex(x => x.type.Name == "ScriptRunDelayedTasks");
+            if (index == -1)
+            {
+                index = dest.FindIndex(x => x.type.Name == "UniTaskLoopRunnerUpdate");
+            }
+
+            dest.Insert(index + 1, loop);
+
+            return dest.ToArray();
+        }
+
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+        static void Init()
+        {
+            // capture default(unity) sync-context.
+            unitySynchronizationContext = SynchronizationContext.Current;
+            mainThreadId = Thread.CurrentThread.ManagedThreadId;
+            try
+            {
+                applicationDataPath = Application.dataPath;
+            }
+            catch { }
+
+#if UNITY_EDITOR && UNITY_2019_3_OR_NEWER
+            // When domain reload is disabled, re-initialization is required when entering play mode; 
+            // otherwise, pending tasks will leak between play mode sessions.
+            var domainReloadDisabled = UnityEditor.EditorSettings.enterPlayModeOptionsEnabled &&
+                UnityEditor.EditorSettings.enterPlayModeOptions.HasFlag(UnityEditor.EnterPlayModeOptions.DisableDomainReload);
+            if (!domainReloadDisabled && runners != null) return;
+#else
+            if (runners != null) return; // already initialized
+#endif
+
+            var playerLoop =
+#if UNITY_2019_3_OR_NEWER
+                PlayerLoop.GetCurrentPlayerLoop();
+#else
+                PlayerLoop.GetDefaultPlayerLoop();
+#endif
+
+            Initialize(ref playerLoop);
+        }
+
+
+#if UNITY_EDITOR
+
+        [InitializeOnLoadMethod]
+        static void InitOnEditor()
+        {
+            // Execute the play mode init method
+            Init();
+
+            // register an Editor update delegate, used to forcing playerLoop update
+            EditorApplication.update += ForceEditorPlayerLoopUpdate;
+        }
+
+        private static void ForceEditorPlayerLoopUpdate()
+        {
+            if (EditorApplication.isPlayingOrWillChangePlaymode || EditorApplication.isCompiling || EditorApplication.isUpdating)
+            {
+                // Not in Edit mode, don't interfere
+                return;
+            }
+
+            // EditorApplication.QueuePlayerLoopUpdate causes performance issue, don't call directly.
+            // EditorApplication.QueuePlayerLoopUpdate();
+
+            if (yielders != null)
+            {
+                foreach (var item in yielders)
+                {
+                    if (item != null) item.Run();
+                }
+            }
+
+            if (runners != null)
+            {
+                foreach (var item in runners)
+                {
+                    if (item != null) item.Run();
+                }
+            }
+
+            UniTaskSynchronizationContext.Run();
+        }
+
+#endif
+
+        private static int FindLoopSystemIndex(PlayerLoopSystem[] playerLoopList, Type systemType)
+        {
+            for (int i = 0; i < playerLoopList.Length; i++)
+            {
+                if (playerLoopList[i].type == systemType)
+                {
+                    return i;
+                }
+            }
+
+            throw new Exception("Target PlayerLoopSystem does not found. Type:" + systemType.FullName);
+        }
+
+        static void InsertLoop(PlayerLoopSystem[] copyList, InjectPlayerLoopTimings injectTimings, Type loopType, InjectPlayerLoopTimings targetTimings,
+            int index, bool injectOnFirst, Type loopRunnerYieldType, Type loopRunnerType, PlayerLoopTiming playerLoopTiming)
+        {
+            var i = FindLoopSystemIndex(copyList, loopType);
+            if ((injectTimings & targetTimings) == targetTimings)
+            {
+                copyList[i].subSystemList = InsertRunner(copyList[i], injectOnFirst,
+                    loopRunnerYieldType, yielders[index] = new ContinuationQueue(playerLoopTiming),
+                    loopRunnerType, runners[index] = new PlayerLoopRunner(playerLoopTiming));
+            }
+            else
+            {
+                copyList[i].subSystemList = RemoveRunner(copyList[i], loopRunnerYieldType, loopRunnerType);
+            }
+        }
+
+        public static void Initialize(ref PlayerLoopSystem playerLoop, InjectPlayerLoopTimings injectTimings = InjectPlayerLoopTimings.All)
+        {
+#if UNITY_2020_2_OR_NEWER
+            yielders = new ContinuationQueue[16];
+            runners = new PlayerLoopRunner[16];
+#else
+            yielders = new ContinuationQueue[14];
+            runners = new PlayerLoopRunner[14];
+#endif
+
+            var copyList = playerLoop.subSystemList.ToArray();
+
+            // Initialization
+            InsertLoop(copyList, injectTimings, typeof(PlayerLoopType.Initialization),
+                InjectPlayerLoopTimings.Initialization, 0, true,
+                typeof(UniTaskLoopRunners.UniTaskLoopRunnerYieldInitialization), typeof(UniTaskLoopRunners.UniTaskLoopRunnerInitialization), PlayerLoopTiming.Initialization);
+
+            InsertLoop(copyList, injectTimings, typeof(PlayerLoopType.Initialization),
+                InjectPlayerLoopTimings.LastInitialization, 1, false,
+                typeof(UniTaskLoopRunners.UniTaskLoopRunnerLastYieldInitialization), typeof(UniTaskLoopRunners.UniTaskLoopRunnerLastInitialization), PlayerLoopTiming.LastInitialization);
+
+            // EarlyUpdate
+            InsertLoop(copyList, injectTimings, typeof(PlayerLoopType.EarlyUpdate),
+                InjectPlayerLoopTimings.EarlyUpdate, 2, true,
+                typeof(UniTaskLoopRunners.UniTaskLoopRunnerYieldEarlyUpdate), typeof(UniTaskLoopRunners.UniTaskLoopRunnerEarlyUpdate), PlayerLoopTiming.EarlyUpdate);
+
+            InsertLoop(copyList, injectTimings, typeof(PlayerLoopType.EarlyUpdate),
+                InjectPlayerLoopTimings.LastEarlyUpdate, 3, false,
+                typeof(UniTaskLoopRunners.UniTaskLoopRunnerLastYieldEarlyUpdate), typeof(UniTaskLoopRunners.UniTaskLoopRunnerLastEarlyUpdate), PlayerLoopTiming.LastEarlyUpdate);
+
+            // FixedUpdate
+            InsertLoop(copyList, injectTimings, typeof(PlayerLoopType.FixedUpdate),
+                InjectPlayerLoopTimings.FixedUpdate, 4, true,
+                typeof(UniTaskLoopRunners.UniTaskLoopRunnerYieldFixedUpdate), typeof(UniTaskLoopRunners.UniTaskLoopRunnerFixedUpdate), PlayerLoopTiming.FixedUpdate);
+
+            InsertLoop(copyList, injectTimings, typeof(PlayerLoopType.FixedUpdate),
+                InjectPlayerLoopTimings.LastFixedUpdate, 5, false,
+                typeof(UniTaskLoopRunners.UniTaskLoopRunnerLastYieldFixedUpdate), typeof(UniTaskLoopRunners.UniTaskLoopRunnerLastFixedUpdate), PlayerLoopTiming.LastFixedUpdate);
+
+            // PreUpdate
+            InsertLoop(copyList, injectTimings, typeof(PlayerLoopType.PreUpdate),
+                InjectPlayerLoopTimings.PreUpdate, 6, true,
+                typeof(UniTaskLoopRunners.UniTaskLoopRunnerYieldPreUpdate), typeof(UniTaskLoopRunners.UniTaskLoopRunnerPreUpdate), PlayerLoopTiming.PreUpdate);
+
+            InsertLoop(copyList, injectTimings, typeof(PlayerLoopType.PreUpdate),
+                InjectPlayerLoopTimings.LastPreUpdate, 7, false,
+                typeof(UniTaskLoopRunners.UniTaskLoopRunnerLastYieldPreUpdate), typeof(UniTaskLoopRunners.UniTaskLoopRunnerLastPreUpdate), PlayerLoopTiming.LastPreUpdate);
+
+            // Update
+            InsertLoop(copyList, injectTimings, typeof(PlayerLoopType.Update),
+                InjectPlayerLoopTimings.Update, 8, true,
+                typeof(UniTaskLoopRunners.UniTaskLoopRunnerYieldUpdate), typeof(UniTaskLoopRunners.UniTaskLoopRunnerUpdate), PlayerLoopTiming.Update);
+
+            InsertLoop(copyList, injectTimings, typeof(PlayerLoopType.Update),
+                InjectPlayerLoopTimings.LastUpdate, 9, false,
+                typeof(UniTaskLoopRunners.UniTaskLoopRunnerLastYieldUpdate), typeof(UniTaskLoopRunners.UniTaskLoopRunnerLastUpdate), PlayerLoopTiming.LastUpdate);
+
+            // PreLateUpdate
+            InsertLoop(copyList, injectTimings, typeof(PlayerLoopType.PreLateUpdate),
+                InjectPlayerLoopTimings.PreLateUpdate, 10, true,
+                typeof(UniTaskLoopRunners.UniTaskLoopRunnerYieldPreLateUpdate), typeof(UniTaskLoopRunners.UniTaskLoopRunnerPreLateUpdate), PlayerLoopTiming.PreLateUpdate);
+
+            InsertLoop(copyList, injectTimings, typeof(PlayerLoopType.PreLateUpdate),
+                InjectPlayerLoopTimings.LastPreLateUpdate, 11, false,
+                typeof(UniTaskLoopRunners.UniTaskLoopRunnerLastYieldPreLateUpdate), typeof(UniTaskLoopRunners.UniTaskLoopRunnerLastPreLateUpdate), PlayerLoopTiming.LastPreLateUpdate);
+
+            // PostLateUpdate
+            InsertLoop(copyList, injectTimings, typeof(PlayerLoopType.PostLateUpdate),
+                InjectPlayerLoopTimings.PostLateUpdate, 12, true,
+                typeof(UniTaskLoopRunners.UniTaskLoopRunnerYieldPostLateUpdate), typeof(UniTaskLoopRunners.UniTaskLoopRunnerPostLateUpdate), PlayerLoopTiming.PostLateUpdate);
+
+            InsertLoop(copyList, injectTimings, typeof(PlayerLoopType.PostLateUpdate),
+                InjectPlayerLoopTimings.LastPostLateUpdate, 13, false,
+                typeof(UniTaskLoopRunners.UniTaskLoopRunnerLastYieldPostLateUpdate), typeof(UniTaskLoopRunners.UniTaskLoopRunnerLastPostLateUpdate), PlayerLoopTiming.LastPostLateUpdate);
+
+#if UNITY_2020_2_OR_NEWER
+            // TimeUpdate
+            InsertLoop(copyList, injectTimings, typeof(PlayerLoopType.TimeUpdate),
+                InjectPlayerLoopTimings.TimeUpdate, 14, true,
+                typeof(UniTaskLoopRunners.UniTaskLoopRunnerYieldTimeUpdate), typeof(UniTaskLoopRunners.UniTaskLoopRunnerTimeUpdate), PlayerLoopTiming.TimeUpdate);
+
+            InsertLoop(copyList, injectTimings, typeof(PlayerLoopType.TimeUpdate),
+                InjectPlayerLoopTimings.LastTimeUpdate, 15, false,
+                typeof(UniTaskLoopRunners.UniTaskLoopRunnerLastYieldTimeUpdate), typeof(UniTaskLoopRunners.UniTaskLoopRunnerLastTimeUpdate), PlayerLoopTiming.LastTimeUpdate);
+#endif
+
+            // Insert UniTaskSynchronizationContext to Update loop
+            var i = FindLoopSystemIndex(copyList, typeof(PlayerLoopType.Update));
+            copyList[i].subSystemList = InsertUniTaskSynchronizationContext(copyList[i]);
+
+            playerLoop.subSystemList = copyList;
+            PlayerLoop.SetPlayerLoop(playerLoop);
+        }
+
+        public static void AddAction(PlayerLoopTiming timing, IPlayerLoopItem action)
+        {
+            var runner = runners[(int)timing];
+            if (runner == null)
+            {
+                ThrowInvalidLoopTiming(timing);
+            }
+            runner.AddAction(action);
+        }
+
+        static void ThrowInvalidLoopTiming(PlayerLoopTiming playerLoopTiming)
+        {
+            throw new InvalidOperationException("Target playerLoopTiming is not injected. Please check PlayerLoopHelper.Initialize. PlayerLoopTiming:" + playerLoopTiming);
+        }
+
+        public static void AddContinuation(PlayerLoopTiming timing, Action continuation)
+        {
+            var q = yielders[(int)timing];
+            if (q == null)
+            {
+                ThrowInvalidLoopTiming(timing);
+            }
+            q.Enqueue(continuation);
+        }
+
+        // Diagnostics helper
+
+#if UNITY_2019_3_OR_NEWER
+
+        public static void DumpCurrentPlayerLoop()
+        {
+            var playerLoop = UnityEngine.LowLevel.PlayerLoop.GetCurrentPlayerLoop();
+
+            var sb = new System.Text.StringBuilder();
+            sb.AppendLine($"PlayerLoop List");
+            foreach (var header in playerLoop.subSystemList)
+            {
+                sb.AppendFormat("------{0}------", header.type.Name);
+                sb.AppendLine();
+                
+                if (header.subSystemList is null) 
+                {
+                    sb.AppendFormat("{0} has no subsystems!", header.ToString());
+                    sb.AppendLine();
+                    continue;
+                }
+
+                foreach (var subSystem in header.subSystemList)
+                {
+                    sb.AppendFormat("{0}", subSystem.type.Name);
+                    sb.AppendLine();
+
+                    if (subSystem.subSystemList != null)
+                    {
+                        UnityEngine.Debug.LogWarning("More Subsystem:" + subSystem.subSystemList.Length);
+                    }
+                }
+            }
+
+            UnityEngine.Debug.Log(sb.ToString());
+        }
+
+        public static bool IsInjectedUniTaskPlayerLoop()
+        {
+            var playerLoop = UnityEngine.LowLevel.PlayerLoop.GetCurrentPlayerLoop();
+
+            foreach (var header in playerLoop.subSystemList)
+            {
+                if (header.subSystemList is null) 
+                { 
+                    continue;
+                }
+                
+                foreach (var subSystem in header.subSystemList)
+                {
+                    if (subSystem.type == typeof(UniTaskLoopRunners.UniTaskLoopRunnerInitialization))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+#endif
+
+    }
+}
+

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/PlayerLoopHelper.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/PlayerLoopHelper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 15fb5b85042f19640b973ce651795aca
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/PlayerLoopTimer.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/PlayerLoopTimer.cs
@@ -1,0 +1,262 @@
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System.Threading;
+using System;
+using Cysharp.Threading.Tasks.Internal;
+using UnityEngine;
+
+namespace Cysharp.Threading.Tasks
+{
+    public abstract class PlayerLoopTimer : IDisposable, IPlayerLoopItem
+    {
+        readonly CancellationToken cancellationToken;
+        readonly Action<object> timerCallback;
+        readonly object state;
+        readonly PlayerLoopTiming playerLoopTiming;
+        readonly bool periodic;
+
+        bool isRunning;
+        bool tryStop;
+        bool isDisposed;
+
+        protected PlayerLoopTimer(bool periodic, PlayerLoopTiming playerLoopTiming, CancellationToken cancellationToken, Action<object> timerCallback, object state)
+        {
+            this.periodic = periodic;
+            this.playerLoopTiming = playerLoopTiming;
+            this.cancellationToken = cancellationToken;
+            this.timerCallback = timerCallback;
+            this.state = state;
+        }
+
+        public static PlayerLoopTimer Create(TimeSpan interval, bool periodic, DelayType delayType, PlayerLoopTiming playerLoopTiming, CancellationToken cancellationToken, Action<object> timerCallback, object state)
+        {
+#if UNITY_EDITOR
+            // force use Realtime.
+            if (PlayerLoopHelper.IsMainThread && !UnityEditor.EditorApplication.isPlaying)
+            {
+                delayType = DelayType.Realtime;
+            }
+#endif
+
+            switch (delayType)
+            {
+                case DelayType.UnscaledDeltaTime:
+                    return new IgnoreTimeScalePlayerLoopTimer(interval, periodic, playerLoopTiming, cancellationToken, timerCallback, state);
+                case DelayType.Realtime:
+                    return new RealtimePlayerLoopTimer(interval, periodic, playerLoopTiming, cancellationToken, timerCallback, state);
+                case DelayType.DeltaTime:
+                default:
+                    return new DeltaTimePlayerLoopTimer(interval, periodic, playerLoopTiming, cancellationToken, timerCallback, state);
+            }
+        }
+
+        public static PlayerLoopTimer StartNew(TimeSpan interval, bool periodic, DelayType delayType, PlayerLoopTiming playerLoopTiming, CancellationToken cancellationToken, Action<object> timerCallback, object state)
+        {
+            var timer = Create(interval, periodic, delayType, playerLoopTiming, cancellationToken, timerCallback, state);
+            timer.Restart();
+            return timer;
+        }
+
+        /// <summary>
+        /// Restart(Reset and Start) timer.
+        /// </summary>
+        public void Restart()
+        {
+            if (isDisposed) throw new ObjectDisposedException(null);
+
+            ResetCore(null); // init state
+            if (!isRunning)
+            {
+                isRunning = true;
+                PlayerLoopHelper.AddAction(playerLoopTiming, this);
+            }
+            tryStop = false;
+        }
+
+        /// <summary>
+        /// Restart(Reset and Start) and change interval.
+        /// </summary>
+        public void Restart(TimeSpan interval)
+        {
+            if (isDisposed) throw new ObjectDisposedException(null);
+
+            ResetCore(interval); // init state
+            if (!isRunning)
+            {
+                isRunning = true;
+                PlayerLoopHelper.AddAction(playerLoopTiming, this);
+            }
+            tryStop = false;
+        }
+
+        /// <summary>
+        /// Stop timer.
+        /// </summary>
+        public void Stop()
+        {
+            tryStop = true;
+        }
+
+        protected abstract void ResetCore(TimeSpan? newInterval);
+
+        public void Dispose()
+        {
+            isDisposed = true;
+        }
+
+        bool IPlayerLoopItem.MoveNext()
+        {
+            if (isDisposed)
+            {
+                isRunning = false;
+                return false;
+            }
+            if (tryStop)
+            {
+                isRunning = false;
+                return false;
+            }
+            if (cancellationToken.IsCancellationRequested)
+            {
+                isRunning = false;
+                return false;
+            }
+
+            if (!MoveNextCore())
+            {
+                timerCallback(state);
+
+                if (periodic)
+                {
+                    ResetCore(null);
+                    return true;
+                }
+                else
+                {
+                    isRunning = false;
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        protected abstract bool MoveNextCore();
+    }
+
+    sealed class DeltaTimePlayerLoopTimer : PlayerLoopTimer
+    {
+        int initialFrame;
+        float elapsed;
+        float interval;
+
+        public DeltaTimePlayerLoopTimer(TimeSpan interval, bool periodic, PlayerLoopTiming playerLoopTiming, CancellationToken cancellationToken, Action<object> timerCallback, object state)
+            : base(periodic, playerLoopTiming, cancellationToken, timerCallback, state)
+        {
+            ResetCore(interval);
+        }
+
+        protected override bool MoveNextCore()
+        {
+            if (elapsed == 0.0f)
+            {
+                if (initialFrame == Time.frameCount)
+                {
+                    return true;
+                }
+            }
+
+            elapsed += Time.deltaTime;
+            if (elapsed >= interval)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        protected override void ResetCore(TimeSpan? interval)
+        {
+            this.elapsed = 0.0f;
+            this.initialFrame = PlayerLoopHelper.IsMainThread ? Time.frameCount : -1;
+            if (interval != null)
+            {
+                this.interval = (float)interval.Value.TotalSeconds;
+            }
+        }
+    }
+
+    sealed class IgnoreTimeScalePlayerLoopTimer : PlayerLoopTimer
+    {
+        int initialFrame;
+        float elapsed;
+        float interval;
+
+        public IgnoreTimeScalePlayerLoopTimer(TimeSpan interval, bool periodic, PlayerLoopTiming playerLoopTiming, CancellationToken cancellationToken, Action<object> timerCallback, object state)
+            : base(periodic, playerLoopTiming, cancellationToken, timerCallback, state)
+        {
+            ResetCore(interval);
+        }
+
+        protected override bool MoveNextCore()
+        {
+            if (elapsed == 0.0f)
+            {
+                if (initialFrame == Time.frameCount)
+                {
+                    return true;
+                }
+            }
+
+            elapsed += Time.unscaledDeltaTime;
+            if (elapsed >= interval)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        protected override void ResetCore(TimeSpan? interval)
+        {
+            this.elapsed = 0.0f;
+            this.initialFrame = PlayerLoopHelper.IsMainThread ? Time.frameCount : -1;
+            if (interval != null)
+            {
+                this.interval = (float)interval.Value.TotalSeconds;
+            }
+        }
+    }
+
+    sealed class RealtimePlayerLoopTimer : PlayerLoopTimer
+    {
+        ValueStopwatch stopwatch;
+        long intervalTicks;
+
+        public RealtimePlayerLoopTimer(TimeSpan interval, bool periodic, PlayerLoopTiming playerLoopTiming, CancellationToken cancellationToken, Action<object> timerCallback, object state)
+            : base(periodic, playerLoopTiming, cancellationToken, timerCallback, state)
+        {
+            ResetCore(interval);
+        }
+
+        protected override bool MoveNextCore()
+        {
+            if (stopwatch.ElapsedTicks >= intervalTicks)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        protected override void ResetCore(TimeSpan? interval)
+        {
+            this.stopwatch = ValueStopwatch.StartNew();
+            if (interval != null)
+            {
+                this.intervalTicks = interval.Value.Ticks;
+            }
+        }
+    }
+}
+

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/PlayerLoopTimer.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/PlayerLoopTimer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 57095a17fdca7ee4380450910afc7f26
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Progress.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Progress.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Collections.Generic;
+using Cysharp.Threading.Tasks.Internal;
+
+namespace Cysharp.Threading.Tasks
+{
+    /// <summary>
+    /// Lightweight IProgress[T] factory.
+    /// </summary>
+    public static class Progress
+    {
+        public static IProgress<T> Create<T>(Action<T> handler)
+        {
+            if (handler == null) return NullProgress<T>.Instance;
+            return new AnonymousProgress<T>(handler);
+        }
+
+        public static IProgress<T> CreateOnlyValueChanged<T>(Action<T> handler, IEqualityComparer<T> comparer = null)
+        {
+            if (handler == null) return NullProgress<T>.Instance;
+#if UNITY_2018_3_OR_NEWER
+            return new OnlyValueChangedProgress<T>(handler, comparer ?? UnityEqualityComparer.GetDefault<T>());
+#else
+            return new OnlyValueChangedProgress<T>(handler, comparer ?? EqualityComparer<T>.Default);
+#endif
+        }
+
+        sealed class NullProgress<T> : IProgress<T>
+        {
+            public static readonly IProgress<T> Instance = new NullProgress<T>();
+
+            NullProgress()
+            {
+
+            }
+
+            public void Report(T value)
+            {
+            }
+        }
+
+        sealed class AnonymousProgress<T> : IProgress<T>
+        {
+            readonly Action<T> action;
+
+            public AnonymousProgress(Action<T> action)
+            {
+                this.action = action;
+            }
+
+            public void Report(T value)
+            {
+                action(value);
+            }
+        }
+
+        sealed class OnlyValueChangedProgress<T> : IProgress<T>
+        {
+            readonly Action<T> action;
+            readonly IEqualityComparer<T> comparer;
+            bool isFirstCall;
+            T latestValue;
+
+            public OnlyValueChangedProgress(Action<T> action, IEqualityComparer<T> comparer)
+            {
+                this.action = action;
+                this.comparer = comparer;
+                this.isFirstCall = true;
+            }
+
+            public void Report(T value)
+            {
+                if (isFirstCall)
+                {
+                    isFirstCall = false;
+                }
+                else if (comparer.Equals(value, latestValue))
+                {
+                    return;
+                }
+
+                latestValue = value;
+                action(value);
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Progress.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Progress.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e3377e2ae934ed54fb8fd5388e2d9eb9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/TaskPool.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/TaskPool.cs
@@ -1,0 +1,123 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks
+{
+    // internally used but public, allow to user create custom operator with pooling.
+
+    public static class TaskPool
+    {
+        internal static int MaxPoolSize;
+
+        // avoid to use ConcurrentDictionary for safety of WebGL build.
+        static Dictionary<Type, Func<int>> sizes = new Dictionary<Type, Func<int>>();
+
+        static TaskPool()
+        {
+            try
+            {
+                var value = Environment.GetEnvironmentVariable("UNITASK_MAX_POOLSIZE");
+                if (value != null)
+                {
+                    if (int.TryParse(value, out var size))
+                    {
+                        MaxPoolSize = size;
+                        return;
+                    }
+                }
+            }
+            catch { }
+
+            MaxPoolSize = int.MaxValue;
+        }
+
+        public static void SetMaxPoolSize(int maxPoolSize)
+        {
+            MaxPoolSize = maxPoolSize;
+        }
+
+        public static IEnumerable<(Type, int)> GetCacheSizeInfo()
+        {
+            lock (sizes)
+            {
+                foreach (var item in sizes)
+                {
+                    yield return (item.Key, item.Value());
+                }
+            }
+        }
+
+        public static void RegisterSizeGetter(Type type, Func<int> getSize)
+        {
+            lock (sizes)
+            {
+                sizes[type] = getSize;
+            }
+        }
+    }
+
+    public interface ITaskPoolNode<T>
+    {
+        ref T NextNode { get; }
+    }
+
+    // mutable struct, don't mark readonly.
+    [StructLayout(LayoutKind.Auto)]
+    public struct TaskPool<T>
+        where T : class, ITaskPoolNode<T>
+    {
+        int gate;
+        int size;
+        T root;
+
+        public int Size => size;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool TryPop(out T result)
+        {
+            if (Interlocked.CompareExchange(ref gate, 1, 0) == 0)
+            {
+                var v = root;
+                if (!(v is null))
+                {
+                    ref var nextNode = ref v.NextNode;
+                    root = nextNode;
+                    nextNode = null;
+                    size--;
+                    result = v;
+                    Volatile.Write(ref gate, 0);
+                    return true;
+                }
+
+                Volatile.Write(ref gate, 0);
+            }
+            result = default;
+            return false;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool TryPush(T item)
+        {
+            if (Interlocked.CompareExchange(ref gate, 1, 0) == 0)
+            {
+                if (size < TaskPool.MaxPoolSize)
+                {
+                    item.NextNode = root;
+                    root = item;
+                    size++;
+                    Volatile.Write(ref gate, 0);
+                    return true;
+                }
+                else
+                {
+                    Volatile.Write(ref gate, 0);
+                }
+            }
+            return false;
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/TaskPool.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/TaskPool.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 19f4e6575150765449cc99f25f06f25f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/TimeoutController.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/TimeoutController.cs
@@ -1,0 +1,129 @@
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks
+{
+    // CancellationTokenSource itself can not reuse but CancelAfter(Timeout.InfiniteTimeSpan) allows reuse if did not reach timeout.
+    // Similar discussion:
+    // https://github.com/dotnet/runtime/issues/4694
+    // https://github.com/dotnet/runtime/issues/48492
+    // This TimeoutController emulate similar implementation, using CancelAfterSlim; to achieve zero allocation timeout.
+
+    public sealed class TimeoutController : IDisposable
+    {
+        readonly static Action<object> CancelCancellationTokenSourceStateDelegate = new Action<object>(CancelCancellationTokenSourceState);
+
+        static void CancelCancellationTokenSourceState(object state)
+        {
+            var cts = (CancellationTokenSource)state;
+            cts.Cancel();
+        }
+
+        CancellationTokenSource timeoutSource;
+        CancellationTokenSource linkedSource;
+        PlayerLoopTimer timer;
+        bool isDisposed;
+
+        readonly DelayType delayType;
+        readonly PlayerLoopTiming delayTiming;
+        readonly CancellationTokenSource originalLinkCancellationTokenSource;
+
+        public TimeoutController(DelayType delayType = DelayType.DeltaTime, PlayerLoopTiming delayTiming = PlayerLoopTiming.Update)
+        {
+            this.timeoutSource = new CancellationTokenSource();
+            this.originalLinkCancellationTokenSource = null;
+            this.linkedSource = null;
+            this.delayType = delayType;
+            this.delayTiming = delayTiming;
+        }
+
+        public TimeoutController(CancellationTokenSource linkCancellationTokenSource, DelayType delayType = DelayType.DeltaTime, PlayerLoopTiming delayTiming = PlayerLoopTiming.Update)
+        {
+            this.timeoutSource = new CancellationTokenSource();
+            this.originalLinkCancellationTokenSource = linkCancellationTokenSource;
+            this.linkedSource = CancellationTokenSource.CreateLinkedTokenSource(timeoutSource.Token, linkCancellationTokenSource.Token);
+            this.delayType = delayType;
+            this.delayTiming = delayTiming;
+        }
+
+        public CancellationToken Timeout(int millisecondsTimeout)
+        {
+            return Timeout(TimeSpan.FromMilliseconds(millisecondsTimeout));
+        }
+
+        public CancellationToken Timeout(TimeSpan timeout)
+        {
+            if (originalLinkCancellationTokenSource != null && originalLinkCancellationTokenSource.IsCancellationRequested)
+            {
+                return originalLinkCancellationTokenSource.Token;
+            }
+
+            // Timeouted, create new source and timer.
+            if (timeoutSource.IsCancellationRequested)
+            {
+                timeoutSource.Dispose();
+                timeoutSource = new CancellationTokenSource();
+                if (linkedSource != null)
+                {
+                    this.linkedSource.Cancel();
+                    this.linkedSource.Dispose();
+                    this.linkedSource = CancellationTokenSource.CreateLinkedTokenSource(timeoutSource.Token, originalLinkCancellationTokenSource.Token);
+                }
+
+                timer?.Dispose();
+                timer = null;
+            }
+
+            var useSource = (linkedSource != null) ? linkedSource : timeoutSource;
+            var token = useSource.Token;
+            if (timer == null)
+            {
+                // Timer complete => timeoutSource.Cancel() -> linkedSource will be canceled.
+                // (linked)token is canceled => stop timer
+                timer = PlayerLoopTimer.StartNew(timeout, false, delayType, delayTiming, token, CancelCancellationTokenSourceStateDelegate, timeoutSource);
+            }
+            else
+            {
+                timer.Restart(timeout);
+            }
+
+            return token;
+        }
+
+        public bool IsTimeout()
+        {
+            return timeoutSource.IsCancellationRequested;
+        }
+
+        public void Reset()
+        {
+            timer?.Stop();
+        }
+
+        public void Dispose()
+        {
+            if (isDisposed) return;
+
+            try
+            {
+                // stop timer.
+                timer?.Dispose();
+
+                // cancel and dispose.
+                timeoutSource.Cancel();
+                timeoutSource.Dispose();
+                if (linkedSource != null)
+                {
+                    linkedSource.Cancel();
+                    linkedSource.Dispose();
+                }
+            }
+            finally
+            {
+                isDisposed = true;
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/TimeoutController.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/TimeoutController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6347ab34d2db6d744a654e8d62d96b96
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/TriggerEvent.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/TriggerEvent.cs
@@ -1,0 +1,311 @@
+﻿using System;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks
+{
+    public interface ITriggerHandler<T>
+    {
+        void OnNext(T value);
+        void OnError(Exception ex);
+        void OnCompleted();
+        void OnCanceled(CancellationToken cancellationToken);
+
+        // set/get from TriggerEvent<T>
+        ITriggerHandler<T> Prev { get; set; }
+        ITriggerHandler<T> Next { get; set; }
+    }
+
+    // be careful to use, itself is struct.
+    public struct TriggerEvent<T>
+    {
+        ITriggerHandler<T> head; // head.prev is last
+        ITriggerHandler<T> iteratingHead;
+
+        bool preserveRemoveSelf;
+        ITriggerHandler<T> iteratingNode;
+
+        void LogError(Exception ex)
+        {
+#if UNITY_2018_3_OR_NEWER
+            UnityEngine.Debug.LogException(ex);
+#else
+            Console.WriteLine(ex);
+#endif
+        }
+
+        public void SetResult(T value)
+        {
+            if (iteratingNode != null)
+            {
+                throw new InvalidOperationException("Can not trigger itself in iterating.");
+            }
+
+            var h = head;
+            while (h != null)
+            {
+                iteratingNode = h;
+
+                try
+                {
+                    h.OnNext(value);
+                }
+                catch (Exception ex)
+                {
+                    LogError(ex);
+                    Remove(h);
+                }
+
+                if (preserveRemoveSelf)
+                {
+                    preserveRemoveSelf = false;
+                    iteratingNode = null;
+                    var next = h.Next;
+                    Remove(h);
+                    h = next;
+                }
+                else
+                {
+                    h = h.Next;
+                }
+            }
+
+            iteratingNode = null;
+            if (iteratingHead != null)
+            {
+                Add(iteratingHead);
+                iteratingHead = null;
+            }
+        }
+
+        public void SetCanceled(CancellationToken cancellationToken)
+        {
+            if (iteratingNode != null)
+            {
+                throw new InvalidOperationException("Can not trigger itself in iterating.");
+            }
+
+            var h = head;
+            while (h != null)
+            {
+                iteratingNode = h;
+                try
+                {
+                    h.OnCanceled(cancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    LogError(ex);
+                }
+
+                preserveRemoveSelf = false;
+                iteratingNode = null;
+                var next = h.Next;
+                Remove(h);
+                h = next;
+            }
+
+            iteratingNode = null;
+            if (iteratingHead != null)
+            {
+                Add(iteratingHead);
+                iteratingHead = null;
+            }
+        }
+
+        public void SetCompleted()
+        {
+            if (iteratingNode != null)
+            {
+                throw new InvalidOperationException("Can not trigger itself in iterating.");
+            }
+
+            var h = head;
+            while (h != null)
+            {
+                iteratingNode = h;
+                try
+                {
+                    h.OnCompleted();
+                }
+                catch (Exception ex)
+                {
+                    LogError(ex);
+                }
+
+                preserveRemoveSelf = false;
+                iteratingNode = null;
+                var next = h.Next;
+                Remove(h);
+                h = next;
+            }
+
+            iteratingNode = null;
+            if (iteratingHead != null)
+            {
+                Add(iteratingHead);
+                iteratingHead = null;
+            }
+        }
+
+        public void SetError(Exception exception)
+        {
+            if (iteratingNode != null)
+            {
+                throw new InvalidOperationException("Can not trigger itself in iterating.");
+            }
+
+            var h = head;
+            while (h != null)
+            {
+                iteratingNode = h;
+                try
+                {
+                    h.OnError(exception);
+                }
+                catch (Exception ex)
+                {
+                    LogError(ex);
+                }
+
+                preserveRemoveSelf = false;
+                iteratingNode = null;
+                var next = h.Next;
+                Remove(h);
+                h = next;
+            }
+
+            iteratingNode = null;
+            if (iteratingHead != null)
+            {
+                Add(iteratingHead);
+                iteratingHead = null;
+            }
+        }
+
+        public void Add(ITriggerHandler<T> handler)
+        {
+            if (handler == null) throw new ArgumentNullException(nameof(handler));
+
+            // zero node.
+            if (head == null)
+            {
+                head = handler;
+                return;
+            }
+
+            if (iteratingNode != null)
+            {
+                if (iteratingHead == null)
+                {
+                    iteratingHead = handler;
+                    return;
+                }
+
+                var last = iteratingHead.Prev;
+                if (last == null)
+                {
+                    // single node.
+                    iteratingHead.Prev = handler;
+                    iteratingHead.Next = handler;
+                    handler.Prev = iteratingHead;
+                }
+                else
+                {
+                    // multi node
+                    iteratingHead.Prev = handler;
+                    last.Next = handler;
+                    handler.Prev = last;
+                }
+            }
+            else
+            {
+                var last = head.Prev;
+                if (last == null)
+                {
+                    // single node.
+                    head.Prev = handler;
+                    head.Next = handler;
+                    handler.Prev = head;
+                }
+                else
+                {
+                    // multi node
+                    head.Prev = handler;
+                    last.Next = handler;
+                    handler.Prev = last;
+                }
+            }
+        }
+
+        public void Remove(ITriggerHandler<T> handler)
+        {
+            if (handler == null) throw new ArgumentNullException(nameof(handler));
+
+            if (iteratingNode != null && iteratingNode == handler)
+            {
+                // if remove self, reserve remove self after invoke completed.
+                preserveRemoveSelf = true;
+            }
+            else
+            {
+                var prev = handler.Prev;
+                var next = handler.Next;
+
+                if (next != null)
+                {
+                    next.Prev = prev;
+                }
+
+                if (handler == head)
+                {
+                    head = next;
+                }
+                else if (handler == iteratingHead)
+                {
+                    iteratingHead = next;
+                }
+                else
+                {
+                    // when handler is head, prev indicate last so don't use it.
+                    if (prev != null)
+                    {
+                        prev.Next = next;
+                    }
+                }
+
+                if (head != null)
+                {
+                    if (head.Prev == handler)
+                    {
+                        if (prev != head)
+                        {
+                            head.Prev = prev;
+                        }
+                        else
+                        {
+                            head.Prev = null;
+                        }
+                    }
+                }
+
+                if (iteratingHead != null)
+                {
+                    if (iteratingHead.Prev == handler)
+                    {
+                        if (prev != iteratingHead.Prev)
+                        {
+                            iteratingHead.Prev = prev;
+                        }
+                        else
+                        {
+                            iteratingHead.Prev = null;
+                        }
+                    }
+                }
+
+                handler.Prev = null;
+                handler.Next = null;
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/TriggerEvent.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/TriggerEvent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f68b22bb8f66f5c4885f9bd3c4fc43ed
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Triggers.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Triggers.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ef70597af28b20945a506c38cfccd6c9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Triggers/AsyncAwakeTrigger.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Triggers/AsyncAwakeTrigger.cs
@@ -1,0 +1,32 @@
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System.Threading;
+using UnityEngine;
+
+namespace Cysharp.Threading.Tasks.Triggers
+{
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncAwakeTrigger GetAsyncAwakeTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncAwakeTrigger>(gameObject);
+        }
+
+        public static AsyncAwakeTrigger GetAsyncAwakeTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncAwakeTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncAwakeTrigger : AsyncTriggerBase<AsyncUnit>
+    {
+        public UniTask AwakeAsync()
+        {
+            if (calledAwake) return UniTask.CompletedTask;
+
+            return ((IAsyncOneShotTrigger)new AsyncTriggerHandler<AsyncUnit>(this, true)).OneShotAsync();
+        }
+    }
+}
+

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Triggers/AsyncAwakeTrigger.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Triggers/AsyncAwakeTrigger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ef2840a2586894741a0ae211b8fd669b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Triggers/AsyncDestroyTrigger.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Triggers/AsyncDestroyTrigger.cs
@@ -1,0 +1,97 @@
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System.Threading;
+using UnityEngine;
+
+namespace Cysharp.Threading.Tasks.Triggers
+{
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncDestroyTrigger GetAsyncDestroyTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncDestroyTrigger>(gameObject);
+        }
+
+        public static AsyncDestroyTrigger GetAsyncDestroyTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncDestroyTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncDestroyTrigger : MonoBehaviour
+    {
+        bool awakeCalled = false;
+        bool called = false;
+        CancellationTokenSource cancellationTokenSource;
+
+        public CancellationToken CancellationToken
+        {
+            get
+            {
+                if (cancellationTokenSource == null)
+                {
+                    cancellationTokenSource = new CancellationTokenSource();
+                }
+
+                if (!awakeCalled)
+                {
+                    PlayerLoopHelper.AddAction(PlayerLoopTiming.Update, new AwakeMonitor(this));
+                }
+
+                return cancellationTokenSource.Token;
+            }
+        }
+
+        void Awake()
+        {
+            awakeCalled = true;
+        }
+
+        void OnDestroy()
+        {
+            called = true;
+
+            cancellationTokenSource?.Cancel();
+            cancellationTokenSource?.Dispose();
+        }
+
+        public UniTask OnDestroyAsync()
+        {
+            if (called) return UniTask.CompletedTask;
+
+            var tcs = new UniTaskCompletionSource();
+
+            // OnDestroy = Called Cancel.
+            CancellationToken.RegisterWithoutCaptureExecutionContext(state =>
+            {
+                var tcs2 = (UniTaskCompletionSource)state;
+                tcs2.TrySetResult();
+            }, tcs);
+
+            return tcs.Task;
+        }
+
+        class AwakeMonitor : IPlayerLoopItem
+        {
+            readonly AsyncDestroyTrigger trigger;
+
+            public AwakeMonitor(AsyncDestroyTrigger trigger)
+            {
+                this.trigger = trigger;
+            }
+
+            public bool MoveNext()
+            {
+                if (trigger.called) return false;
+                if (trigger == null)
+                {
+                    trigger.OnDestroy();
+                    return false;
+                }
+                return true;
+            }
+        }
+    }
+}
+

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Triggers/AsyncDestroyTrigger.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Triggers/AsyncDestroyTrigger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f4afdcb1cbadf954ba8b1cf465429e17
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Triggers/AsyncStartTrigger.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Triggers/AsyncStartTrigger.cs
@@ -1,0 +1,38 @@
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using UnityEngine;
+
+namespace Cysharp.Threading.Tasks.Triggers
+{
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncStartTrigger GetAsyncStartTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncStartTrigger>(gameObject);
+        }
+
+        public static AsyncStartTrigger GetAsyncStartTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncStartTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncStartTrigger : AsyncTriggerBase<AsyncUnit>
+    {
+        bool called;
+
+        void Start()
+        {
+            called = true;
+            RaiseEvent(AsyncUnit.Default);
+        }
+
+        public UniTask StartAsync()
+        {
+            if (called) return UniTask.CompletedTask;
+
+            return ((IAsyncOneShotTrigger)new AsyncTriggerHandler<AsyncUnit>(this, true)).OneShotAsync();
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Triggers/AsyncStartTrigger.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Triggers/AsyncStartTrigger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b4fd0f75e54ec3d4fbcb7fc65b11646b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Triggers/AsyncTriggerBase.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Triggers/AsyncTriggerBase.cs
@@ -1,0 +1,310 @@
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System;
+using System.Threading;
+using UnityEngine;
+
+namespace Cysharp.Threading.Tasks.Triggers
+{
+    public abstract class AsyncTriggerBase<T> : MonoBehaviour, IUniTaskAsyncEnumerable<T>
+    {
+        TriggerEvent<T> triggerEvent;
+
+        internal protected bool calledAwake;
+        internal protected bool calledDestroy;
+
+        void Awake()
+        {
+            calledAwake = true;
+        }
+
+        void OnDestroy()
+        {
+            if (calledDestroy) return;
+            calledDestroy = true;
+
+            triggerEvent.SetCompleted();
+        }
+
+        internal void AddHandler(ITriggerHandler<T> handler)
+        {
+            if (!calledAwake)
+            {
+                PlayerLoopHelper.AddAction(PlayerLoopTiming.Update, new AwakeMonitor(this));
+            }
+
+            triggerEvent.Add(handler);
+        }
+
+        internal void RemoveHandler(ITriggerHandler<T> handler)
+        {
+            if (!calledAwake)
+            {
+                PlayerLoopHelper.AddAction(PlayerLoopTiming.Update, new AwakeMonitor(this));
+            }
+
+            triggerEvent.Remove(handler);
+        }
+
+        protected void RaiseEvent(T value)
+        {
+            triggerEvent.SetResult(value);
+        }
+
+        public IUniTaskAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new AsyncTriggerEnumerator(this, cancellationToken);
+        }
+
+        sealed class AsyncTriggerEnumerator : MoveNextSource, IUniTaskAsyncEnumerator<T>, ITriggerHandler<T>
+        {
+            static Action<object> cancellationCallback = CancellationCallback;
+
+            readonly AsyncTriggerBase<T> parent;
+            CancellationToken cancellationToken;
+            CancellationTokenRegistration registration;
+            bool called;
+            bool isDisposed;
+
+            public AsyncTriggerEnumerator(AsyncTriggerBase<T> parent, CancellationToken cancellationToken)
+            {
+                this.parent = parent;
+                this.cancellationToken = cancellationToken;
+            }
+
+            public void OnCanceled(CancellationToken cancellationToken = default)
+            {
+                completionSource.TrySetCanceled(cancellationToken);
+            }
+
+            public void OnNext(T value)
+            {
+                Current = value;
+                completionSource.TrySetResult(true);
+            }
+
+            public void OnCompleted()
+            {
+                completionSource.TrySetResult(false);
+            }
+
+            public void OnError(Exception ex)
+            {
+                completionSource.TrySetException(ex);
+            }
+
+            static void CancellationCallback(object state)
+            {
+                var self = (AsyncTriggerEnumerator)state;
+                self.DisposeAsync().Forget(); // sync
+
+                self.completionSource.TrySetCanceled(self.cancellationToken);
+            }
+
+            public T Current { get; private set; }
+            ITriggerHandler<T> ITriggerHandler<T>.Prev { get; set; }
+            ITriggerHandler<T> ITriggerHandler<T>.Next { get; set; }
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                completionSource.Reset();
+
+                if (!called)
+                {
+                    called = true;
+
+                    TaskTracker.TrackActiveTask(this, 3);
+                    parent.AddHandler(this);
+                    if (cancellationToken.CanBeCanceled)
+                    {
+                        registration = cancellationToken.RegisterWithoutCaptureExecutionContext(cancellationCallback, this);
+                    }
+                }
+
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            public UniTask DisposeAsync()
+            {
+                if (!isDisposed)
+                {
+                    isDisposed = true;
+                    TaskTracker.RemoveTracking(this);
+                    registration.Dispose();
+                    parent.RemoveHandler(this);
+                }
+
+                return default;
+            }
+        }
+
+        class AwakeMonitor : IPlayerLoopItem
+        {
+            readonly AsyncTriggerBase<T> trigger;
+
+            public AwakeMonitor(AsyncTriggerBase<T> trigger)
+            {
+                this.trigger = trigger;
+            }
+
+            public bool MoveNext()
+            {
+                if (trigger.calledAwake) return false;
+                if (trigger == null)
+                {
+                    trigger.OnDestroy();
+                    return false;
+                }
+                return true;
+            }
+        }
+    }
+
+    public interface IAsyncOneShotTrigger
+    {
+        UniTask OneShotAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOneShotTrigger
+    {
+        UniTask IAsyncOneShotTrigger.OneShotAsync()
+        {
+            core.Reset();
+            return new UniTask((IUniTaskSource)this, core.Version);
+        }
+    }
+
+    public sealed partial class AsyncTriggerHandler<T> : IUniTaskSource<T>, ITriggerHandler<T>, IDisposable
+    {
+        static Action<object> cancellationCallback = CancellationCallback;
+
+        readonly AsyncTriggerBase<T> trigger;
+
+        CancellationToken cancellationToken;
+        CancellationTokenRegistration registration;
+        bool isDisposed;
+        bool callOnce;
+
+        UniTaskCompletionSourceCore<T> core;
+
+        internal CancellationToken CancellationToken => cancellationToken;
+
+        ITriggerHandler<T> ITriggerHandler<T>.Prev { get; set; }
+        ITriggerHandler<T> ITriggerHandler<T>.Next { get; set; }
+
+        internal AsyncTriggerHandler(AsyncTriggerBase<T> trigger, bool callOnce)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                isDisposed = true;
+                return;
+            }
+
+            this.trigger = trigger;
+            this.cancellationToken = default;
+            this.registration = default;
+            this.callOnce = callOnce;
+
+            trigger.AddHandler(this);
+
+            TaskTracker.TrackActiveTask(this, 3);
+        }
+
+        internal AsyncTriggerHandler(AsyncTriggerBase<T> trigger, CancellationToken cancellationToken, bool callOnce)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                isDisposed = true;
+                return;
+            }
+
+            this.trigger = trigger;
+            this.cancellationToken = cancellationToken;
+            this.callOnce = callOnce;
+
+            trigger.AddHandler(this);
+
+            if (cancellationToken.CanBeCanceled)
+            {
+                registration = cancellationToken.RegisterWithoutCaptureExecutionContext(cancellationCallback, this);
+            }
+
+            TaskTracker.TrackActiveTask(this, 3);
+        }
+
+        static void CancellationCallback(object state)
+        {
+            var self = (AsyncTriggerHandler<T>)state;
+            self.Dispose();
+
+            self.core.TrySetCanceled(self.cancellationToken);
+        }
+
+        public void Dispose()
+        {
+            if (!isDisposed)
+            {
+                isDisposed = true;
+                TaskTracker.RemoveTracking(this);
+                registration.Dispose();
+                trigger.RemoveHandler(this);
+            }
+        }
+
+        T IUniTaskSource<T>.GetResult(short token)
+        {
+            try
+            {
+                return core.GetResult(token);
+            }
+            finally
+            {
+                if (callOnce)
+                {
+                    Dispose();
+                }
+            }
+        }
+
+        void ITriggerHandler<T>.OnNext(T value)
+        {
+            core.TrySetResult(value);
+        }
+
+        void ITriggerHandler<T>.OnCanceled(CancellationToken cancellationToken)
+        {
+            core.TrySetCanceled(cancellationToken);
+        }
+
+        void ITriggerHandler<T>.OnCompleted()
+        {
+            core.TrySetCanceled(CancellationToken.None);
+        }
+
+        void ITriggerHandler<T>.OnError(Exception ex)
+        {
+            core.TrySetException(ex);
+        }
+
+        void IUniTaskSource.GetResult(short token)
+        {
+            ((IUniTaskSource<T>)this).GetResult(token);
+        }
+
+        UniTaskStatus IUniTaskSource.GetStatus(short token)
+        {
+            return core.GetStatus(token);
+        }
+
+        UniTaskStatus IUniTaskSource.UnsafeGetStatus()
+        {
+            return core.UnsafeGetStatus();
+        }
+
+        void IUniTaskSource.OnCompleted(Action<object> continuation, object state, short token)
+        {
+            core.OnCompleted(continuation, state, token);
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Triggers/AsyncTriggerBase.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Triggers/AsyncTriggerBase.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2c0c2bcee832c6641b25949c412f020f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Triggers/AsyncTriggerExtensions.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Triggers/AsyncTriggerExtensions.cs
@@ -1,0 +1,102 @@
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System.Threading;
+using UnityEngine;
+using Cysharp.Threading.Tasks.Triggers;
+
+namespace Cysharp.Threading.Tasks
+{
+    public static class UniTaskCancellationExtensions
+    {
+#if UNITY_2022_2_OR_NEWER
+
+        /// <summary>This CancellationToken is canceled when the MonoBehaviour will be destroyed.</summary>
+        public static CancellationToken GetCancellationTokenOnDestroy(this MonoBehaviour monoBehaviour)
+        {
+            return monoBehaviour.destroyCancellationToken;
+        }
+
+#endif
+
+        /// <summary>This CancellationToken is canceled when the MonoBehaviour will be destroyed.</summary>
+        public static CancellationToken GetCancellationTokenOnDestroy(this GameObject gameObject)
+        {
+            return gameObject.GetAsyncDestroyTrigger().CancellationToken;
+        }
+
+        /// <summary>This CancellationToken is canceled when the MonoBehaviour will be destroyed.</summary>
+        public static CancellationToken GetCancellationTokenOnDestroy(this Component component)
+        {
+#if UNITY_2022_2_OR_NEWER
+            if (component is MonoBehaviour mb)
+            {
+                return mb.destroyCancellationToken;
+            }
+#endif
+
+            return component.GetAsyncDestroyTrigger().CancellationToken;
+        }
+    }
+}
+
+namespace Cysharp.Threading.Tasks.Triggers
+{
+    public static partial class AsyncTriggerExtensions
+    {
+        // Util.
+
+        static T GetOrAddComponent<T>(GameObject gameObject)
+            where T : Component
+        {
+#if UNITY_2019_2_OR_NEWER
+            if (!gameObject.TryGetComponent<T>(out var component))
+            {
+                component = gameObject.AddComponent<T>();
+            }
+#else
+            var component = gameObject.GetComponent<T>();
+            if (component == null)
+            {
+                component = gameObject.AddComponent<T>();
+            }
+#endif
+
+            return component;
+        }
+
+        // Special for single operation.
+
+        /// <summary>This function is called when the MonoBehaviour will be destroyed.</summary>
+        public static UniTask OnDestroyAsync(this GameObject gameObject)
+        {
+            return gameObject.GetAsyncDestroyTrigger().OnDestroyAsync();
+        }
+
+        /// <summary>This function is called when the MonoBehaviour will be destroyed.</summary>
+        public static UniTask OnDestroyAsync(this Component component)
+        {
+            return component.GetAsyncDestroyTrigger().OnDestroyAsync();
+        }
+
+        public static UniTask StartAsync(this GameObject gameObject)
+        {
+            return gameObject.GetAsyncStartTrigger().StartAsync();
+        }
+
+        public static UniTask StartAsync(this Component component)
+        {
+            return component.GetAsyncStartTrigger().StartAsync();
+        }
+
+        public static UniTask AwakeAsync(this GameObject gameObject)
+        {
+            return gameObject.GetAsyncAwakeTrigger().AwakeAsync();
+        }
+
+        public static UniTask AwakeAsync(this Component component)
+        {
+            return component.GetAsyncAwakeTrigger().AwakeAsync();
+        }
+    }
+}
+

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Triggers/AsyncTriggerExtensions.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Triggers/AsyncTriggerExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 59b61dbea1562a84fb7a38ae0a0a0f88
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Triggers/MonoBehaviourMessagesTriggers.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Triggers/MonoBehaviourMessagesTriggers.cs
@@ -1,0 +1,4457 @@
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System.Threading;
+using UnityEngine;
+#if !UNITY_2019_1_OR_NEWER || UNITASK_UGUI_SUPPORT
+using UnityEngine.EventSystems;
+#endif
+
+namespace Cysharp.Threading.Tasks.Triggers
+{
+#region FixedUpdate
+
+    public interface IAsyncFixedUpdateHandler
+    {
+        UniTask FixedUpdateAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncFixedUpdateHandler
+    {
+        UniTask IAsyncFixedUpdateHandler.FixedUpdateAsync()
+        {
+            core.Reset();
+            return new UniTask((IUniTaskSource)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncFixedUpdateTrigger GetAsyncFixedUpdateTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncFixedUpdateTrigger>(gameObject);
+        }
+        
+        public static AsyncFixedUpdateTrigger GetAsyncFixedUpdateTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncFixedUpdateTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncFixedUpdateTrigger : AsyncTriggerBase<AsyncUnit>
+    {
+        void FixedUpdate()
+        {
+            RaiseEvent(AsyncUnit.Default);
+        }
+
+        public IAsyncFixedUpdateHandler GetFixedUpdateAsyncHandler()
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, false);
+        }
+
+        public IAsyncFixedUpdateHandler GetFixedUpdateAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, false);
+        }
+
+        public UniTask FixedUpdateAsync()
+        {
+            return ((IAsyncFixedUpdateHandler)new AsyncTriggerHandler<AsyncUnit>(this, true)).FixedUpdateAsync();
+        }
+
+        public UniTask FixedUpdateAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncFixedUpdateHandler)new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, true)).FixedUpdateAsync();
+        }
+    }
+#endregion
+
+#region LateUpdate
+
+    public interface IAsyncLateUpdateHandler
+    {
+        UniTask LateUpdateAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncLateUpdateHandler
+    {
+        UniTask IAsyncLateUpdateHandler.LateUpdateAsync()
+        {
+            core.Reset();
+            return new UniTask((IUniTaskSource)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncLateUpdateTrigger GetAsyncLateUpdateTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncLateUpdateTrigger>(gameObject);
+        }
+        
+        public static AsyncLateUpdateTrigger GetAsyncLateUpdateTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncLateUpdateTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncLateUpdateTrigger : AsyncTriggerBase<AsyncUnit>
+    {
+        void LateUpdate()
+        {
+            RaiseEvent(AsyncUnit.Default);
+        }
+
+        public IAsyncLateUpdateHandler GetLateUpdateAsyncHandler()
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, false);
+        }
+
+        public IAsyncLateUpdateHandler GetLateUpdateAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, false);
+        }
+
+        public UniTask LateUpdateAsync()
+        {
+            return ((IAsyncLateUpdateHandler)new AsyncTriggerHandler<AsyncUnit>(this, true)).LateUpdateAsync();
+        }
+
+        public UniTask LateUpdateAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncLateUpdateHandler)new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, true)).LateUpdateAsync();
+        }
+    }
+#endregion
+
+#region AnimatorIK
+
+    public interface IAsyncOnAnimatorIKHandler
+    {
+        UniTask<int> OnAnimatorIKAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnAnimatorIKHandler
+    {
+        UniTask<int> IAsyncOnAnimatorIKHandler.OnAnimatorIKAsync()
+        {
+            core.Reset();
+            return new UniTask<int>((IUniTaskSource<int>)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncAnimatorIKTrigger GetAsyncAnimatorIKTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncAnimatorIKTrigger>(gameObject);
+        }
+        
+        public static AsyncAnimatorIKTrigger GetAsyncAnimatorIKTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncAnimatorIKTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncAnimatorIKTrigger : AsyncTriggerBase<int>
+    {
+        void OnAnimatorIK(int layerIndex)
+        {
+            RaiseEvent((layerIndex));
+        }
+
+        public IAsyncOnAnimatorIKHandler GetOnAnimatorIKAsyncHandler()
+        {
+            return new AsyncTriggerHandler<int>(this, false);
+        }
+
+        public IAsyncOnAnimatorIKHandler GetOnAnimatorIKAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<int>(this, cancellationToken, false);
+        }
+
+        public UniTask<int> OnAnimatorIKAsync()
+        {
+            return ((IAsyncOnAnimatorIKHandler)new AsyncTriggerHandler<int>(this, true)).OnAnimatorIKAsync();
+        }
+
+        public UniTask<int> OnAnimatorIKAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnAnimatorIKHandler)new AsyncTriggerHandler<int>(this, cancellationToken, true)).OnAnimatorIKAsync();
+        }
+    }
+#endregion
+
+#region AnimatorMove
+
+    public interface IAsyncOnAnimatorMoveHandler
+    {
+        UniTask OnAnimatorMoveAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnAnimatorMoveHandler
+    {
+        UniTask IAsyncOnAnimatorMoveHandler.OnAnimatorMoveAsync()
+        {
+            core.Reset();
+            return new UniTask((IUniTaskSource)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncAnimatorMoveTrigger GetAsyncAnimatorMoveTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncAnimatorMoveTrigger>(gameObject);
+        }
+        
+        public static AsyncAnimatorMoveTrigger GetAsyncAnimatorMoveTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncAnimatorMoveTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncAnimatorMoveTrigger : AsyncTriggerBase<AsyncUnit>
+    {
+        void OnAnimatorMove()
+        {
+            RaiseEvent(AsyncUnit.Default);
+        }
+
+        public IAsyncOnAnimatorMoveHandler GetOnAnimatorMoveAsyncHandler()
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, false);
+        }
+
+        public IAsyncOnAnimatorMoveHandler GetOnAnimatorMoveAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, false);
+        }
+
+        public UniTask OnAnimatorMoveAsync()
+        {
+            return ((IAsyncOnAnimatorMoveHandler)new AsyncTriggerHandler<AsyncUnit>(this, true)).OnAnimatorMoveAsync();
+        }
+
+        public UniTask OnAnimatorMoveAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnAnimatorMoveHandler)new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, true)).OnAnimatorMoveAsync();
+        }
+    }
+#endregion
+
+#region ApplicationFocus
+
+    public interface IAsyncOnApplicationFocusHandler
+    {
+        UniTask<bool> OnApplicationFocusAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnApplicationFocusHandler
+    {
+        UniTask<bool> IAsyncOnApplicationFocusHandler.OnApplicationFocusAsync()
+        {
+            core.Reset();
+            return new UniTask<bool>((IUniTaskSource<bool>)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncApplicationFocusTrigger GetAsyncApplicationFocusTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncApplicationFocusTrigger>(gameObject);
+        }
+        
+        public static AsyncApplicationFocusTrigger GetAsyncApplicationFocusTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncApplicationFocusTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncApplicationFocusTrigger : AsyncTriggerBase<bool>
+    {
+        void OnApplicationFocus(bool hasFocus)
+        {
+            RaiseEvent((hasFocus));
+        }
+
+        public IAsyncOnApplicationFocusHandler GetOnApplicationFocusAsyncHandler()
+        {
+            return new AsyncTriggerHandler<bool>(this, false);
+        }
+
+        public IAsyncOnApplicationFocusHandler GetOnApplicationFocusAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<bool>(this, cancellationToken, false);
+        }
+
+        public UniTask<bool> OnApplicationFocusAsync()
+        {
+            return ((IAsyncOnApplicationFocusHandler)new AsyncTriggerHandler<bool>(this, true)).OnApplicationFocusAsync();
+        }
+
+        public UniTask<bool> OnApplicationFocusAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnApplicationFocusHandler)new AsyncTriggerHandler<bool>(this, cancellationToken, true)).OnApplicationFocusAsync();
+        }
+    }
+#endregion
+
+#region ApplicationPause
+
+    public interface IAsyncOnApplicationPauseHandler
+    {
+        UniTask<bool> OnApplicationPauseAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnApplicationPauseHandler
+    {
+        UniTask<bool> IAsyncOnApplicationPauseHandler.OnApplicationPauseAsync()
+        {
+            core.Reset();
+            return new UniTask<bool>((IUniTaskSource<bool>)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncApplicationPauseTrigger GetAsyncApplicationPauseTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncApplicationPauseTrigger>(gameObject);
+        }
+        
+        public static AsyncApplicationPauseTrigger GetAsyncApplicationPauseTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncApplicationPauseTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncApplicationPauseTrigger : AsyncTriggerBase<bool>
+    {
+        void OnApplicationPause(bool pauseStatus)
+        {
+            RaiseEvent((pauseStatus));
+        }
+
+        public IAsyncOnApplicationPauseHandler GetOnApplicationPauseAsyncHandler()
+        {
+            return new AsyncTriggerHandler<bool>(this, false);
+        }
+
+        public IAsyncOnApplicationPauseHandler GetOnApplicationPauseAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<bool>(this, cancellationToken, false);
+        }
+
+        public UniTask<bool> OnApplicationPauseAsync()
+        {
+            return ((IAsyncOnApplicationPauseHandler)new AsyncTriggerHandler<bool>(this, true)).OnApplicationPauseAsync();
+        }
+
+        public UniTask<bool> OnApplicationPauseAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnApplicationPauseHandler)new AsyncTriggerHandler<bool>(this, cancellationToken, true)).OnApplicationPauseAsync();
+        }
+    }
+#endregion
+
+#region ApplicationQuit
+
+    public interface IAsyncOnApplicationQuitHandler
+    {
+        UniTask OnApplicationQuitAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnApplicationQuitHandler
+    {
+        UniTask IAsyncOnApplicationQuitHandler.OnApplicationQuitAsync()
+        {
+            core.Reset();
+            return new UniTask((IUniTaskSource)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncApplicationQuitTrigger GetAsyncApplicationQuitTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncApplicationQuitTrigger>(gameObject);
+        }
+        
+        public static AsyncApplicationQuitTrigger GetAsyncApplicationQuitTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncApplicationQuitTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncApplicationQuitTrigger : AsyncTriggerBase<AsyncUnit>
+    {
+        void OnApplicationQuit()
+        {
+            RaiseEvent(AsyncUnit.Default);
+        }
+
+        public IAsyncOnApplicationQuitHandler GetOnApplicationQuitAsyncHandler()
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, false);
+        }
+
+        public IAsyncOnApplicationQuitHandler GetOnApplicationQuitAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, false);
+        }
+
+        public UniTask OnApplicationQuitAsync()
+        {
+            return ((IAsyncOnApplicationQuitHandler)new AsyncTriggerHandler<AsyncUnit>(this, true)).OnApplicationQuitAsync();
+        }
+
+        public UniTask OnApplicationQuitAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnApplicationQuitHandler)new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, true)).OnApplicationQuitAsync();
+        }
+    }
+#endregion
+
+#region AudioFilterRead
+
+    public interface IAsyncOnAudioFilterReadHandler
+    {
+        UniTask<(float[] data, int channels)> OnAudioFilterReadAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnAudioFilterReadHandler
+    {
+        UniTask<(float[] data, int channels)> IAsyncOnAudioFilterReadHandler.OnAudioFilterReadAsync()
+        {
+            core.Reset();
+            return new UniTask<(float[] data, int channels)>((IUniTaskSource<(float[] data, int channels)>)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncAudioFilterReadTrigger GetAsyncAudioFilterReadTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncAudioFilterReadTrigger>(gameObject);
+        }
+        
+        public static AsyncAudioFilterReadTrigger GetAsyncAudioFilterReadTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncAudioFilterReadTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncAudioFilterReadTrigger : AsyncTriggerBase<(float[] data, int channels)>
+    {
+        void OnAudioFilterRead(float[] data, int channels)
+        {
+            RaiseEvent((data, channels));
+        }
+
+        public IAsyncOnAudioFilterReadHandler GetOnAudioFilterReadAsyncHandler()
+        {
+            return new AsyncTriggerHandler<(float[] data, int channels)>(this, false);
+        }
+
+        public IAsyncOnAudioFilterReadHandler GetOnAudioFilterReadAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<(float[] data, int channels)>(this, cancellationToken, false);
+        }
+
+        public UniTask<(float[] data, int channels)> OnAudioFilterReadAsync()
+        {
+            return ((IAsyncOnAudioFilterReadHandler)new AsyncTriggerHandler<(float[] data, int channels)>(this, true)).OnAudioFilterReadAsync();
+        }
+
+        public UniTask<(float[] data, int channels)> OnAudioFilterReadAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnAudioFilterReadHandler)new AsyncTriggerHandler<(float[] data, int channels)>(this, cancellationToken, true)).OnAudioFilterReadAsync();
+        }
+    }
+#endregion
+
+#region BecameInvisible
+
+    public interface IAsyncOnBecameInvisibleHandler
+    {
+        UniTask OnBecameInvisibleAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnBecameInvisibleHandler
+    {
+        UniTask IAsyncOnBecameInvisibleHandler.OnBecameInvisibleAsync()
+        {
+            core.Reset();
+            return new UniTask((IUniTaskSource)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncBecameInvisibleTrigger GetAsyncBecameInvisibleTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncBecameInvisibleTrigger>(gameObject);
+        }
+        
+        public static AsyncBecameInvisibleTrigger GetAsyncBecameInvisibleTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncBecameInvisibleTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncBecameInvisibleTrigger : AsyncTriggerBase<AsyncUnit>
+    {
+        void OnBecameInvisible()
+        {
+            RaiseEvent(AsyncUnit.Default);
+        }
+
+        public IAsyncOnBecameInvisibleHandler GetOnBecameInvisibleAsyncHandler()
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, false);
+        }
+
+        public IAsyncOnBecameInvisibleHandler GetOnBecameInvisibleAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, false);
+        }
+
+        public UniTask OnBecameInvisibleAsync()
+        {
+            return ((IAsyncOnBecameInvisibleHandler)new AsyncTriggerHandler<AsyncUnit>(this, true)).OnBecameInvisibleAsync();
+        }
+
+        public UniTask OnBecameInvisibleAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnBecameInvisibleHandler)new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, true)).OnBecameInvisibleAsync();
+        }
+    }
+#endregion
+
+#region BecameVisible
+
+    public interface IAsyncOnBecameVisibleHandler
+    {
+        UniTask OnBecameVisibleAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnBecameVisibleHandler
+    {
+        UniTask IAsyncOnBecameVisibleHandler.OnBecameVisibleAsync()
+        {
+            core.Reset();
+            return new UniTask((IUniTaskSource)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncBecameVisibleTrigger GetAsyncBecameVisibleTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncBecameVisibleTrigger>(gameObject);
+        }
+        
+        public static AsyncBecameVisibleTrigger GetAsyncBecameVisibleTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncBecameVisibleTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncBecameVisibleTrigger : AsyncTriggerBase<AsyncUnit>
+    {
+        void OnBecameVisible()
+        {
+            RaiseEvent(AsyncUnit.Default);
+        }
+
+        public IAsyncOnBecameVisibleHandler GetOnBecameVisibleAsyncHandler()
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, false);
+        }
+
+        public IAsyncOnBecameVisibleHandler GetOnBecameVisibleAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, false);
+        }
+
+        public UniTask OnBecameVisibleAsync()
+        {
+            return ((IAsyncOnBecameVisibleHandler)new AsyncTriggerHandler<AsyncUnit>(this, true)).OnBecameVisibleAsync();
+        }
+
+        public UniTask OnBecameVisibleAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnBecameVisibleHandler)new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, true)).OnBecameVisibleAsync();
+        }
+    }
+#endregion
+
+#region BeforeTransformParentChanged
+
+    public interface IAsyncOnBeforeTransformParentChangedHandler
+    {
+        UniTask OnBeforeTransformParentChangedAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnBeforeTransformParentChangedHandler
+    {
+        UniTask IAsyncOnBeforeTransformParentChangedHandler.OnBeforeTransformParentChangedAsync()
+        {
+            core.Reset();
+            return new UniTask((IUniTaskSource)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncBeforeTransformParentChangedTrigger GetAsyncBeforeTransformParentChangedTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncBeforeTransformParentChangedTrigger>(gameObject);
+        }
+        
+        public static AsyncBeforeTransformParentChangedTrigger GetAsyncBeforeTransformParentChangedTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncBeforeTransformParentChangedTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncBeforeTransformParentChangedTrigger : AsyncTriggerBase<AsyncUnit>
+    {
+        void OnBeforeTransformParentChanged()
+        {
+            RaiseEvent(AsyncUnit.Default);
+        }
+
+        public IAsyncOnBeforeTransformParentChangedHandler GetOnBeforeTransformParentChangedAsyncHandler()
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, false);
+        }
+
+        public IAsyncOnBeforeTransformParentChangedHandler GetOnBeforeTransformParentChangedAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, false);
+        }
+
+        public UniTask OnBeforeTransformParentChangedAsync()
+        {
+            return ((IAsyncOnBeforeTransformParentChangedHandler)new AsyncTriggerHandler<AsyncUnit>(this, true)).OnBeforeTransformParentChangedAsync();
+        }
+
+        public UniTask OnBeforeTransformParentChangedAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnBeforeTransformParentChangedHandler)new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, true)).OnBeforeTransformParentChangedAsync();
+        }
+    }
+#endregion
+
+#region OnCanvasGroupChanged
+
+    public interface IAsyncOnCanvasGroupChangedHandler
+    {
+        UniTask OnCanvasGroupChangedAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnCanvasGroupChangedHandler
+    {
+        UniTask IAsyncOnCanvasGroupChangedHandler.OnCanvasGroupChangedAsync()
+        {
+            core.Reset();
+            return new UniTask((IUniTaskSource)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncOnCanvasGroupChangedTrigger GetAsyncOnCanvasGroupChangedTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncOnCanvasGroupChangedTrigger>(gameObject);
+        }
+        
+        public static AsyncOnCanvasGroupChangedTrigger GetAsyncOnCanvasGroupChangedTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncOnCanvasGroupChangedTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncOnCanvasGroupChangedTrigger : AsyncTriggerBase<AsyncUnit>
+    {
+        void OnCanvasGroupChanged()
+        {
+            RaiseEvent(AsyncUnit.Default);
+        }
+
+        public IAsyncOnCanvasGroupChangedHandler GetOnCanvasGroupChangedAsyncHandler()
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, false);
+        }
+
+        public IAsyncOnCanvasGroupChangedHandler GetOnCanvasGroupChangedAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, false);
+        }
+
+        public UniTask OnCanvasGroupChangedAsync()
+        {
+            return ((IAsyncOnCanvasGroupChangedHandler)new AsyncTriggerHandler<AsyncUnit>(this, true)).OnCanvasGroupChangedAsync();
+        }
+
+        public UniTask OnCanvasGroupChangedAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnCanvasGroupChangedHandler)new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, true)).OnCanvasGroupChangedAsync();
+        }
+    }
+#endregion
+
+#region CollisionEnter
+#if !UNITY_2019_1_OR_NEWER || UNITASK_PHYSICS_SUPPORT
+
+    public interface IAsyncOnCollisionEnterHandler
+    {
+        UniTask<Collision> OnCollisionEnterAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnCollisionEnterHandler
+    {
+        UniTask<Collision> IAsyncOnCollisionEnterHandler.OnCollisionEnterAsync()
+        {
+            core.Reset();
+            return new UniTask<Collision>((IUniTaskSource<Collision>)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncCollisionEnterTrigger GetAsyncCollisionEnterTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncCollisionEnterTrigger>(gameObject);
+        }
+        
+        public static AsyncCollisionEnterTrigger GetAsyncCollisionEnterTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncCollisionEnterTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncCollisionEnterTrigger : AsyncTriggerBase<Collision>
+    {
+        void OnCollisionEnter(Collision coll)
+        {
+            RaiseEvent((coll));
+        }
+
+        public IAsyncOnCollisionEnterHandler GetOnCollisionEnterAsyncHandler()
+        {
+            return new AsyncTriggerHandler<Collision>(this, false);
+        }
+
+        public IAsyncOnCollisionEnterHandler GetOnCollisionEnterAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<Collision>(this, cancellationToken, false);
+        }
+
+        public UniTask<Collision> OnCollisionEnterAsync()
+        {
+            return ((IAsyncOnCollisionEnterHandler)new AsyncTriggerHandler<Collision>(this, true)).OnCollisionEnterAsync();
+        }
+
+        public UniTask<Collision> OnCollisionEnterAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnCollisionEnterHandler)new AsyncTriggerHandler<Collision>(this, cancellationToken, true)).OnCollisionEnterAsync();
+        }
+    }
+#endif
+#endregion
+
+#region CollisionEnter2D
+#if !UNITY_2019_1_OR_NEWER || UNITASK_PHYSICS2D_SUPPORT
+
+    public interface IAsyncOnCollisionEnter2DHandler
+    {
+        UniTask<Collision2D> OnCollisionEnter2DAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnCollisionEnter2DHandler
+    {
+        UniTask<Collision2D> IAsyncOnCollisionEnter2DHandler.OnCollisionEnter2DAsync()
+        {
+            core.Reset();
+            return new UniTask<Collision2D>((IUniTaskSource<Collision2D>)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncCollisionEnter2DTrigger GetAsyncCollisionEnter2DTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncCollisionEnter2DTrigger>(gameObject);
+        }
+        
+        public static AsyncCollisionEnter2DTrigger GetAsyncCollisionEnter2DTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncCollisionEnter2DTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncCollisionEnter2DTrigger : AsyncTriggerBase<Collision2D>
+    {
+        void OnCollisionEnter2D(Collision2D coll)
+        {
+            RaiseEvent((coll));
+        }
+
+        public IAsyncOnCollisionEnter2DHandler GetOnCollisionEnter2DAsyncHandler()
+        {
+            return new AsyncTriggerHandler<Collision2D>(this, false);
+        }
+
+        public IAsyncOnCollisionEnter2DHandler GetOnCollisionEnter2DAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<Collision2D>(this, cancellationToken, false);
+        }
+
+        public UniTask<Collision2D> OnCollisionEnter2DAsync()
+        {
+            return ((IAsyncOnCollisionEnter2DHandler)new AsyncTriggerHandler<Collision2D>(this, true)).OnCollisionEnter2DAsync();
+        }
+
+        public UniTask<Collision2D> OnCollisionEnter2DAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnCollisionEnter2DHandler)new AsyncTriggerHandler<Collision2D>(this, cancellationToken, true)).OnCollisionEnter2DAsync();
+        }
+    }
+#endif
+#endregion
+
+#region CollisionExit
+#if !UNITY_2019_1_OR_NEWER || UNITASK_PHYSICS_SUPPORT
+
+    public interface IAsyncOnCollisionExitHandler
+    {
+        UniTask<Collision> OnCollisionExitAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnCollisionExitHandler
+    {
+        UniTask<Collision> IAsyncOnCollisionExitHandler.OnCollisionExitAsync()
+        {
+            core.Reset();
+            return new UniTask<Collision>((IUniTaskSource<Collision>)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncCollisionExitTrigger GetAsyncCollisionExitTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncCollisionExitTrigger>(gameObject);
+        }
+        
+        public static AsyncCollisionExitTrigger GetAsyncCollisionExitTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncCollisionExitTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncCollisionExitTrigger : AsyncTriggerBase<Collision>
+    {
+        void OnCollisionExit(Collision coll)
+        {
+            RaiseEvent((coll));
+        }
+
+        public IAsyncOnCollisionExitHandler GetOnCollisionExitAsyncHandler()
+        {
+            return new AsyncTriggerHandler<Collision>(this, false);
+        }
+
+        public IAsyncOnCollisionExitHandler GetOnCollisionExitAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<Collision>(this, cancellationToken, false);
+        }
+
+        public UniTask<Collision> OnCollisionExitAsync()
+        {
+            return ((IAsyncOnCollisionExitHandler)new AsyncTriggerHandler<Collision>(this, true)).OnCollisionExitAsync();
+        }
+
+        public UniTask<Collision> OnCollisionExitAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnCollisionExitHandler)new AsyncTriggerHandler<Collision>(this, cancellationToken, true)).OnCollisionExitAsync();
+        }
+    }
+#endif
+#endregion
+
+#region CollisionExit2D
+#if !UNITY_2019_1_OR_NEWER || UNITASK_PHYSICS2D_SUPPORT
+
+    public interface IAsyncOnCollisionExit2DHandler
+    {
+        UniTask<Collision2D> OnCollisionExit2DAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnCollisionExit2DHandler
+    {
+        UniTask<Collision2D> IAsyncOnCollisionExit2DHandler.OnCollisionExit2DAsync()
+        {
+            core.Reset();
+            return new UniTask<Collision2D>((IUniTaskSource<Collision2D>)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncCollisionExit2DTrigger GetAsyncCollisionExit2DTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncCollisionExit2DTrigger>(gameObject);
+        }
+        
+        public static AsyncCollisionExit2DTrigger GetAsyncCollisionExit2DTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncCollisionExit2DTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncCollisionExit2DTrigger : AsyncTriggerBase<Collision2D>
+    {
+        void OnCollisionExit2D(Collision2D coll)
+        {
+            RaiseEvent((coll));
+        }
+
+        public IAsyncOnCollisionExit2DHandler GetOnCollisionExit2DAsyncHandler()
+        {
+            return new AsyncTriggerHandler<Collision2D>(this, false);
+        }
+
+        public IAsyncOnCollisionExit2DHandler GetOnCollisionExit2DAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<Collision2D>(this, cancellationToken, false);
+        }
+
+        public UniTask<Collision2D> OnCollisionExit2DAsync()
+        {
+            return ((IAsyncOnCollisionExit2DHandler)new AsyncTriggerHandler<Collision2D>(this, true)).OnCollisionExit2DAsync();
+        }
+
+        public UniTask<Collision2D> OnCollisionExit2DAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnCollisionExit2DHandler)new AsyncTriggerHandler<Collision2D>(this, cancellationToken, true)).OnCollisionExit2DAsync();
+        }
+    }
+#endif
+#endregion
+
+#region CollisionStay
+#if !UNITY_2019_1_OR_NEWER || UNITASK_PHYSICS_SUPPORT
+
+    public interface IAsyncOnCollisionStayHandler
+    {
+        UniTask<Collision> OnCollisionStayAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnCollisionStayHandler
+    {
+        UniTask<Collision> IAsyncOnCollisionStayHandler.OnCollisionStayAsync()
+        {
+            core.Reset();
+            return new UniTask<Collision>((IUniTaskSource<Collision>)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncCollisionStayTrigger GetAsyncCollisionStayTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncCollisionStayTrigger>(gameObject);
+        }
+        
+        public static AsyncCollisionStayTrigger GetAsyncCollisionStayTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncCollisionStayTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncCollisionStayTrigger : AsyncTriggerBase<Collision>
+    {
+        void OnCollisionStay(Collision coll)
+        {
+            RaiseEvent((coll));
+        }
+
+        public IAsyncOnCollisionStayHandler GetOnCollisionStayAsyncHandler()
+        {
+            return new AsyncTriggerHandler<Collision>(this, false);
+        }
+
+        public IAsyncOnCollisionStayHandler GetOnCollisionStayAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<Collision>(this, cancellationToken, false);
+        }
+
+        public UniTask<Collision> OnCollisionStayAsync()
+        {
+            return ((IAsyncOnCollisionStayHandler)new AsyncTriggerHandler<Collision>(this, true)).OnCollisionStayAsync();
+        }
+
+        public UniTask<Collision> OnCollisionStayAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnCollisionStayHandler)new AsyncTriggerHandler<Collision>(this, cancellationToken, true)).OnCollisionStayAsync();
+        }
+    }
+#endif
+#endregion
+
+#region CollisionStay2D
+#if !UNITY_2019_1_OR_NEWER || UNITASK_PHYSICS2D_SUPPORT
+
+    public interface IAsyncOnCollisionStay2DHandler
+    {
+        UniTask<Collision2D> OnCollisionStay2DAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnCollisionStay2DHandler
+    {
+        UniTask<Collision2D> IAsyncOnCollisionStay2DHandler.OnCollisionStay2DAsync()
+        {
+            core.Reset();
+            return new UniTask<Collision2D>((IUniTaskSource<Collision2D>)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncCollisionStay2DTrigger GetAsyncCollisionStay2DTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncCollisionStay2DTrigger>(gameObject);
+        }
+        
+        public static AsyncCollisionStay2DTrigger GetAsyncCollisionStay2DTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncCollisionStay2DTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncCollisionStay2DTrigger : AsyncTriggerBase<Collision2D>
+    {
+        void OnCollisionStay2D(Collision2D coll)
+        {
+            RaiseEvent((coll));
+        }
+
+        public IAsyncOnCollisionStay2DHandler GetOnCollisionStay2DAsyncHandler()
+        {
+            return new AsyncTriggerHandler<Collision2D>(this, false);
+        }
+
+        public IAsyncOnCollisionStay2DHandler GetOnCollisionStay2DAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<Collision2D>(this, cancellationToken, false);
+        }
+
+        public UniTask<Collision2D> OnCollisionStay2DAsync()
+        {
+            return ((IAsyncOnCollisionStay2DHandler)new AsyncTriggerHandler<Collision2D>(this, true)).OnCollisionStay2DAsync();
+        }
+
+        public UniTask<Collision2D> OnCollisionStay2DAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnCollisionStay2DHandler)new AsyncTriggerHandler<Collision2D>(this, cancellationToken, true)).OnCollisionStay2DAsync();
+        }
+    }
+#endif
+#endregion
+
+#region ControllerColliderHit
+#if !UNITY_2019_1_OR_NEWER || UNITASK_PHYSICS_SUPPORT
+
+    public interface IAsyncOnControllerColliderHitHandler
+    {
+        UniTask<ControllerColliderHit> OnControllerColliderHitAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnControllerColliderHitHandler
+    {
+        UniTask<ControllerColliderHit> IAsyncOnControllerColliderHitHandler.OnControllerColliderHitAsync()
+        {
+            core.Reset();
+            return new UniTask<ControllerColliderHit>((IUniTaskSource<ControllerColliderHit>)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncControllerColliderHitTrigger GetAsyncControllerColliderHitTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncControllerColliderHitTrigger>(gameObject);
+        }
+        
+        public static AsyncControllerColliderHitTrigger GetAsyncControllerColliderHitTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncControllerColliderHitTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncControllerColliderHitTrigger : AsyncTriggerBase<ControllerColliderHit>
+    {
+        void OnControllerColliderHit(ControllerColliderHit hit)
+        {
+            RaiseEvent((hit));
+        }
+
+        public IAsyncOnControllerColliderHitHandler GetOnControllerColliderHitAsyncHandler()
+        {
+            return new AsyncTriggerHandler<ControllerColliderHit>(this, false);
+        }
+
+        public IAsyncOnControllerColliderHitHandler GetOnControllerColliderHitAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<ControllerColliderHit>(this, cancellationToken, false);
+        }
+
+        public UniTask<ControllerColliderHit> OnControllerColliderHitAsync()
+        {
+            return ((IAsyncOnControllerColliderHitHandler)new AsyncTriggerHandler<ControllerColliderHit>(this, true)).OnControllerColliderHitAsync();
+        }
+
+        public UniTask<ControllerColliderHit> OnControllerColliderHitAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnControllerColliderHitHandler)new AsyncTriggerHandler<ControllerColliderHit>(this, cancellationToken, true)).OnControllerColliderHitAsync();
+        }
+    }
+#endif
+#endregion
+
+#region Disable
+
+    public interface IAsyncOnDisableHandler
+    {
+        UniTask OnDisableAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnDisableHandler
+    {
+        UniTask IAsyncOnDisableHandler.OnDisableAsync()
+        {
+            core.Reset();
+            return new UniTask((IUniTaskSource)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncDisableTrigger GetAsyncDisableTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncDisableTrigger>(gameObject);
+        }
+        
+        public static AsyncDisableTrigger GetAsyncDisableTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncDisableTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncDisableTrigger : AsyncTriggerBase<AsyncUnit>
+    {
+        void OnDisable()
+        {
+            RaiseEvent(AsyncUnit.Default);
+        }
+
+        public IAsyncOnDisableHandler GetOnDisableAsyncHandler()
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, false);
+        }
+
+        public IAsyncOnDisableHandler GetOnDisableAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, false);
+        }
+
+        public UniTask OnDisableAsync()
+        {
+            return ((IAsyncOnDisableHandler)new AsyncTriggerHandler<AsyncUnit>(this, true)).OnDisableAsync();
+        }
+
+        public UniTask OnDisableAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnDisableHandler)new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, true)).OnDisableAsync();
+        }
+    }
+#endregion
+
+#region DrawGizmos
+
+    public interface IAsyncOnDrawGizmosHandler
+    {
+        UniTask OnDrawGizmosAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnDrawGizmosHandler
+    {
+        UniTask IAsyncOnDrawGizmosHandler.OnDrawGizmosAsync()
+        {
+            core.Reset();
+            return new UniTask((IUniTaskSource)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncDrawGizmosTrigger GetAsyncDrawGizmosTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncDrawGizmosTrigger>(gameObject);
+        }
+        
+        public static AsyncDrawGizmosTrigger GetAsyncDrawGizmosTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncDrawGizmosTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncDrawGizmosTrigger : AsyncTriggerBase<AsyncUnit>
+    {
+        void OnDrawGizmos()
+        {
+            RaiseEvent(AsyncUnit.Default);
+        }
+
+        public IAsyncOnDrawGizmosHandler GetOnDrawGizmosAsyncHandler()
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, false);
+        }
+
+        public IAsyncOnDrawGizmosHandler GetOnDrawGizmosAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, false);
+        }
+
+        public UniTask OnDrawGizmosAsync()
+        {
+            return ((IAsyncOnDrawGizmosHandler)new AsyncTriggerHandler<AsyncUnit>(this, true)).OnDrawGizmosAsync();
+        }
+
+        public UniTask OnDrawGizmosAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnDrawGizmosHandler)new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, true)).OnDrawGizmosAsync();
+        }
+    }
+#endregion
+
+#region DrawGizmosSelected
+
+    public interface IAsyncOnDrawGizmosSelectedHandler
+    {
+        UniTask OnDrawGizmosSelectedAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnDrawGizmosSelectedHandler
+    {
+        UniTask IAsyncOnDrawGizmosSelectedHandler.OnDrawGizmosSelectedAsync()
+        {
+            core.Reset();
+            return new UniTask((IUniTaskSource)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncDrawGizmosSelectedTrigger GetAsyncDrawGizmosSelectedTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncDrawGizmosSelectedTrigger>(gameObject);
+        }
+        
+        public static AsyncDrawGizmosSelectedTrigger GetAsyncDrawGizmosSelectedTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncDrawGizmosSelectedTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncDrawGizmosSelectedTrigger : AsyncTriggerBase<AsyncUnit>
+    {
+        void OnDrawGizmosSelected()
+        {
+            RaiseEvent(AsyncUnit.Default);
+        }
+
+        public IAsyncOnDrawGizmosSelectedHandler GetOnDrawGizmosSelectedAsyncHandler()
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, false);
+        }
+
+        public IAsyncOnDrawGizmosSelectedHandler GetOnDrawGizmosSelectedAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, false);
+        }
+
+        public UniTask OnDrawGizmosSelectedAsync()
+        {
+            return ((IAsyncOnDrawGizmosSelectedHandler)new AsyncTriggerHandler<AsyncUnit>(this, true)).OnDrawGizmosSelectedAsync();
+        }
+
+        public UniTask OnDrawGizmosSelectedAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnDrawGizmosSelectedHandler)new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, true)).OnDrawGizmosSelectedAsync();
+        }
+    }
+#endregion
+
+#region Enable
+
+    public interface IAsyncOnEnableHandler
+    {
+        UniTask OnEnableAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnEnableHandler
+    {
+        UniTask IAsyncOnEnableHandler.OnEnableAsync()
+        {
+            core.Reset();
+            return new UniTask((IUniTaskSource)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncEnableTrigger GetAsyncEnableTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncEnableTrigger>(gameObject);
+        }
+        
+        public static AsyncEnableTrigger GetAsyncEnableTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncEnableTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncEnableTrigger : AsyncTriggerBase<AsyncUnit>
+    {
+        void OnEnable()
+        {
+            RaiseEvent(AsyncUnit.Default);
+        }
+
+        public IAsyncOnEnableHandler GetOnEnableAsyncHandler()
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, false);
+        }
+
+        public IAsyncOnEnableHandler GetOnEnableAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, false);
+        }
+
+        public UniTask OnEnableAsync()
+        {
+            return ((IAsyncOnEnableHandler)new AsyncTriggerHandler<AsyncUnit>(this, true)).OnEnableAsync();
+        }
+
+        public UniTask OnEnableAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnEnableHandler)new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, true)).OnEnableAsync();
+        }
+    }
+#endregion
+
+#region GUI
+
+    public interface IAsyncOnGUIHandler
+    {
+        UniTask OnGUIAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnGUIHandler
+    {
+        UniTask IAsyncOnGUIHandler.OnGUIAsync()
+        {
+            core.Reset();
+            return new UniTask((IUniTaskSource)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncGUITrigger GetAsyncGUITrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncGUITrigger>(gameObject);
+        }
+        
+        public static AsyncGUITrigger GetAsyncGUITrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncGUITrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncGUITrigger : AsyncTriggerBase<AsyncUnit>
+    {
+        void OnGUI()
+        {
+            RaiseEvent(AsyncUnit.Default);
+        }
+
+        public IAsyncOnGUIHandler GetOnGUIAsyncHandler()
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, false);
+        }
+
+        public IAsyncOnGUIHandler GetOnGUIAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, false);
+        }
+
+        public UniTask OnGUIAsync()
+        {
+            return ((IAsyncOnGUIHandler)new AsyncTriggerHandler<AsyncUnit>(this, true)).OnGUIAsync();
+        }
+
+        public UniTask OnGUIAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnGUIHandler)new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, true)).OnGUIAsync();
+        }
+    }
+#endregion
+
+#region JointBreak
+#if !UNITY_2019_1_OR_NEWER || UNITASK_PHYSICS_SUPPORT
+
+    public interface IAsyncOnJointBreakHandler
+    {
+        UniTask<float> OnJointBreakAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnJointBreakHandler
+    {
+        UniTask<float> IAsyncOnJointBreakHandler.OnJointBreakAsync()
+        {
+            core.Reset();
+            return new UniTask<float>((IUniTaskSource<float>)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncJointBreakTrigger GetAsyncJointBreakTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncJointBreakTrigger>(gameObject);
+        }
+        
+        public static AsyncJointBreakTrigger GetAsyncJointBreakTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncJointBreakTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncJointBreakTrigger : AsyncTriggerBase<float>
+    {
+        void OnJointBreak(float breakForce)
+        {
+            RaiseEvent((breakForce));
+        }
+
+        public IAsyncOnJointBreakHandler GetOnJointBreakAsyncHandler()
+        {
+            return new AsyncTriggerHandler<float>(this, false);
+        }
+
+        public IAsyncOnJointBreakHandler GetOnJointBreakAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<float>(this, cancellationToken, false);
+        }
+
+        public UniTask<float> OnJointBreakAsync()
+        {
+            return ((IAsyncOnJointBreakHandler)new AsyncTriggerHandler<float>(this, true)).OnJointBreakAsync();
+        }
+
+        public UniTask<float> OnJointBreakAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnJointBreakHandler)new AsyncTriggerHandler<float>(this, cancellationToken, true)).OnJointBreakAsync();
+        }
+    }
+#endif
+#endregion
+
+#region JointBreak2D
+#if !UNITY_2019_1_OR_NEWER || UNITASK_PHYSICS2D_SUPPORT
+
+    public interface IAsyncOnJointBreak2DHandler
+    {
+        UniTask<Joint2D> OnJointBreak2DAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnJointBreak2DHandler
+    {
+        UniTask<Joint2D> IAsyncOnJointBreak2DHandler.OnJointBreak2DAsync()
+        {
+            core.Reset();
+            return new UniTask<Joint2D>((IUniTaskSource<Joint2D>)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncJointBreak2DTrigger GetAsyncJointBreak2DTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncJointBreak2DTrigger>(gameObject);
+        }
+        
+        public static AsyncJointBreak2DTrigger GetAsyncJointBreak2DTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncJointBreak2DTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncJointBreak2DTrigger : AsyncTriggerBase<Joint2D>
+    {
+        void OnJointBreak2D(Joint2D brokenJoint)
+        {
+            RaiseEvent((brokenJoint));
+        }
+
+        public IAsyncOnJointBreak2DHandler GetOnJointBreak2DAsyncHandler()
+        {
+            return new AsyncTriggerHandler<Joint2D>(this, false);
+        }
+
+        public IAsyncOnJointBreak2DHandler GetOnJointBreak2DAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<Joint2D>(this, cancellationToken, false);
+        }
+
+        public UniTask<Joint2D> OnJointBreak2DAsync()
+        {
+            return ((IAsyncOnJointBreak2DHandler)new AsyncTriggerHandler<Joint2D>(this, true)).OnJointBreak2DAsync();
+        }
+
+        public UniTask<Joint2D> OnJointBreak2DAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnJointBreak2DHandler)new AsyncTriggerHandler<Joint2D>(this, cancellationToken, true)).OnJointBreak2DAsync();
+        }
+    }
+#endif
+#endregion
+
+#region MouseDown
+#if !(UNITY_IPHONE || UNITY_ANDROID || UNITY_METRO)
+
+    public interface IAsyncOnMouseDownHandler
+    {
+        UniTask OnMouseDownAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnMouseDownHandler
+    {
+        UniTask IAsyncOnMouseDownHandler.OnMouseDownAsync()
+        {
+            core.Reset();
+            return new UniTask((IUniTaskSource)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncMouseDownTrigger GetAsyncMouseDownTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncMouseDownTrigger>(gameObject);
+        }
+        
+        public static AsyncMouseDownTrigger GetAsyncMouseDownTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncMouseDownTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncMouseDownTrigger : AsyncTriggerBase<AsyncUnit>
+    {
+        void OnMouseDown()
+        {
+            RaiseEvent(AsyncUnit.Default);
+        }
+
+        public IAsyncOnMouseDownHandler GetOnMouseDownAsyncHandler()
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, false);
+        }
+
+        public IAsyncOnMouseDownHandler GetOnMouseDownAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, false);
+        }
+
+        public UniTask OnMouseDownAsync()
+        {
+            return ((IAsyncOnMouseDownHandler)new AsyncTriggerHandler<AsyncUnit>(this, true)).OnMouseDownAsync();
+        }
+
+        public UniTask OnMouseDownAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnMouseDownHandler)new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, true)).OnMouseDownAsync();
+        }
+    }
+#endif
+#endregion
+
+#region MouseDrag
+#if !(UNITY_IPHONE || UNITY_ANDROID || UNITY_METRO)
+
+    public interface IAsyncOnMouseDragHandler
+    {
+        UniTask OnMouseDragAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnMouseDragHandler
+    {
+        UniTask IAsyncOnMouseDragHandler.OnMouseDragAsync()
+        {
+            core.Reset();
+            return new UniTask((IUniTaskSource)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncMouseDragTrigger GetAsyncMouseDragTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncMouseDragTrigger>(gameObject);
+        }
+        
+        public static AsyncMouseDragTrigger GetAsyncMouseDragTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncMouseDragTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncMouseDragTrigger : AsyncTriggerBase<AsyncUnit>
+    {
+        void OnMouseDrag()
+        {
+            RaiseEvent(AsyncUnit.Default);
+        }
+
+        public IAsyncOnMouseDragHandler GetOnMouseDragAsyncHandler()
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, false);
+        }
+
+        public IAsyncOnMouseDragHandler GetOnMouseDragAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, false);
+        }
+
+        public UniTask OnMouseDragAsync()
+        {
+            return ((IAsyncOnMouseDragHandler)new AsyncTriggerHandler<AsyncUnit>(this, true)).OnMouseDragAsync();
+        }
+
+        public UniTask OnMouseDragAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnMouseDragHandler)new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, true)).OnMouseDragAsync();
+        }
+    }
+#endif
+#endregion
+
+#region MouseEnter
+#if !(UNITY_IPHONE || UNITY_ANDROID || UNITY_METRO)
+
+    public interface IAsyncOnMouseEnterHandler
+    {
+        UniTask OnMouseEnterAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnMouseEnterHandler
+    {
+        UniTask IAsyncOnMouseEnterHandler.OnMouseEnterAsync()
+        {
+            core.Reset();
+            return new UniTask((IUniTaskSource)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncMouseEnterTrigger GetAsyncMouseEnterTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncMouseEnterTrigger>(gameObject);
+        }
+        
+        public static AsyncMouseEnterTrigger GetAsyncMouseEnterTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncMouseEnterTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncMouseEnterTrigger : AsyncTriggerBase<AsyncUnit>
+    {
+        void OnMouseEnter()
+        {
+            RaiseEvent(AsyncUnit.Default);
+        }
+
+        public IAsyncOnMouseEnterHandler GetOnMouseEnterAsyncHandler()
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, false);
+        }
+
+        public IAsyncOnMouseEnterHandler GetOnMouseEnterAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, false);
+        }
+
+        public UniTask OnMouseEnterAsync()
+        {
+            return ((IAsyncOnMouseEnterHandler)new AsyncTriggerHandler<AsyncUnit>(this, true)).OnMouseEnterAsync();
+        }
+
+        public UniTask OnMouseEnterAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnMouseEnterHandler)new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, true)).OnMouseEnterAsync();
+        }
+    }
+#endif
+#endregion
+
+#region MouseExit
+#if !(UNITY_IPHONE || UNITY_ANDROID || UNITY_METRO)
+
+    public interface IAsyncOnMouseExitHandler
+    {
+        UniTask OnMouseExitAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnMouseExitHandler
+    {
+        UniTask IAsyncOnMouseExitHandler.OnMouseExitAsync()
+        {
+            core.Reset();
+            return new UniTask((IUniTaskSource)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncMouseExitTrigger GetAsyncMouseExitTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncMouseExitTrigger>(gameObject);
+        }
+        
+        public static AsyncMouseExitTrigger GetAsyncMouseExitTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncMouseExitTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncMouseExitTrigger : AsyncTriggerBase<AsyncUnit>
+    {
+        void OnMouseExit()
+        {
+            RaiseEvent(AsyncUnit.Default);
+        }
+
+        public IAsyncOnMouseExitHandler GetOnMouseExitAsyncHandler()
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, false);
+        }
+
+        public IAsyncOnMouseExitHandler GetOnMouseExitAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, false);
+        }
+
+        public UniTask OnMouseExitAsync()
+        {
+            return ((IAsyncOnMouseExitHandler)new AsyncTriggerHandler<AsyncUnit>(this, true)).OnMouseExitAsync();
+        }
+
+        public UniTask OnMouseExitAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnMouseExitHandler)new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, true)).OnMouseExitAsync();
+        }
+    }
+#endif
+#endregion
+
+#region MouseOver
+#if !(UNITY_IPHONE || UNITY_ANDROID || UNITY_METRO)
+
+    public interface IAsyncOnMouseOverHandler
+    {
+        UniTask OnMouseOverAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnMouseOverHandler
+    {
+        UniTask IAsyncOnMouseOverHandler.OnMouseOverAsync()
+        {
+            core.Reset();
+            return new UniTask((IUniTaskSource)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncMouseOverTrigger GetAsyncMouseOverTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncMouseOverTrigger>(gameObject);
+        }
+        
+        public static AsyncMouseOverTrigger GetAsyncMouseOverTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncMouseOverTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncMouseOverTrigger : AsyncTriggerBase<AsyncUnit>
+    {
+        void OnMouseOver()
+        {
+            RaiseEvent(AsyncUnit.Default);
+        }
+
+        public IAsyncOnMouseOverHandler GetOnMouseOverAsyncHandler()
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, false);
+        }
+
+        public IAsyncOnMouseOverHandler GetOnMouseOverAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, false);
+        }
+
+        public UniTask OnMouseOverAsync()
+        {
+            return ((IAsyncOnMouseOverHandler)new AsyncTriggerHandler<AsyncUnit>(this, true)).OnMouseOverAsync();
+        }
+
+        public UniTask OnMouseOverAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnMouseOverHandler)new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, true)).OnMouseOverAsync();
+        }
+    }
+#endif
+#endregion
+
+#region MouseUp
+#if !(UNITY_IPHONE || UNITY_ANDROID || UNITY_METRO)
+
+    public interface IAsyncOnMouseUpHandler
+    {
+        UniTask OnMouseUpAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnMouseUpHandler
+    {
+        UniTask IAsyncOnMouseUpHandler.OnMouseUpAsync()
+        {
+            core.Reset();
+            return new UniTask((IUniTaskSource)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncMouseUpTrigger GetAsyncMouseUpTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncMouseUpTrigger>(gameObject);
+        }
+        
+        public static AsyncMouseUpTrigger GetAsyncMouseUpTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncMouseUpTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncMouseUpTrigger : AsyncTriggerBase<AsyncUnit>
+    {
+        void OnMouseUp()
+        {
+            RaiseEvent(AsyncUnit.Default);
+        }
+
+        public IAsyncOnMouseUpHandler GetOnMouseUpAsyncHandler()
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, false);
+        }
+
+        public IAsyncOnMouseUpHandler GetOnMouseUpAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, false);
+        }
+
+        public UniTask OnMouseUpAsync()
+        {
+            return ((IAsyncOnMouseUpHandler)new AsyncTriggerHandler<AsyncUnit>(this, true)).OnMouseUpAsync();
+        }
+
+        public UniTask OnMouseUpAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnMouseUpHandler)new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, true)).OnMouseUpAsync();
+        }
+    }
+#endif
+#endregion
+
+#region MouseUpAsButton
+#if !(UNITY_IPHONE || UNITY_ANDROID || UNITY_METRO)
+
+    public interface IAsyncOnMouseUpAsButtonHandler
+    {
+        UniTask OnMouseUpAsButtonAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnMouseUpAsButtonHandler
+    {
+        UniTask IAsyncOnMouseUpAsButtonHandler.OnMouseUpAsButtonAsync()
+        {
+            core.Reset();
+            return new UniTask((IUniTaskSource)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncMouseUpAsButtonTrigger GetAsyncMouseUpAsButtonTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncMouseUpAsButtonTrigger>(gameObject);
+        }
+        
+        public static AsyncMouseUpAsButtonTrigger GetAsyncMouseUpAsButtonTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncMouseUpAsButtonTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncMouseUpAsButtonTrigger : AsyncTriggerBase<AsyncUnit>
+    {
+        void OnMouseUpAsButton()
+        {
+            RaiseEvent(AsyncUnit.Default);
+        }
+
+        public IAsyncOnMouseUpAsButtonHandler GetOnMouseUpAsButtonAsyncHandler()
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, false);
+        }
+
+        public IAsyncOnMouseUpAsButtonHandler GetOnMouseUpAsButtonAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, false);
+        }
+
+        public UniTask OnMouseUpAsButtonAsync()
+        {
+            return ((IAsyncOnMouseUpAsButtonHandler)new AsyncTriggerHandler<AsyncUnit>(this, true)).OnMouseUpAsButtonAsync();
+        }
+
+        public UniTask OnMouseUpAsButtonAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnMouseUpAsButtonHandler)new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, true)).OnMouseUpAsButtonAsync();
+        }
+    }
+#endif
+#endregion
+
+#region ParticleCollision
+
+    public interface IAsyncOnParticleCollisionHandler
+    {
+        UniTask<GameObject> OnParticleCollisionAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnParticleCollisionHandler
+    {
+        UniTask<GameObject> IAsyncOnParticleCollisionHandler.OnParticleCollisionAsync()
+        {
+            core.Reset();
+            return new UniTask<GameObject>((IUniTaskSource<GameObject>)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncParticleCollisionTrigger GetAsyncParticleCollisionTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncParticleCollisionTrigger>(gameObject);
+        }
+        
+        public static AsyncParticleCollisionTrigger GetAsyncParticleCollisionTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncParticleCollisionTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncParticleCollisionTrigger : AsyncTriggerBase<GameObject>
+    {
+        void OnParticleCollision(GameObject other)
+        {
+            RaiseEvent((other));
+        }
+
+        public IAsyncOnParticleCollisionHandler GetOnParticleCollisionAsyncHandler()
+        {
+            return new AsyncTriggerHandler<GameObject>(this, false);
+        }
+
+        public IAsyncOnParticleCollisionHandler GetOnParticleCollisionAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<GameObject>(this, cancellationToken, false);
+        }
+
+        public UniTask<GameObject> OnParticleCollisionAsync()
+        {
+            return ((IAsyncOnParticleCollisionHandler)new AsyncTriggerHandler<GameObject>(this, true)).OnParticleCollisionAsync();
+        }
+
+        public UniTask<GameObject> OnParticleCollisionAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnParticleCollisionHandler)new AsyncTriggerHandler<GameObject>(this, cancellationToken, true)).OnParticleCollisionAsync();
+        }
+    }
+#endregion
+
+#region ParticleSystemStopped
+
+    public interface IAsyncOnParticleSystemStoppedHandler
+    {
+        UniTask OnParticleSystemStoppedAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnParticleSystemStoppedHandler
+    {
+        UniTask IAsyncOnParticleSystemStoppedHandler.OnParticleSystemStoppedAsync()
+        {
+            core.Reset();
+            return new UniTask((IUniTaskSource)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncParticleSystemStoppedTrigger GetAsyncParticleSystemStoppedTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncParticleSystemStoppedTrigger>(gameObject);
+        }
+        
+        public static AsyncParticleSystemStoppedTrigger GetAsyncParticleSystemStoppedTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncParticleSystemStoppedTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncParticleSystemStoppedTrigger : AsyncTriggerBase<AsyncUnit>
+    {
+        void OnParticleSystemStopped()
+        {
+            RaiseEvent(AsyncUnit.Default);
+        }
+
+        public IAsyncOnParticleSystemStoppedHandler GetOnParticleSystemStoppedAsyncHandler()
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, false);
+        }
+
+        public IAsyncOnParticleSystemStoppedHandler GetOnParticleSystemStoppedAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, false);
+        }
+
+        public UniTask OnParticleSystemStoppedAsync()
+        {
+            return ((IAsyncOnParticleSystemStoppedHandler)new AsyncTriggerHandler<AsyncUnit>(this, true)).OnParticleSystemStoppedAsync();
+        }
+
+        public UniTask OnParticleSystemStoppedAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnParticleSystemStoppedHandler)new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, true)).OnParticleSystemStoppedAsync();
+        }
+    }
+#endregion
+
+#region ParticleTrigger
+
+    public interface IAsyncOnParticleTriggerHandler
+    {
+        UniTask OnParticleTriggerAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnParticleTriggerHandler
+    {
+        UniTask IAsyncOnParticleTriggerHandler.OnParticleTriggerAsync()
+        {
+            core.Reset();
+            return new UniTask((IUniTaskSource)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncParticleTriggerTrigger GetAsyncParticleTriggerTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncParticleTriggerTrigger>(gameObject);
+        }
+        
+        public static AsyncParticleTriggerTrigger GetAsyncParticleTriggerTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncParticleTriggerTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncParticleTriggerTrigger : AsyncTriggerBase<AsyncUnit>
+    {
+        void OnParticleTrigger()
+        {
+            RaiseEvent(AsyncUnit.Default);
+        }
+
+        public IAsyncOnParticleTriggerHandler GetOnParticleTriggerAsyncHandler()
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, false);
+        }
+
+        public IAsyncOnParticleTriggerHandler GetOnParticleTriggerAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, false);
+        }
+
+        public UniTask OnParticleTriggerAsync()
+        {
+            return ((IAsyncOnParticleTriggerHandler)new AsyncTriggerHandler<AsyncUnit>(this, true)).OnParticleTriggerAsync();
+        }
+
+        public UniTask OnParticleTriggerAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnParticleTriggerHandler)new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, true)).OnParticleTriggerAsync();
+        }
+    }
+#endregion
+
+#region ParticleUpdateJobScheduled
+#if UNITY_2019_3_OR_NEWER && (!UNITY_2019_1_OR_NEWER || UNITASK_PARTICLESYSTEM_SUPPORT)
+
+    public interface IAsyncOnParticleUpdateJobScheduledHandler
+    {
+        UniTask<UnityEngine.ParticleSystemJobs.ParticleSystemJobData> OnParticleUpdateJobScheduledAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnParticleUpdateJobScheduledHandler
+    {
+        UniTask<UnityEngine.ParticleSystemJobs.ParticleSystemJobData> IAsyncOnParticleUpdateJobScheduledHandler.OnParticleUpdateJobScheduledAsync()
+        {
+            core.Reset();
+            return new UniTask<UnityEngine.ParticleSystemJobs.ParticleSystemJobData>((IUniTaskSource<UnityEngine.ParticleSystemJobs.ParticleSystemJobData>)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncParticleUpdateJobScheduledTrigger GetAsyncParticleUpdateJobScheduledTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncParticleUpdateJobScheduledTrigger>(gameObject);
+        }
+        
+        public static AsyncParticleUpdateJobScheduledTrigger GetAsyncParticleUpdateJobScheduledTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncParticleUpdateJobScheduledTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncParticleUpdateJobScheduledTrigger : AsyncTriggerBase<UnityEngine.ParticleSystemJobs.ParticleSystemJobData>
+    {
+        void OnParticleUpdateJobScheduled(UnityEngine.ParticleSystemJobs.ParticleSystemJobData particles)
+        {
+            RaiseEvent((particles));
+        }
+
+        public IAsyncOnParticleUpdateJobScheduledHandler GetOnParticleUpdateJobScheduledAsyncHandler()
+        {
+            return new AsyncTriggerHandler<UnityEngine.ParticleSystemJobs.ParticleSystemJobData>(this, false);
+        }
+
+        public IAsyncOnParticleUpdateJobScheduledHandler GetOnParticleUpdateJobScheduledAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<UnityEngine.ParticleSystemJobs.ParticleSystemJobData>(this, cancellationToken, false);
+        }
+
+        public UniTask<UnityEngine.ParticleSystemJobs.ParticleSystemJobData> OnParticleUpdateJobScheduledAsync()
+        {
+            return ((IAsyncOnParticleUpdateJobScheduledHandler)new AsyncTriggerHandler<UnityEngine.ParticleSystemJobs.ParticleSystemJobData>(this, true)).OnParticleUpdateJobScheduledAsync();
+        }
+
+        public UniTask<UnityEngine.ParticleSystemJobs.ParticleSystemJobData> OnParticleUpdateJobScheduledAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnParticleUpdateJobScheduledHandler)new AsyncTriggerHandler<UnityEngine.ParticleSystemJobs.ParticleSystemJobData>(this, cancellationToken, true)).OnParticleUpdateJobScheduledAsync();
+        }
+    }
+#endif
+#endregion
+
+#region PostRender
+
+    public interface IAsyncOnPostRenderHandler
+    {
+        UniTask OnPostRenderAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnPostRenderHandler
+    {
+        UniTask IAsyncOnPostRenderHandler.OnPostRenderAsync()
+        {
+            core.Reset();
+            return new UniTask((IUniTaskSource)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncPostRenderTrigger GetAsyncPostRenderTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncPostRenderTrigger>(gameObject);
+        }
+        
+        public static AsyncPostRenderTrigger GetAsyncPostRenderTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncPostRenderTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncPostRenderTrigger : AsyncTriggerBase<AsyncUnit>
+    {
+        void OnPostRender()
+        {
+            RaiseEvent(AsyncUnit.Default);
+        }
+
+        public IAsyncOnPostRenderHandler GetOnPostRenderAsyncHandler()
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, false);
+        }
+
+        public IAsyncOnPostRenderHandler GetOnPostRenderAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, false);
+        }
+
+        public UniTask OnPostRenderAsync()
+        {
+            return ((IAsyncOnPostRenderHandler)new AsyncTriggerHandler<AsyncUnit>(this, true)).OnPostRenderAsync();
+        }
+
+        public UniTask OnPostRenderAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnPostRenderHandler)new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, true)).OnPostRenderAsync();
+        }
+    }
+#endregion
+
+#region PreCull
+
+    public interface IAsyncOnPreCullHandler
+    {
+        UniTask OnPreCullAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnPreCullHandler
+    {
+        UniTask IAsyncOnPreCullHandler.OnPreCullAsync()
+        {
+            core.Reset();
+            return new UniTask((IUniTaskSource)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncPreCullTrigger GetAsyncPreCullTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncPreCullTrigger>(gameObject);
+        }
+        
+        public static AsyncPreCullTrigger GetAsyncPreCullTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncPreCullTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncPreCullTrigger : AsyncTriggerBase<AsyncUnit>
+    {
+        void OnPreCull()
+        {
+            RaiseEvent(AsyncUnit.Default);
+        }
+
+        public IAsyncOnPreCullHandler GetOnPreCullAsyncHandler()
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, false);
+        }
+
+        public IAsyncOnPreCullHandler GetOnPreCullAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, false);
+        }
+
+        public UniTask OnPreCullAsync()
+        {
+            return ((IAsyncOnPreCullHandler)new AsyncTriggerHandler<AsyncUnit>(this, true)).OnPreCullAsync();
+        }
+
+        public UniTask OnPreCullAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnPreCullHandler)new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, true)).OnPreCullAsync();
+        }
+    }
+#endregion
+
+#region PreRender
+
+    public interface IAsyncOnPreRenderHandler
+    {
+        UniTask OnPreRenderAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnPreRenderHandler
+    {
+        UniTask IAsyncOnPreRenderHandler.OnPreRenderAsync()
+        {
+            core.Reset();
+            return new UniTask((IUniTaskSource)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncPreRenderTrigger GetAsyncPreRenderTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncPreRenderTrigger>(gameObject);
+        }
+        
+        public static AsyncPreRenderTrigger GetAsyncPreRenderTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncPreRenderTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncPreRenderTrigger : AsyncTriggerBase<AsyncUnit>
+    {
+        void OnPreRender()
+        {
+            RaiseEvent(AsyncUnit.Default);
+        }
+
+        public IAsyncOnPreRenderHandler GetOnPreRenderAsyncHandler()
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, false);
+        }
+
+        public IAsyncOnPreRenderHandler GetOnPreRenderAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, false);
+        }
+
+        public UniTask OnPreRenderAsync()
+        {
+            return ((IAsyncOnPreRenderHandler)new AsyncTriggerHandler<AsyncUnit>(this, true)).OnPreRenderAsync();
+        }
+
+        public UniTask OnPreRenderAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnPreRenderHandler)new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, true)).OnPreRenderAsync();
+        }
+    }
+#endregion
+
+#region RectTransformDimensionsChange
+
+    public interface IAsyncOnRectTransformDimensionsChangeHandler
+    {
+        UniTask OnRectTransformDimensionsChangeAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnRectTransformDimensionsChangeHandler
+    {
+        UniTask IAsyncOnRectTransformDimensionsChangeHandler.OnRectTransformDimensionsChangeAsync()
+        {
+            core.Reset();
+            return new UniTask((IUniTaskSource)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncRectTransformDimensionsChangeTrigger GetAsyncRectTransformDimensionsChangeTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncRectTransformDimensionsChangeTrigger>(gameObject);
+        }
+        
+        public static AsyncRectTransformDimensionsChangeTrigger GetAsyncRectTransformDimensionsChangeTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncRectTransformDimensionsChangeTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncRectTransformDimensionsChangeTrigger : AsyncTriggerBase<AsyncUnit>
+    {
+        void OnRectTransformDimensionsChange()
+        {
+            RaiseEvent(AsyncUnit.Default);
+        }
+
+        public IAsyncOnRectTransformDimensionsChangeHandler GetOnRectTransformDimensionsChangeAsyncHandler()
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, false);
+        }
+
+        public IAsyncOnRectTransformDimensionsChangeHandler GetOnRectTransformDimensionsChangeAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, false);
+        }
+
+        public UniTask OnRectTransformDimensionsChangeAsync()
+        {
+            return ((IAsyncOnRectTransformDimensionsChangeHandler)new AsyncTriggerHandler<AsyncUnit>(this, true)).OnRectTransformDimensionsChangeAsync();
+        }
+
+        public UniTask OnRectTransformDimensionsChangeAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnRectTransformDimensionsChangeHandler)new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, true)).OnRectTransformDimensionsChangeAsync();
+        }
+    }
+#endregion
+
+#region RectTransformRemoved
+
+    public interface IAsyncOnRectTransformRemovedHandler
+    {
+        UniTask OnRectTransformRemovedAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnRectTransformRemovedHandler
+    {
+        UniTask IAsyncOnRectTransformRemovedHandler.OnRectTransformRemovedAsync()
+        {
+            core.Reset();
+            return new UniTask((IUniTaskSource)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncRectTransformRemovedTrigger GetAsyncRectTransformRemovedTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncRectTransformRemovedTrigger>(gameObject);
+        }
+        
+        public static AsyncRectTransformRemovedTrigger GetAsyncRectTransformRemovedTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncRectTransformRemovedTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncRectTransformRemovedTrigger : AsyncTriggerBase<AsyncUnit>
+    {
+        void OnRectTransformRemoved()
+        {
+            RaiseEvent(AsyncUnit.Default);
+        }
+
+        public IAsyncOnRectTransformRemovedHandler GetOnRectTransformRemovedAsyncHandler()
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, false);
+        }
+
+        public IAsyncOnRectTransformRemovedHandler GetOnRectTransformRemovedAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, false);
+        }
+
+        public UniTask OnRectTransformRemovedAsync()
+        {
+            return ((IAsyncOnRectTransformRemovedHandler)new AsyncTriggerHandler<AsyncUnit>(this, true)).OnRectTransformRemovedAsync();
+        }
+
+        public UniTask OnRectTransformRemovedAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnRectTransformRemovedHandler)new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, true)).OnRectTransformRemovedAsync();
+        }
+    }
+#endregion
+
+#region RenderImage
+
+    public interface IAsyncOnRenderImageHandler
+    {
+        UniTask<(RenderTexture source, RenderTexture destination)> OnRenderImageAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnRenderImageHandler
+    {
+        UniTask<(RenderTexture source, RenderTexture destination)> IAsyncOnRenderImageHandler.OnRenderImageAsync()
+        {
+            core.Reset();
+            return new UniTask<(RenderTexture source, RenderTexture destination)>((IUniTaskSource<(RenderTexture source, RenderTexture destination)>)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncRenderImageTrigger GetAsyncRenderImageTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncRenderImageTrigger>(gameObject);
+        }
+        
+        public static AsyncRenderImageTrigger GetAsyncRenderImageTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncRenderImageTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncRenderImageTrigger : AsyncTriggerBase<(RenderTexture source, RenderTexture destination)>
+    {
+        void OnRenderImage(RenderTexture source, RenderTexture destination)
+        {
+            RaiseEvent((source, destination));
+        }
+
+        public IAsyncOnRenderImageHandler GetOnRenderImageAsyncHandler()
+        {
+            return new AsyncTriggerHandler<(RenderTexture source, RenderTexture destination)>(this, false);
+        }
+
+        public IAsyncOnRenderImageHandler GetOnRenderImageAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<(RenderTexture source, RenderTexture destination)>(this, cancellationToken, false);
+        }
+
+        public UniTask<(RenderTexture source, RenderTexture destination)> OnRenderImageAsync()
+        {
+            return ((IAsyncOnRenderImageHandler)new AsyncTriggerHandler<(RenderTexture source, RenderTexture destination)>(this, true)).OnRenderImageAsync();
+        }
+
+        public UniTask<(RenderTexture source, RenderTexture destination)> OnRenderImageAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnRenderImageHandler)new AsyncTriggerHandler<(RenderTexture source, RenderTexture destination)>(this, cancellationToken, true)).OnRenderImageAsync();
+        }
+    }
+#endregion
+
+#region RenderObject
+
+    public interface IAsyncOnRenderObjectHandler
+    {
+        UniTask OnRenderObjectAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnRenderObjectHandler
+    {
+        UniTask IAsyncOnRenderObjectHandler.OnRenderObjectAsync()
+        {
+            core.Reset();
+            return new UniTask((IUniTaskSource)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncRenderObjectTrigger GetAsyncRenderObjectTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncRenderObjectTrigger>(gameObject);
+        }
+        
+        public static AsyncRenderObjectTrigger GetAsyncRenderObjectTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncRenderObjectTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncRenderObjectTrigger : AsyncTriggerBase<AsyncUnit>
+    {
+        void OnRenderObject()
+        {
+            RaiseEvent(AsyncUnit.Default);
+        }
+
+        public IAsyncOnRenderObjectHandler GetOnRenderObjectAsyncHandler()
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, false);
+        }
+
+        public IAsyncOnRenderObjectHandler GetOnRenderObjectAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, false);
+        }
+
+        public UniTask OnRenderObjectAsync()
+        {
+            return ((IAsyncOnRenderObjectHandler)new AsyncTriggerHandler<AsyncUnit>(this, true)).OnRenderObjectAsync();
+        }
+
+        public UniTask OnRenderObjectAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnRenderObjectHandler)new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, true)).OnRenderObjectAsync();
+        }
+    }
+#endregion
+
+#region ServerInitialized
+
+    public interface IAsyncOnServerInitializedHandler
+    {
+        UniTask OnServerInitializedAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnServerInitializedHandler
+    {
+        UniTask IAsyncOnServerInitializedHandler.OnServerInitializedAsync()
+        {
+            core.Reset();
+            return new UniTask((IUniTaskSource)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncServerInitializedTrigger GetAsyncServerInitializedTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncServerInitializedTrigger>(gameObject);
+        }
+        
+        public static AsyncServerInitializedTrigger GetAsyncServerInitializedTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncServerInitializedTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncServerInitializedTrigger : AsyncTriggerBase<AsyncUnit>
+    {
+        void OnServerInitialized()
+        {
+            RaiseEvent(AsyncUnit.Default);
+        }
+
+        public IAsyncOnServerInitializedHandler GetOnServerInitializedAsyncHandler()
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, false);
+        }
+
+        public IAsyncOnServerInitializedHandler GetOnServerInitializedAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, false);
+        }
+
+        public UniTask OnServerInitializedAsync()
+        {
+            return ((IAsyncOnServerInitializedHandler)new AsyncTriggerHandler<AsyncUnit>(this, true)).OnServerInitializedAsync();
+        }
+
+        public UniTask OnServerInitializedAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnServerInitializedHandler)new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, true)).OnServerInitializedAsync();
+        }
+    }
+#endregion
+
+#region TransformChildrenChanged
+
+    public interface IAsyncOnTransformChildrenChangedHandler
+    {
+        UniTask OnTransformChildrenChangedAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnTransformChildrenChangedHandler
+    {
+        UniTask IAsyncOnTransformChildrenChangedHandler.OnTransformChildrenChangedAsync()
+        {
+            core.Reset();
+            return new UniTask((IUniTaskSource)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncTransformChildrenChangedTrigger GetAsyncTransformChildrenChangedTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncTransformChildrenChangedTrigger>(gameObject);
+        }
+        
+        public static AsyncTransformChildrenChangedTrigger GetAsyncTransformChildrenChangedTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncTransformChildrenChangedTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncTransformChildrenChangedTrigger : AsyncTriggerBase<AsyncUnit>
+    {
+        void OnTransformChildrenChanged()
+        {
+            RaiseEvent(AsyncUnit.Default);
+        }
+
+        public IAsyncOnTransformChildrenChangedHandler GetOnTransformChildrenChangedAsyncHandler()
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, false);
+        }
+
+        public IAsyncOnTransformChildrenChangedHandler GetOnTransformChildrenChangedAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, false);
+        }
+
+        public UniTask OnTransformChildrenChangedAsync()
+        {
+            return ((IAsyncOnTransformChildrenChangedHandler)new AsyncTriggerHandler<AsyncUnit>(this, true)).OnTransformChildrenChangedAsync();
+        }
+
+        public UniTask OnTransformChildrenChangedAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnTransformChildrenChangedHandler)new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, true)).OnTransformChildrenChangedAsync();
+        }
+    }
+#endregion
+
+#region TransformParentChanged
+
+    public interface IAsyncOnTransformParentChangedHandler
+    {
+        UniTask OnTransformParentChangedAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnTransformParentChangedHandler
+    {
+        UniTask IAsyncOnTransformParentChangedHandler.OnTransformParentChangedAsync()
+        {
+            core.Reset();
+            return new UniTask((IUniTaskSource)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncTransformParentChangedTrigger GetAsyncTransformParentChangedTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncTransformParentChangedTrigger>(gameObject);
+        }
+        
+        public static AsyncTransformParentChangedTrigger GetAsyncTransformParentChangedTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncTransformParentChangedTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncTransformParentChangedTrigger : AsyncTriggerBase<AsyncUnit>
+    {
+        void OnTransformParentChanged()
+        {
+            RaiseEvent(AsyncUnit.Default);
+        }
+
+        public IAsyncOnTransformParentChangedHandler GetOnTransformParentChangedAsyncHandler()
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, false);
+        }
+
+        public IAsyncOnTransformParentChangedHandler GetOnTransformParentChangedAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, false);
+        }
+
+        public UniTask OnTransformParentChangedAsync()
+        {
+            return ((IAsyncOnTransformParentChangedHandler)new AsyncTriggerHandler<AsyncUnit>(this, true)).OnTransformParentChangedAsync();
+        }
+
+        public UniTask OnTransformParentChangedAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnTransformParentChangedHandler)new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, true)).OnTransformParentChangedAsync();
+        }
+    }
+#endregion
+
+#region TriggerEnter
+#if !UNITY_2019_1_OR_NEWER || UNITASK_PHYSICS_SUPPORT
+
+    public interface IAsyncOnTriggerEnterHandler
+    {
+        UniTask<Collider> OnTriggerEnterAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnTriggerEnterHandler
+    {
+        UniTask<Collider> IAsyncOnTriggerEnterHandler.OnTriggerEnterAsync()
+        {
+            core.Reset();
+            return new UniTask<Collider>((IUniTaskSource<Collider>)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncTriggerEnterTrigger GetAsyncTriggerEnterTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncTriggerEnterTrigger>(gameObject);
+        }
+        
+        public static AsyncTriggerEnterTrigger GetAsyncTriggerEnterTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncTriggerEnterTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncTriggerEnterTrigger : AsyncTriggerBase<Collider>
+    {
+        void OnTriggerEnter(Collider other)
+        {
+            RaiseEvent((other));
+        }
+
+        public IAsyncOnTriggerEnterHandler GetOnTriggerEnterAsyncHandler()
+        {
+            return new AsyncTriggerHandler<Collider>(this, false);
+        }
+
+        public IAsyncOnTriggerEnterHandler GetOnTriggerEnterAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<Collider>(this, cancellationToken, false);
+        }
+
+        public UniTask<Collider> OnTriggerEnterAsync()
+        {
+            return ((IAsyncOnTriggerEnterHandler)new AsyncTriggerHandler<Collider>(this, true)).OnTriggerEnterAsync();
+        }
+
+        public UniTask<Collider> OnTriggerEnterAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnTriggerEnterHandler)new AsyncTriggerHandler<Collider>(this, cancellationToken, true)).OnTriggerEnterAsync();
+        }
+    }
+#endif
+#endregion
+
+#region TriggerEnter2D
+#if !UNITY_2019_1_OR_NEWER || UNITASK_PHYSICS2D_SUPPORT
+
+    public interface IAsyncOnTriggerEnter2DHandler
+    {
+        UniTask<Collider2D> OnTriggerEnter2DAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnTriggerEnter2DHandler
+    {
+        UniTask<Collider2D> IAsyncOnTriggerEnter2DHandler.OnTriggerEnter2DAsync()
+        {
+            core.Reset();
+            return new UniTask<Collider2D>((IUniTaskSource<Collider2D>)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncTriggerEnter2DTrigger GetAsyncTriggerEnter2DTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncTriggerEnter2DTrigger>(gameObject);
+        }
+        
+        public static AsyncTriggerEnter2DTrigger GetAsyncTriggerEnter2DTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncTriggerEnter2DTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncTriggerEnter2DTrigger : AsyncTriggerBase<Collider2D>
+    {
+        void OnTriggerEnter2D(Collider2D other)
+        {
+            RaiseEvent((other));
+        }
+
+        public IAsyncOnTriggerEnter2DHandler GetOnTriggerEnter2DAsyncHandler()
+        {
+            return new AsyncTriggerHandler<Collider2D>(this, false);
+        }
+
+        public IAsyncOnTriggerEnter2DHandler GetOnTriggerEnter2DAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<Collider2D>(this, cancellationToken, false);
+        }
+
+        public UniTask<Collider2D> OnTriggerEnter2DAsync()
+        {
+            return ((IAsyncOnTriggerEnter2DHandler)new AsyncTriggerHandler<Collider2D>(this, true)).OnTriggerEnter2DAsync();
+        }
+
+        public UniTask<Collider2D> OnTriggerEnter2DAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnTriggerEnter2DHandler)new AsyncTriggerHandler<Collider2D>(this, cancellationToken, true)).OnTriggerEnter2DAsync();
+        }
+    }
+#endif
+#endregion
+
+#region TriggerExit
+#if !UNITY_2019_1_OR_NEWER || UNITASK_PHYSICS_SUPPORT
+
+    public interface IAsyncOnTriggerExitHandler
+    {
+        UniTask<Collider> OnTriggerExitAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnTriggerExitHandler
+    {
+        UniTask<Collider> IAsyncOnTriggerExitHandler.OnTriggerExitAsync()
+        {
+            core.Reset();
+            return new UniTask<Collider>((IUniTaskSource<Collider>)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncTriggerExitTrigger GetAsyncTriggerExitTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncTriggerExitTrigger>(gameObject);
+        }
+        
+        public static AsyncTriggerExitTrigger GetAsyncTriggerExitTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncTriggerExitTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncTriggerExitTrigger : AsyncTriggerBase<Collider>
+    {
+        void OnTriggerExit(Collider other)
+        {
+            RaiseEvent((other));
+        }
+
+        public IAsyncOnTriggerExitHandler GetOnTriggerExitAsyncHandler()
+        {
+            return new AsyncTriggerHandler<Collider>(this, false);
+        }
+
+        public IAsyncOnTriggerExitHandler GetOnTriggerExitAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<Collider>(this, cancellationToken, false);
+        }
+
+        public UniTask<Collider> OnTriggerExitAsync()
+        {
+            return ((IAsyncOnTriggerExitHandler)new AsyncTriggerHandler<Collider>(this, true)).OnTriggerExitAsync();
+        }
+
+        public UniTask<Collider> OnTriggerExitAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnTriggerExitHandler)new AsyncTriggerHandler<Collider>(this, cancellationToken, true)).OnTriggerExitAsync();
+        }
+    }
+#endif
+#endregion
+
+#region TriggerExit2D
+#if !UNITY_2019_1_OR_NEWER || UNITASK_PHYSICS2D_SUPPORT
+
+    public interface IAsyncOnTriggerExit2DHandler
+    {
+        UniTask<Collider2D> OnTriggerExit2DAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnTriggerExit2DHandler
+    {
+        UniTask<Collider2D> IAsyncOnTriggerExit2DHandler.OnTriggerExit2DAsync()
+        {
+            core.Reset();
+            return new UniTask<Collider2D>((IUniTaskSource<Collider2D>)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncTriggerExit2DTrigger GetAsyncTriggerExit2DTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncTriggerExit2DTrigger>(gameObject);
+        }
+        
+        public static AsyncTriggerExit2DTrigger GetAsyncTriggerExit2DTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncTriggerExit2DTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncTriggerExit2DTrigger : AsyncTriggerBase<Collider2D>
+    {
+        void OnTriggerExit2D(Collider2D other)
+        {
+            RaiseEvent((other));
+        }
+
+        public IAsyncOnTriggerExit2DHandler GetOnTriggerExit2DAsyncHandler()
+        {
+            return new AsyncTriggerHandler<Collider2D>(this, false);
+        }
+
+        public IAsyncOnTriggerExit2DHandler GetOnTriggerExit2DAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<Collider2D>(this, cancellationToken, false);
+        }
+
+        public UniTask<Collider2D> OnTriggerExit2DAsync()
+        {
+            return ((IAsyncOnTriggerExit2DHandler)new AsyncTriggerHandler<Collider2D>(this, true)).OnTriggerExit2DAsync();
+        }
+
+        public UniTask<Collider2D> OnTriggerExit2DAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnTriggerExit2DHandler)new AsyncTriggerHandler<Collider2D>(this, cancellationToken, true)).OnTriggerExit2DAsync();
+        }
+    }
+#endif
+#endregion
+
+#region TriggerStay
+#if !UNITY_2019_1_OR_NEWER || UNITASK_PHYSICS_SUPPORT
+
+    public interface IAsyncOnTriggerStayHandler
+    {
+        UniTask<Collider> OnTriggerStayAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnTriggerStayHandler
+    {
+        UniTask<Collider> IAsyncOnTriggerStayHandler.OnTriggerStayAsync()
+        {
+            core.Reset();
+            return new UniTask<Collider>((IUniTaskSource<Collider>)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncTriggerStayTrigger GetAsyncTriggerStayTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncTriggerStayTrigger>(gameObject);
+        }
+        
+        public static AsyncTriggerStayTrigger GetAsyncTriggerStayTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncTriggerStayTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncTriggerStayTrigger : AsyncTriggerBase<Collider>
+    {
+        void OnTriggerStay(Collider other)
+        {
+            RaiseEvent((other));
+        }
+
+        public IAsyncOnTriggerStayHandler GetOnTriggerStayAsyncHandler()
+        {
+            return new AsyncTriggerHandler<Collider>(this, false);
+        }
+
+        public IAsyncOnTriggerStayHandler GetOnTriggerStayAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<Collider>(this, cancellationToken, false);
+        }
+
+        public UniTask<Collider> OnTriggerStayAsync()
+        {
+            return ((IAsyncOnTriggerStayHandler)new AsyncTriggerHandler<Collider>(this, true)).OnTriggerStayAsync();
+        }
+
+        public UniTask<Collider> OnTriggerStayAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnTriggerStayHandler)new AsyncTriggerHandler<Collider>(this, cancellationToken, true)).OnTriggerStayAsync();
+        }
+    }
+#endif
+#endregion
+
+#region TriggerStay2D
+#if !UNITY_2019_1_OR_NEWER || UNITASK_PHYSICS2D_SUPPORT
+
+    public interface IAsyncOnTriggerStay2DHandler
+    {
+        UniTask<Collider2D> OnTriggerStay2DAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnTriggerStay2DHandler
+    {
+        UniTask<Collider2D> IAsyncOnTriggerStay2DHandler.OnTriggerStay2DAsync()
+        {
+            core.Reset();
+            return new UniTask<Collider2D>((IUniTaskSource<Collider2D>)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncTriggerStay2DTrigger GetAsyncTriggerStay2DTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncTriggerStay2DTrigger>(gameObject);
+        }
+        
+        public static AsyncTriggerStay2DTrigger GetAsyncTriggerStay2DTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncTriggerStay2DTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncTriggerStay2DTrigger : AsyncTriggerBase<Collider2D>
+    {
+        void OnTriggerStay2D(Collider2D other)
+        {
+            RaiseEvent((other));
+        }
+
+        public IAsyncOnTriggerStay2DHandler GetOnTriggerStay2DAsyncHandler()
+        {
+            return new AsyncTriggerHandler<Collider2D>(this, false);
+        }
+
+        public IAsyncOnTriggerStay2DHandler GetOnTriggerStay2DAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<Collider2D>(this, cancellationToken, false);
+        }
+
+        public UniTask<Collider2D> OnTriggerStay2DAsync()
+        {
+            return ((IAsyncOnTriggerStay2DHandler)new AsyncTriggerHandler<Collider2D>(this, true)).OnTriggerStay2DAsync();
+        }
+
+        public UniTask<Collider2D> OnTriggerStay2DAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnTriggerStay2DHandler)new AsyncTriggerHandler<Collider2D>(this, cancellationToken, true)).OnTriggerStay2DAsync();
+        }
+    }
+#endif
+#endregion
+
+#region Validate
+
+    public interface IAsyncOnValidateHandler
+    {
+        UniTask OnValidateAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnValidateHandler
+    {
+        UniTask IAsyncOnValidateHandler.OnValidateAsync()
+        {
+            core.Reset();
+            return new UniTask((IUniTaskSource)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncValidateTrigger GetAsyncValidateTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncValidateTrigger>(gameObject);
+        }
+        
+        public static AsyncValidateTrigger GetAsyncValidateTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncValidateTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncValidateTrigger : AsyncTriggerBase<AsyncUnit>
+    {
+        void OnValidate()
+        {
+            RaiseEvent(AsyncUnit.Default);
+        }
+
+        public IAsyncOnValidateHandler GetOnValidateAsyncHandler()
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, false);
+        }
+
+        public IAsyncOnValidateHandler GetOnValidateAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, false);
+        }
+
+        public UniTask OnValidateAsync()
+        {
+            return ((IAsyncOnValidateHandler)new AsyncTriggerHandler<AsyncUnit>(this, true)).OnValidateAsync();
+        }
+
+        public UniTask OnValidateAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnValidateHandler)new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, true)).OnValidateAsync();
+        }
+    }
+#endregion
+
+#region WillRenderObject
+
+    public interface IAsyncOnWillRenderObjectHandler
+    {
+        UniTask OnWillRenderObjectAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnWillRenderObjectHandler
+    {
+        UniTask IAsyncOnWillRenderObjectHandler.OnWillRenderObjectAsync()
+        {
+            core.Reset();
+            return new UniTask((IUniTaskSource)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncWillRenderObjectTrigger GetAsyncWillRenderObjectTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncWillRenderObjectTrigger>(gameObject);
+        }
+        
+        public static AsyncWillRenderObjectTrigger GetAsyncWillRenderObjectTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncWillRenderObjectTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncWillRenderObjectTrigger : AsyncTriggerBase<AsyncUnit>
+    {
+        void OnWillRenderObject()
+        {
+            RaiseEvent(AsyncUnit.Default);
+        }
+
+        public IAsyncOnWillRenderObjectHandler GetOnWillRenderObjectAsyncHandler()
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, false);
+        }
+
+        public IAsyncOnWillRenderObjectHandler GetOnWillRenderObjectAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, false);
+        }
+
+        public UniTask OnWillRenderObjectAsync()
+        {
+            return ((IAsyncOnWillRenderObjectHandler)new AsyncTriggerHandler<AsyncUnit>(this, true)).OnWillRenderObjectAsync();
+        }
+
+        public UniTask OnWillRenderObjectAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnWillRenderObjectHandler)new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, true)).OnWillRenderObjectAsync();
+        }
+    }
+#endregion
+
+#region Reset
+
+    public interface IAsyncResetHandler
+    {
+        UniTask ResetAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncResetHandler
+    {
+        UniTask IAsyncResetHandler.ResetAsync()
+        {
+            core.Reset();
+            return new UniTask((IUniTaskSource)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncResetTrigger GetAsyncResetTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncResetTrigger>(gameObject);
+        }
+        
+        public static AsyncResetTrigger GetAsyncResetTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncResetTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncResetTrigger : AsyncTriggerBase<AsyncUnit>
+    {
+        void Reset()
+        {
+            RaiseEvent(AsyncUnit.Default);
+        }
+
+        public IAsyncResetHandler GetResetAsyncHandler()
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, false);
+        }
+
+        public IAsyncResetHandler GetResetAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, false);
+        }
+
+        public UniTask ResetAsync()
+        {
+            return ((IAsyncResetHandler)new AsyncTriggerHandler<AsyncUnit>(this, true)).ResetAsync();
+        }
+
+        public UniTask ResetAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncResetHandler)new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, true)).ResetAsync();
+        }
+    }
+#endregion
+
+#region Update
+
+    public interface IAsyncUpdateHandler
+    {
+        UniTask UpdateAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncUpdateHandler
+    {
+        UniTask IAsyncUpdateHandler.UpdateAsync()
+        {
+            core.Reset();
+            return new UniTask((IUniTaskSource)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncUpdateTrigger GetAsyncUpdateTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncUpdateTrigger>(gameObject);
+        }
+        
+        public static AsyncUpdateTrigger GetAsyncUpdateTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncUpdateTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncUpdateTrigger : AsyncTriggerBase<AsyncUnit>
+    {
+        void Update()
+        {
+            RaiseEvent(AsyncUnit.Default);
+        }
+
+        public IAsyncUpdateHandler GetUpdateAsyncHandler()
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, false);
+        }
+
+        public IAsyncUpdateHandler GetUpdateAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, false);
+        }
+
+        public UniTask UpdateAsync()
+        {
+            return ((IAsyncUpdateHandler)new AsyncTriggerHandler<AsyncUnit>(this, true)).UpdateAsync();
+        }
+
+        public UniTask UpdateAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncUpdateHandler)new AsyncTriggerHandler<AsyncUnit>(this, cancellationToken, true)).UpdateAsync();
+        }
+    }
+#endregion
+
+#region BeginDrag
+#if !UNITY_2019_1_OR_NEWER || UNITASK_UGUI_SUPPORT
+
+    public interface IAsyncOnBeginDragHandler
+    {
+        UniTask<PointerEventData> OnBeginDragAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnBeginDragHandler
+    {
+        UniTask<PointerEventData> IAsyncOnBeginDragHandler.OnBeginDragAsync()
+        {
+            core.Reset();
+            return new UniTask<PointerEventData>((IUniTaskSource<PointerEventData>)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncBeginDragTrigger GetAsyncBeginDragTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncBeginDragTrigger>(gameObject);
+        }
+        
+        public static AsyncBeginDragTrigger GetAsyncBeginDragTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncBeginDragTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncBeginDragTrigger : AsyncTriggerBase<PointerEventData>, IBeginDragHandler
+    {
+        void IBeginDragHandler.OnBeginDrag(PointerEventData eventData)
+        {
+            RaiseEvent((eventData));
+        }
+
+        public IAsyncOnBeginDragHandler GetOnBeginDragAsyncHandler()
+        {
+            return new AsyncTriggerHandler<PointerEventData>(this, false);
+        }
+
+        public IAsyncOnBeginDragHandler GetOnBeginDragAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<PointerEventData>(this, cancellationToken, false);
+        }
+
+        public UniTask<PointerEventData> OnBeginDragAsync()
+        {
+            return ((IAsyncOnBeginDragHandler)new AsyncTriggerHandler<PointerEventData>(this, true)).OnBeginDragAsync();
+        }
+
+        public UniTask<PointerEventData> OnBeginDragAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnBeginDragHandler)new AsyncTriggerHandler<PointerEventData>(this, cancellationToken, true)).OnBeginDragAsync();
+        }
+    }
+#endif
+#endregion
+
+#region Cancel
+#if !UNITY_2019_1_OR_NEWER || UNITASK_UGUI_SUPPORT
+
+    public interface IAsyncOnCancelHandler
+    {
+        UniTask<BaseEventData> OnCancelAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnCancelHandler
+    {
+        UniTask<BaseEventData> IAsyncOnCancelHandler.OnCancelAsync()
+        {
+            core.Reset();
+            return new UniTask<BaseEventData>((IUniTaskSource<BaseEventData>)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncCancelTrigger GetAsyncCancelTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncCancelTrigger>(gameObject);
+        }
+        
+        public static AsyncCancelTrigger GetAsyncCancelTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncCancelTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncCancelTrigger : AsyncTriggerBase<BaseEventData>, ICancelHandler
+    {
+        void ICancelHandler.OnCancel(BaseEventData eventData)
+        {
+            RaiseEvent((eventData));
+        }
+
+        public IAsyncOnCancelHandler GetOnCancelAsyncHandler()
+        {
+            return new AsyncTriggerHandler<BaseEventData>(this, false);
+        }
+
+        public IAsyncOnCancelHandler GetOnCancelAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<BaseEventData>(this, cancellationToken, false);
+        }
+
+        public UniTask<BaseEventData> OnCancelAsync()
+        {
+            return ((IAsyncOnCancelHandler)new AsyncTriggerHandler<BaseEventData>(this, true)).OnCancelAsync();
+        }
+
+        public UniTask<BaseEventData> OnCancelAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnCancelHandler)new AsyncTriggerHandler<BaseEventData>(this, cancellationToken, true)).OnCancelAsync();
+        }
+    }
+#endif
+#endregion
+
+#region Deselect
+#if !UNITY_2019_1_OR_NEWER || UNITASK_UGUI_SUPPORT
+
+    public interface IAsyncOnDeselectHandler
+    {
+        UniTask<BaseEventData> OnDeselectAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnDeselectHandler
+    {
+        UniTask<BaseEventData> IAsyncOnDeselectHandler.OnDeselectAsync()
+        {
+            core.Reset();
+            return new UniTask<BaseEventData>((IUniTaskSource<BaseEventData>)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncDeselectTrigger GetAsyncDeselectTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncDeselectTrigger>(gameObject);
+        }
+        
+        public static AsyncDeselectTrigger GetAsyncDeselectTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncDeselectTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncDeselectTrigger : AsyncTriggerBase<BaseEventData>, IDeselectHandler
+    {
+        void IDeselectHandler.OnDeselect(BaseEventData eventData)
+        {
+            RaiseEvent((eventData));
+        }
+
+        public IAsyncOnDeselectHandler GetOnDeselectAsyncHandler()
+        {
+            return new AsyncTriggerHandler<BaseEventData>(this, false);
+        }
+
+        public IAsyncOnDeselectHandler GetOnDeselectAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<BaseEventData>(this, cancellationToken, false);
+        }
+
+        public UniTask<BaseEventData> OnDeselectAsync()
+        {
+            return ((IAsyncOnDeselectHandler)new AsyncTriggerHandler<BaseEventData>(this, true)).OnDeselectAsync();
+        }
+
+        public UniTask<BaseEventData> OnDeselectAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnDeselectHandler)new AsyncTriggerHandler<BaseEventData>(this, cancellationToken, true)).OnDeselectAsync();
+        }
+    }
+#endif
+#endregion
+
+#region Drag
+#if !UNITY_2019_1_OR_NEWER || UNITASK_UGUI_SUPPORT
+
+    public interface IAsyncOnDragHandler
+    {
+        UniTask<PointerEventData> OnDragAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnDragHandler
+    {
+        UniTask<PointerEventData> IAsyncOnDragHandler.OnDragAsync()
+        {
+            core.Reset();
+            return new UniTask<PointerEventData>((IUniTaskSource<PointerEventData>)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncDragTrigger GetAsyncDragTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncDragTrigger>(gameObject);
+        }
+        
+        public static AsyncDragTrigger GetAsyncDragTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncDragTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncDragTrigger : AsyncTriggerBase<PointerEventData>, IDragHandler
+    {
+        void IDragHandler.OnDrag(PointerEventData eventData)
+        {
+            RaiseEvent((eventData));
+        }
+
+        public IAsyncOnDragHandler GetOnDragAsyncHandler()
+        {
+            return new AsyncTriggerHandler<PointerEventData>(this, false);
+        }
+
+        public IAsyncOnDragHandler GetOnDragAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<PointerEventData>(this, cancellationToken, false);
+        }
+
+        public UniTask<PointerEventData> OnDragAsync()
+        {
+            return ((IAsyncOnDragHandler)new AsyncTriggerHandler<PointerEventData>(this, true)).OnDragAsync();
+        }
+
+        public UniTask<PointerEventData> OnDragAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnDragHandler)new AsyncTriggerHandler<PointerEventData>(this, cancellationToken, true)).OnDragAsync();
+        }
+    }
+#endif
+#endregion
+
+#region Drop
+#if !UNITY_2019_1_OR_NEWER || UNITASK_UGUI_SUPPORT
+
+    public interface IAsyncOnDropHandler
+    {
+        UniTask<PointerEventData> OnDropAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnDropHandler
+    {
+        UniTask<PointerEventData> IAsyncOnDropHandler.OnDropAsync()
+        {
+            core.Reset();
+            return new UniTask<PointerEventData>((IUniTaskSource<PointerEventData>)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncDropTrigger GetAsyncDropTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncDropTrigger>(gameObject);
+        }
+        
+        public static AsyncDropTrigger GetAsyncDropTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncDropTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncDropTrigger : AsyncTriggerBase<PointerEventData>, IDropHandler
+    {
+        void IDropHandler.OnDrop(PointerEventData eventData)
+        {
+            RaiseEvent((eventData));
+        }
+
+        public IAsyncOnDropHandler GetOnDropAsyncHandler()
+        {
+            return new AsyncTriggerHandler<PointerEventData>(this, false);
+        }
+
+        public IAsyncOnDropHandler GetOnDropAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<PointerEventData>(this, cancellationToken, false);
+        }
+
+        public UniTask<PointerEventData> OnDropAsync()
+        {
+            return ((IAsyncOnDropHandler)new AsyncTriggerHandler<PointerEventData>(this, true)).OnDropAsync();
+        }
+
+        public UniTask<PointerEventData> OnDropAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnDropHandler)new AsyncTriggerHandler<PointerEventData>(this, cancellationToken, true)).OnDropAsync();
+        }
+    }
+#endif
+#endregion
+
+#region EndDrag
+#if !UNITY_2019_1_OR_NEWER || UNITASK_UGUI_SUPPORT
+
+    public interface IAsyncOnEndDragHandler
+    {
+        UniTask<PointerEventData> OnEndDragAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnEndDragHandler
+    {
+        UniTask<PointerEventData> IAsyncOnEndDragHandler.OnEndDragAsync()
+        {
+            core.Reset();
+            return new UniTask<PointerEventData>((IUniTaskSource<PointerEventData>)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncEndDragTrigger GetAsyncEndDragTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncEndDragTrigger>(gameObject);
+        }
+        
+        public static AsyncEndDragTrigger GetAsyncEndDragTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncEndDragTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncEndDragTrigger : AsyncTriggerBase<PointerEventData>, IEndDragHandler
+    {
+        void IEndDragHandler.OnEndDrag(PointerEventData eventData)
+        {
+            RaiseEvent((eventData));
+        }
+
+        public IAsyncOnEndDragHandler GetOnEndDragAsyncHandler()
+        {
+            return new AsyncTriggerHandler<PointerEventData>(this, false);
+        }
+
+        public IAsyncOnEndDragHandler GetOnEndDragAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<PointerEventData>(this, cancellationToken, false);
+        }
+
+        public UniTask<PointerEventData> OnEndDragAsync()
+        {
+            return ((IAsyncOnEndDragHandler)new AsyncTriggerHandler<PointerEventData>(this, true)).OnEndDragAsync();
+        }
+
+        public UniTask<PointerEventData> OnEndDragAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnEndDragHandler)new AsyncTriggerHandler<PointerEventData>(this, cancellationToken, true)).OnEndDragAsync();
+        }
+    }
+#endif
+#endregion
+
+#region InitializePotentialDrag
+#if !UNITY_2019_1_OR_NEWER || UNITASK_UGUI_SUPPORT
+
+    public interface IAsyncOnInitializePotentialDragHandler
+    {
+        UniTask<PointerEventData> OnInitializePotentialDragAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnInitializePotentialDragHandler
+    {
+        UniTask<PointerEventData> IAsyncOnInitializePotentialDragHandler.OnInitializePotentialDragAsync()
+        {
+            core.Reset();
+            return new UniTask<PointerEventData>((IUniTaskSource<PointerEventData>)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncInitializePotentialDragTrigger GetAsyncInitializePotentialDragTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncInitializePotentialDragTrigger>(gameObject);
+        }
+        
+        public static AsyncInitializePotentialDragTrigger GetAsyncInitializePotentialDragTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncInitializePotentialDragTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncInitializePotentialDragTrigger : AsyncTriggerBase<PointerEventData>, IInitializePotentialDragHandler
+    {
+        void IInitializePotentialDragHandler.OnInitializePotentialDrag(PointerEventData eventData)
+        {
+            RaiseEvent((eventData));
+        }
+
+        public IAsyncOnInitializePotentialDragHandler GetOnInitializePotentialDragAsyncHandler()
+        {
+            return new AsyncTriggerHandler<PointerEventData>(this, false);
+        }
+
+        public IAsyncOnInitializePotentialDragHandler GetOnInitializePotentialDragAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<PointerEventData>(this, cancellationToken, false);
+        }
+
+        public UniTask<PointerEventData> OnInitializePotentialDragAsync()
+        {
+            return ((IAsyncOnInitializePotentialDragHandler)new AsyncTriggerHandler<PointerEventData>(this, true)).OnInitializePotentialDragAsync();
+        }
+
+        public UniTask<PointerEventData> OnInitializePotentialDragAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnInitializePotentialDragHandler)new AsyncTriggerHandler<PointerEventData>(this, cancellationToken, true)).OnInitializePotentialDragAsync();
+        }
+    }
+#endif
+#endregion
+
+#region Move
+#if !UNITY_2019_1_OR_NEWER || UNITASK_UGUI_SUPPORT
+
+    public interface IAsyncOnMoveHandler
+    {
+        UniTask<AxisEventData> OnMoveAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnMoveHandler
+    {
+        UniTask<AxisEventData> IAsyncOnMoveHandler.OnMoveAsync()
+        {
+            core.Reset();
+            return new UniTask<AxisEventData>((IUniTaskSource<AxisEventData>)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncMoveTrigger GetAsyncMoveTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncMoveTrigger>(gameObject);
+        }
+        
+        public static AsyncMoveTrigger GetAsyncMoveTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncMoveTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncMoveTrigger : AsyncTriggerBase<AxisEventData>, IMoveHandler
+    {
+        void IMoveHandler.OnMove(AxisEventData eventData)
+        {
+            RaiseEvent((eventData));
+        }
+
+        public IAsyncOnMoveHandler GetOnMoveAsyncHandler()
+        {
+            return new AsyncTriggerHandler<AxisEventData>(this, false);
+        }
+
+        public IAsyncOnMoveHandler GetOnMoveAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<AxisEventData>(this, cancellationToken, false);
+        }
+
+        public UniTask<AxisEventData> OnMoveAsync()
+        {
+            return ((IAsyncOnMoveHandler)new AsyncTriggerHandler<AxisEventData>(this, true)).OnMoveAsync();
+        }
+
+        public UniTask<AxisEventData> OnMoveAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnMoveHandler)new AsyncTriggerHandler<AxisEventData>(this, cancellationToken, true)).OnMoveAsync();
+        }
+    }
+#endif
+#endregion
+
+#region PointerClick
+#if !UNITY_2019_1_OR_NEWER || UNITASK_UGUI_SUPPORT
+
+    public interface IAsyncOnPointerClickHandler
+    {
+        UniTask<PointerEventData> OnPointerClickAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnPointerClickHandler
+    {
+        UniTask<PointerEventData> IAsyncOnPointerClickHandler.OnPointerClickAsync()
+        {
+            core.Reset();
+            return new UniTask<PointerEventData>((IUniTaskSource<PointerEventData>)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncPointerClickTrigger GetAsyncPointerClickTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncPointerClickTrigger>(gameObject);
+        }
+        
+        public static AsyncPointerClickTrigger GetAsyncPointerClickTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncPointerClickTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncPointerClickTrigger : AsyncTriggerBase<PointerEventData>, IPointerClickHandler
+    {
+        void IPointerClickHandler.OnPointerClick(PointerEventData eventData)
+        {
+            RaiseEvent((eventData));
+        }
+
+        public IAsyncOnPointerClickHandler GetOnPointerClickAsyncHandler()
+        {
+            return new AsyncTriggerHandler<PointerEventData>(this, false);
+        }
+
+        public IAsyncOnPointerClickHandler GetOnPointerClickAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<PointerEventData>(this, cancellationToken, false);
+        }
+
+        public UniTask<PointerEventData> OnPointerClickAsync()
+        {
+            return ((IAsyncOnPointerClickHandler)new AsyncTriggerHandler<PointerEventData>(this, true)).OnPointerClickAsync();
+        }
+
+        public UniTask<PointerEventData> OnPointerClickAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnPointerClickHandler)new AsyncTriggerHandler<PointerEventData>(this, cancellationToken, true)).OnPointerClickAsync();
+        }
+    }
+#endif
+#endregion
+
+#region PointerDown
+#if !UNITY_2019_1_OR_NEWER || UNITASK_UGUI_SUPPORT
+
+    public interface IAsyncOnPointerDownHandler
+    {
+        UniTask<PointerEventData> OnPointerDownAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnPointerDownHandler
+    {
+        UniTask<PointerEventData> IAsyncOnPointerDownHandler.OnPointerDownAsync()
+        {
+            core.Reset();
+            return new UniTask<PointerEventData>((IUniTaskSource<PointerEventData>)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncPointerDownTrigger GetAsyncPointerDownTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncPointerDownTrigger>(gameObject);
+        }
+        
+        public static AsyncPointerDownTrigger GetAsyncPointerDownTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncPointerDownTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncPointerDownTrigger : AsyncTriggerBase<PointerEventData>, IPointerDownHandler
+    {
+        void IPointerDownHandler.OnPointerDown(PointerEventData eventData)
+        {
+            RaiseEvent((eventData));
+        }
+
+        public IAsyncOnPointerDownHandler GetOnPointerDownAsyncHandler()
+        {
+            return new AsyncTriggerHandler<PointerEventData>(this, false);
+        }
+
+        public IAsyncOnPointerDownHandler GetOnPointerDownAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<PointerEventData>(this, cancellationToken, false);
+        }
+
+        public UniTask<PointerEventData> OnPointerDownAsync()
+        {
+            return ((IAsyncOnPointerDownHandler)new AsyncTriggerHandler<PointerEventData>(this, true)).OnPointerDownAsync();
+        }
+
+        public UniTask<PointerEventData> OnPointerDownAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnPointerDownHandler)new AsyncTriggerHandler<PointerEventData>(this, cancellationToken, true)).OnPointerDownAsync();
+        }
+    }
+#endif
+#endregion
+
+#region PointerEnter
+#if !UNITY_2019_1_OR_NEWER || UNITASK_UGUI_SUPPORT
+
+    public interface IAsyncOnPointerEnterHandler
+    {
+        UniTask<PointerEventData> OnPointerEnterAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnPointerEnterHandler
+    {
+        UniTask<PointerEventData> IAsyncOnPointerEnterHandler.OnPointerEnterAsync()
+        {
+            core.Reset();
+            return new UniTask<PointerEventData>((IUniTaskSource<PointerEventData>)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncPointerEnterTrigger GetAsyncPointerEnterTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncPointerEnterTrigger>(gameObject);
+        }
+        
+        public static AsyncPointerEnterTrigger GetAsyncPointerEnterTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncPointerEnterTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncPointerEnterTrigger : AsyncTriggerBase<PointerEventData>, IPointerEnterHandler
+    {
+        void IPointerEnterHandler.OnPointerEnter(PointerEventData eventData)
+        {
+            RaiseEvent((eventData));
+        }
+
+        public IAsyncOnPointerEnterHandler GetOnPointerEnterAsyncHandler()
+        {
+            return new AsyncTriggerHandler<PointerEventData>(this, false);
+        }
+
+        public IAsyncOnPointerEnterHandler GetOnPointerEnterAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<PointerEventData>(this, cancellationToken, false);
+        }
+
+        public UniTask<PointerEventData> OnPointerEnterAsync()
+        {
+            return ((IAsyncOnPointerEnterHandler)new AsyncTriggerHandler<PointerEventData>(this, true)).OnPointerEnterAsync();
+        }
+
+        public UniTask<PointerEventData> OnPointerEnterAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnPointerEnterHandler)new AsyncTriggerHandler<PointerEventData>(this, cancellationToken, true)).OnPointerEnterAsync();
+        }
+    }
+#endif
+#endregion
+
+#region PointerExit
+#if !UNITY_2019_1_OR_NEWER || UNITASK_UGUI_SUPPORT
+
+    public interface IAsyncOnPointerExitHandler
+    {
+        UniTask<PointerEventData> OnPointerExitAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnPointerExitHandler
+    {
+        UniTask<PointerEventData> IAsyncOnPointerExitHandler.OnPointerExitAsync()
+        {
+            core.Reset();
+            return new UniTask<PointerEventData>((IUniTaskSource<PointerEventData>)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncPointerExitTrigger GetAsyncPointerExitTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncPointerExitTrigger>(gameObject);
+        }
+        
+        public static AsyncPointerExitTrigger GetAsyncPointerExitTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncPointerExitTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncPointerExitTrigger : AsyncTriggerBase<PointerEventData>, IPointerExitHandler
+    {
+        void IPointerExitHandler.OnPointerExit(PointerEventData eventData)
+        {
+            RaiseEvent((eventData));
+        }
+
+        public IAsyncOnPointerExitHandler GetOnPointerExitAsyncHandler()
+        {
+            return new AsyncTriggerHandler<PointerEventData>(this, false);
+        }
+
+        public IAsyncOnPointerExitHandler GetOnPointerExitAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<PointerEventData>(this, cancellationToken, false);
+        }
+
+        public UniTask<PointerEventData> OnPointerExitAsync()
+        {
+            return ((IAsyncOnPointerExitHandler)new AsyncTriggerHandler<PointerEventData>(this, true)).OnPointerExitAsync();
+        }
+
+        public UniTask<PointerEventData> OnPointerExitAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnPointerExitHandler)new AsyncTriggerHandler<PointerEventData>(this, cancellationToken, true)).OnPointerExitAsync();
+        }
+    }
+#endif
+#endregion
+
+#region PointerUp
+#if !UNITY_2019_1_OR_NEWER || UNITASK_UGUI_SUPPORT
+
+    public interface IAsyncOnPointerUpHandler
+    {
+        UniTask<PointerEventData> OnPointerUpAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnPointerUpHandler
+    {
+        UniTask<PointerEventData> IAsyncOnPointerUpHandler.OnPointerUpAsync()
+        {
+            core.Reset();
+            return new UniTask<PointerEventData>((IUniTaskSource<PointerEventData>)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncPointerUpTrigger GetAsyncPointerUpTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncPointerUpTrigger>(gameObject);
+        }
+        
+        public static AsyncPointerUpTrigger GetAsyncPointerUpTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncPointerUpTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncPointerUpTrigger : AsyncTriggerBase<PointerEventData>, IPointerUpHandler
+    {
+        void IPointerUpHandler.OnPointerUp(PointerEventData eventData)
+        {
+            RaiseEvent((eventData));
+        }
+
+        public IAsyncOnPointerUpHandler GetOnPointerUpAsyncHandler()
+        {
+            return new AsyncTriggerHandler<PointerEventData>(this, false);
+        }
+
+        public IAsyncOnPointerUpHandler GetOnPointerUpAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<PointerEventData>(this, cancellationToken, false);
+        }
+
+        public UniTask<PointerEventData> OnPointerUpAsync()
+        {
+            return ((IAsyncOnPointerUpHandler)new AsyncTriggerHandler<PointerEventData>(this, true)).OnPointerUpAsync();
+        }
+
+        public UniTask<PointerEventData> OnPointerUpAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnPointerUpHandler)new AsyncTriggerHandler<PointerEventData>(this, cancellationToken, true)).OnPointerUpAsync();
+        }
+    }
+#endif
+#endregion
+
+#region Scroll
+#if !UNITY_2019_1_OR_NEWER || UNITASK_UGUI_SUPPORT
+
+    public interface IAsyncOnScrollHandler
+    {
+        UniTask<PointerEventData> OnScrollAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnScrollHandler
+    {
+        UniTask<PointerEventData> IAsyncOnScrollHandler.OnScrollAsync()
+        {
+            core.Reset();
+            return new UniTask<PointerEventData>((IUniTaskSource<PointerEventData>)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncScrollTrigger GetAsyncScrollTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncScrollTrigger>(gameObject);
+        }
+        
+        public static AsyncScrollTrigger GetAsyncScrollTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncScrollTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncScrollTrigger : AsyncTriggerBase<PointerEventData>, IScrollHandler
+    {
+        void IScrollHandler.OnScroll(PointerEventData eventData)
+        {
+            RaiseEvent((eventData));
+        }
+
+        public IAsyncOnScrollHandler GetOnScrollAsyncHandler()
+        {
+            return new AsyncTriggerHandler<PointerEventData>(this, false);
+        }
+
+        public IAsyncOnScrollHandler GetOnScrollAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<PointerEventData>(this, cancellationToken, false);
+        }
+
+        public UniTask<PointerEventData> OnScrollAsync()
+        {
+            return ((IAsyncOnScrollHandler)new AsyncTriggerHandler<PointerEventData>(this, true)).OnScrollAsync();
+        }
+
+        public UniTask<PointerEventData> OnScrollAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnScrollHandler)new AsyncTriggerHandler<PointerEventData>(this, cancellationToken, true)).OnScrollAsync();
+        }
+    }
+#endif
+#endregion
+
+#region Select
+#if !UNITY_2019_1_OR_NEWER || UNITASK_UGUI_SUPPORT
+
+    public interface IAsyncOnSelectHandler
+    {
+        UniTask<BaseEventData> OnSelectAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnSelectHandler
+    {
+        UniTask<BaseEventData> IAsyncOnSelectHandler.OnSelectAsync()
+        {
+            core.Reset();
+            return new UniTask<BaseEventData>((IUniTaskSource<BaseEventData>)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncSelectTrigger GetAsyncSelectTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncSelectTrigger>(gameObject);
+        }
+        
+        public static AsyncSelectTrigger GetAsyncSelectTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncSelectTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncSelectTrigger : AsyncTriggerBase<BaseEventData>, ISelectHandler
+    {
+        void ISelectHandler.OnSelect(BaseEventData eventData)
+        {
+            RaiseEvent((eventData));
+        }
+
+        public IAsyncOnSelectHandler GetOnSelectAsyncHandler()
+        {
+            return new AsyncTriggerHandler<BaseEventData>(this, false);
+        }
+
+        public IAsyncOnSelectHandler GetOnSelectAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<BaseEventData>(this, cancellationToken, false);
+        }
+
+        public UniTask<BaseEventData> OnSelectAsync()
+        {
+            return ((IAsyncOnSelectHandler)new AsyncTriggerHandler<BaseEventData>(this, true)).OnSelectAsync();
+        }
+
+        public UniTask<BaseEventData> OnSelectAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnSelectHandler)new AsyncTriggerHandler<BaseEventData>(this, cancellationToken, true)).OnSelectAsync();
+        }
+    }
+#endif
+#endregion
+
+#region Submit
+#if !UNITY_2019_1_OR_NEWER || UNITASK_UGUI_SUPPORT
+
+    public interface IAsyncOnSubmitHandler
+    {
+        UniTask<BaseEventData> OnSubmitAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnSubmitHandler
+    {
+        UniTask<BaseEventData> IAsyncOnSubmitHandler.OnSubmitAsync()
+        {
+            core.Reset();
+            return new UniTask<BaseEventData>((IUniTaskSource<BaseEventData>)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncSubmitTrigger GetAsyncSubmitTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncSubmitTrigger>(gameObject);
+        }
+        
+        public static AsyncSubmitTrigger GetAsyncSubmitTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncSubmitTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncSubmitTrigger : AsyncTriggerBase<BaseEventData>, ISubmitHandler
+    {
+        void ISubmitHandler.OnSubmit(BaseEventData eventData)
+        {
+            RaiseEvent((eventData));
+        }
+
+        public IAsyncOnSubmitHandler GetOnSubmitAsyncHandler()
+        {
+            return new AsyncTriggerHandler<BaseEventData>(this, false);
+        }
+
+        public IAsyncOnSubmitHandler GetOnSubmitAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<BaseEventData>(this, cancellationToken, false);
+        }
+
+        public UniTask<BaseEventData> OnSubmitAsync()
+        {
+            return ((IAsyncOnSubmitHandler)new AsyncTriggerHandler<BaseEventData>(this, true)).OnSubmitAsync();
+        }
+
+        public UniTask<BaseEventData> OnSubmitAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnSubmitHandler)new AsyncTriggerHandler<BaseEventData>(this, cancellationToken, true)).OnSubmitAsync();
+        }
+    }
+#endif
+#endregion
+
+#region UpdateSelected
+#if !UNITY_2019_1_OR_NEWER || UNITASK_UGUI_SUPPORT
+
+    public interface IAsyncOnUpdateSelectedHandler
+    {
+        UniTask<BaseEventData> OnUpdateSelectedAsync();
+    }
+
+    public partial class AsyncTriggerHandler<T> : IAsyncOnUpdateSelectedHandler
+    {
+        UniTask<BaseEventData> IAsyncOnUpdateSelectedHandler.OnUpdateSelectedAsync()
+        {
+            core.Reset();
+            return new UniTask<BaseEventData>((IUniTaskSource<BaseEventData>)(object)this, core.Version);
+        }
+    }
+
+    public static partial class AsyncTriggerExtensions
+    {
+        public static AsyncUpdateSelectedTrigger GetAsyncUpdateSelectedTrigger(this GameObject gameObject)
+        {
+            return GetOrAddComponent<AsyncUpdateSelectedTrigger>(gameObject);
+        }
+        
+        public static AsyncUpdateSelectedTrigger GetAsyncUpdateSelectedTrigger(this Component component)
+        {
+            return component.gameObject.GetAsyncUpdateSelectedTrigger();
+        }
+    }
+
+    [DisallowMultipleComponent]
+    public sealed class AsyncUpdateSelectedTrigger : AsyncTriggerBase<BaseEventData>, IUpdateSelectedHandler
+    {
+        void IUpdateSelectedHandler.OnUpdateSelected(BaseEventData eventData)
+        {
+            RaiseEvent((eventData));
+        }
+
+        public IAsyncOnUpdateSelectedHandler GetOnUpdateSelectedAsyncHandler()
+        {
+            return new AsyncTriggerHandler<BaseEventData>(this, false);
+        }
+
+        public IAsyncOnUpdateSelectedHandler GetOnUpdateSelectedAsyncHandler(CancellationToken cancellationToken)
+        {
+            return new AsyncTriggerHandler<BaseEventData>(this, cancellationToken, false);
+        }
+
+        public UniTask<BaseEventData> OnUpdateSelectedAsync()
+        {
+            return ((IAsyncOnUpdateSelectedHandler)new AsyncTriggerHandler<BaseEventData>(this, true)).OnUpdateSelectedAsync();
+        }
+
+        public UniTask<BaseEventData> OnUpdateSelectedAsync(CancellationToken cancellationToken)
+        {
+            return ((IAsyncOnUpdateSelectedHandler)new AsyncTriggerHandler<BaseEventData>(this, cancellationToken, true)).OnUpdateSelectedAsync();
+        }
+    }
+#endif
+#endregion
+
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/Triggers/MonoBehaviourMessagesTriggers.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/Triggers/MonoBehaviourMessagesTriggers.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c30655636c35c3d4da44064af3d2d9a7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/UniTask.Bridge.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/UniTask.Bridge.cs
@@ -1,0 +1,18 @@
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System;
+using System.Collections;
+
+namespace Cysharp.Threading.Tasks
+{
+    // UnityEngine Bridges.
+
+    public partial struct UniTask
+    {
+        public static IEnumerator ToCoroutine(Func<UniTask> taskFactory)
+        {
+            return taskFactory().ToCoroutine();
+        }
+    }
+}
+

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/UniTask.Bridge.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/UniTask.Bridge.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bd6beac8e0ebd264e9ba246c39429c72
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/UniTask.Delay.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/UniTask.Delay.cs
@@ -1,0 +1,965 @@
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using Cysharp.Threading.Tasks.Internal;
+using System;
+using System.Collections;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using UnityEngine;
+
+namespace Cysharp.Threading.Tasks
+{
+    public enum DelayType
+    {
+        /// <summary>use Time.deltaTime.</summary>
+        DeltaTime,
+        /// <summary>Ignore timescale, use Time.unscaledDeltaTime.</summary>
+        UnscaledDeltaTime,
+        /// <summary>use Stopwatch.GetTimestamp().</summary>
+        Realtime
+    }
+
+    public partial struct UniTask
+    {
+        public static YieldAwaitable Yield()
+        {
+            // optimized for single continuation
+            return new YieldAwaitable(PlayerLoopTiming.Update);
+        }
+
+        public static YieldAwaitable Yield(PlayerLoopTiming timing)
+        {
+            // optimized for single continuation
+            return new YieldAwaitable(timing);
+        }
+
+        public static UniTask Yield(CancellationToken cancellationToken)
+        {
+            return new UniTask(YieldPromise.Create(PlayerLoopTiming.Update, cancellationToken, out var token), token);
+        }
+
+        public static UniTask Yield(PlayerLoopTiming timing, CancellationToken cancellationToken)
+        {
+            return new UniTask(YieldPromise.Create(timing, cancellationToken, out var token), token);
+        }
+
+        /// <summary>
+        /// Similar as UniTask.Yield but guaranteed run on next frame.
+        /// </summary>
+        public static UniTask NextFrame()
+        {
+            return new UniTask(NextFramePromise.Create(PlayerLoopTiming.Update, CancellationToken.None, out var token), token);
+        }
+
+        /// <summary>
+        /// Similar as UniTask.Yield but guaranteed run on next frame.
+        /// </summary>
+        public static UniTask NextFrame(PlayerLoopTiming timing)
+        {
+            return new UniTask(NextFramePromise.Create(timing, CancellationToken.None, out var token), token);
+        }
+
+        /// <summary>
+        /// Similar as UniTask.Yield but guaranteed run on next frame.
+        /// </summary>
+        public static UniTask NextFrame(CancellationToken cancellationToken)
+        {
+            return new UniTask(NextFramePromise.Create(PlayerLoopTiming.Update, cancellationToken, out var token), token);
+        }
+
+        /// <summary>
+        /// Similar as UniTask.Yield but guaranteed run on next frame.
+        /// </summary>
+        public static UniTask NextFrame(PlayerLoopTiming timing, CancellationToken cancellationToken)
+        {
+            return new UniTask(NextFramePromise.Create(timing, cancellationToken, out var token), token);
+        }
+
+        [Obsolete("Use WaitForEndOfFrame(MonoBehaviour) instead or UniTask.Yield(PlayerLoopTiming.LastPostLateUpdate). Equivalent for coroutine's WaitForEndOfFrame requires MonoBehaviour(runner of Coroutine).")]
+        public static YieldAwaitable WaitForEndOfFrame()
+        {
+            return UniTask.Yield(PlayerLoopTiming.LastPostLateUpdate);
+        }
+
+        [Obsolete("Use WaitForEndOfFrame(MonoBehaviour) instead or UniTask.Yield(PlayerLoopTiming.LastPostLateUpdate). Equivalent for coroutine's WaitForEndOfFrame requires MonoBehaviour(runner of Coroutine).")]
+        public static UniTask WaitForEndOfFrame(CancellationToken cancellationToken)
+        {
+            return UniTask.Yield(PlayerLoopTiming.LastPostLateUpdate, cancellationToken);
+        }
+
+        public static UniTask WaitForEndOfFrame(MonoBehaviour coroutineRunner, CancellationToken cancellationToken = default)
+        {
+            var source = WaitForEndOfFramePromise.Create(coroutineRunner, cancellationToken, out var token);
+            return new UniTask(source, token);
+        }
+
+        /// <summary>
+        /// Same as UniTask.Yield(PlayerLoopTiming.LastFixedUpdate).
+        /// </summary>
+        public static YieldAwaitable WaitForFixedUpdate()
+        {
+            // use LastFixedUpdate instead of FixedUpdate
+            // https://github.com/Cysharp/UniTask/issues/377
+            return UniTask.Yield(PlayerLoopTiming.LastFixedUpdate);
+        }
+
+        /// <summary>
+        /// Same as UniTask.Yield(PlayerLoopTiming.LastFixedUpdate, cancellationToken).
+        /// </summary>
+        public static UniTask WaitForFixedUpdate(CancellationToken cancellationToken)
+        {
+            return UniTask.Yield(PlayerLoopTiming.LastFixedUpdate, cancellationToken);
+        }
+
+        public static UniTask DelayFrame(int delayFrameCount, PlayerLoopTiming delayTiming = PlayerLoopTiming.Update, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (delayFrameCount < 0)
+            {
+                throw new ArgumentOutOfRangeException("Delay does not allow minus delayFrameCount. delayFrameCount:" + delayFrameCount);
+            }
+
+            return new UniTask(DelayFramePromise.Create(delayFrameCount, delayTiming, cancellationToken, out var token), token);
+        }
+
+        public static UniTask Delay(int millisecondsDelay, bool ignoreTimeScale = false, PlayerLoopTiming delayTiming = PlayerLoopTiming.Update, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var delayTimeSpan = TimeSpan.FromMilliseconds(millisecondsDelay);
+            return Delay(delayTimeSpan, ignoreTimeScale, delayTiming, cancellationToken);
+        }
+
+        public static UniTask Delay(TimeSpan delayTimeSpan, bool ignoreTimeScale = false, PlayerLoopTiming delayTiming = PlayerLoopTiming.Update, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var delayType = ignoreTimeScale ? DelayType.UnscaledDeltaTime : DelayType.DeltaTime;
+            return Delay(delayTimeSpan, delayType, delayTiming, cancellationToken);
+        }
+
+        public static UniTask Delay(int millisecondsDelay, DelayType delayType, PlayerLoopTiming delayTiming = PlayerLoopTiming.Update, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var delayTimeSpan = TimeSpan.FromMilliseconds(millisecondsDelay);
+            return Delay(delayTimeSpan, delayType, delayTiming, cancellationToken);
+        }
+
+        public static UniTask Delay(TimeSpan delayTimeSpan, DelayType delayType, PlayerLoopTiming delayTiming = PlayerLoopTiming.Update, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (delayTimeSpan < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException("Delay does not allow minus delayTimeSpan. delayTimeSpan:" + delayTimeSpan);
+            }
+
+#if UNITY_EDITOR
+            // force use Realtime.
+            if (PlayerLoopHelper.IsMainThread && !UnityEditor.EditorApplication.isPlaying)
+            {
+                delayType = DelayType.Realtime;
+            }
+#endif
+
+            switch (delayType)
+            {
+                case DelayType.UnscaledDeltaTime:
+                    {
+                        return new UniTask(DelayIgnoreTimeScalePromise.Create(delayTimeSpan, delayTiming, cancellationToken, out var token), token);
+                    }
+                case DelayType.Realtime:
+                    {
+                        return new UniTask(DelayRealtimePromise.Create(delayTimeSpan, delayTiming, cancellationToken, out var token), token);
+                    }
+                case DelayType.DeltaTime:
+                default:
+                    {
+                        return new UniTask(DelayPromise.Create(delayTimeSpan, delayTiming, cancellationToken, out var token), token);
+                    }
+            }
+        }
+
+        sealed class YieldPromise : IUniTaskSource, IPlayerLoopItem, ITaskPoolNode<YieldPromise>
+        {
+            static TaskPool<YieldPromise> pool;
+            YieldPromise nextNode;
+            public ref YieldPromise NextNode => ref nextNode;
+
+            static YieldPromise()
+            {
+                TaskPool.RegisterSizeGetter(typeof(YieldPromise), () => pool.Size);
+            }
+
+            CancellationToken cancellationToken;
+            UniTaskCompletionSourceCore<object> core;
+
+            YieldPromise()
+            {
+            }
+
+            public static IUniTaskSource Create(PlayerLoopTiming timing, CancellationToken cancellationToken, out short token)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return AutoResetUniTaskCompletionSource.CreateFromCanceled(cancellationToken, out token);
+                }
+
+                if (!pool.TryPop(out var result))
+                {
+                    result = new YieldPromise();
+                }
+
+
+                result.cancellationToken = cancellationToken;
+
+                TaskTracker.TrackActiveTask(result, 3);
+
+                PlayerLoopHelper.AddAction(timing, result);
+
+                token = result.core.Version;
+                return result;
+            }
+
+            public void GetResult(short token)
+            {
+                try
+                {
+                    core.GetResult(token);
+                }
+                finally
+                {
+                    TryReturn();
+                }
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+
+            public bool MoveNext()
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    core.TrySetCanceled(cancellationToken);
+                    return false;
+                }
+
+                core.TrySetResult(null);
+                return false;
+            }
+
+            bool TryReturn()
+            {
+                TaskTracker.RemoveTracking(this);
+                core.Reset();
+                cancellationToken = default;
+                return pool.TryPush(this);
+            }
+        }
+
+        sealed class NextFramePromise : IUniTaskSource, IPlayerLoopItem, ITaskPoolNode<NextFramePromise>
+        {
+            static TaskPool<NextFramePromise> pool;
+            NextFramePromise nextNode;
+            public ref NextFramePromise NextNode => ref nextNode;
+
+            static NextFramePromise()
+            {
+                TaskPool.RegisterSizeGetter(typeof(NextFramePromise), () => pool.Size);
+            }
+
+            int frameCount;
+            CancellationToken cancellationToken;
+            UniTaskCompletionSourceCore<AsyncUnit> core;
+
+            NextFramePromise()
+            {
+            }
+
+            public static IUniTaskSource Create(PlayerLoopTiming timing, CancellationToken cancellationToken, out short token)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return AutoResetUniTaskCompletionSource.CreateFromCanceled(cancellationToken, out token);
+                }
+
+                if (!pool.TryPop(out var result))
+                {
+                    result = new NextFramePromise();
+                }
+
+                result.frameCount = PlayerLoopHelper.IsMainThread ? Time.frameCount : -1;
+                result.cancellationToken = cancellationToken;
+
+                TaskTracker.TrackActiveTask(result, 3);
+
+                PlayerLoopHelper.AddAction(timing, result);
+
+                token = result.core.Version;
+                return result;
+            }
+
+            public void GetResult(short token)
+            {
+                try
+                {
+                    core.GetResult(token);
+                }
+                finally
+                {
+                    TryReturn();
+                }
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+
+            public bool MoveNext()
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    core.TrySetCanceled(cancellationToken);
+                    return false;
+                }
+
+                if (frameCount == Time.frameCount)
+                {
+                    return true;
+                }
+
+                core.TrySetResult(AsyncUnit.Default);
+                return false;
+            }
+
+            bool TryReturn()
+            {
+                TaskTracker.RemoveTracking(this);
+                core.Reset();
+                cancellationToken = default;
+                return pool.TryPush(this);
+            }
+        }
+
+        sealed class WaitForEndOfFramePromise : IUniTaskSource, ITaskPoolNode<WaitForEndOfFramePromise>, System.Collections.IEnumerator
+        {
+            static TaskPool<WaitForEndOfFramePromise> pool;
+            WaitForEndOfFramePromise nextNode;
+            public ref WaitForEndOfFramePromise NextNode => ref nextNode;
+
+            static WaitForEndOfFramePromise()
+            {
+                TaskPool.RegisterSizeGetter(typeof(WaitForEndOfFramePromise), () => pool.Size);
+            }
+
+            CancellationToken cancellationToken;
+            UniTaskCompletionSourceCore<object> core;
+
+            WaitForEndOfFramePromise()
+            {
+            }
+
+            public static IUniTaskSource Create(MonoBehaviour coroutineRunner, CancellationToken cancellationToken, out short token)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return AutoResetUniTaskCompletionSource.CreateFromCanceled(cancellationToken, out token);
+                }
+
+                if (!pool.TryPop(out var result))
+                {
+                    result = new WaitForEndOfFramePromise();
+                }
+
+                result.cancellationToken = cancellationToken;
+
+                TaskTracker.TrackActiveTask(result, 3);
+
+                coroutineRunner.StartCoroutine(result);
+
+                token = result.core.Version;
+                return result;
+            }
+
+            public void GetResult(short token)
+            {
+                try
+                {
+                    core.GetResult(token);
+                }
+                finally
+                {
+                    TryReturn();
+                }
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+
+            bool TryReturn()
+            {
+                TaskTracker.RemoveTracking(this);
+                core.Reset();
+                Reset(); // Reset Enumerator
+                cancellationToken = default;
+                return pool.TryPush(this);
+            }
+
+            // Coroutine Runner implementation
+
+            static readonly WaitForEndOfFrame waitForEndOfFrameYieldInstruction = new WaitForEndOfFrame();
+            bool isFirst = true;
+
+            object IEnumerator.Current => waitForEndOfFrameYieldInstruction;
+
+            bool IEnumerator.MoveNext()
+            {
+                if (isFirst)
+                {
+                    isFirst = false;
+                    return true; // start WaitForEndOfFrame
+                }
+
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    core.TrySetCanceled(cancellationToken);
+                    return false;
+                }
+
+                core.TrySetResult(null);
+                return false;
+            }
+
+            public void Reset()
+            {
+                isFirst = true;
+            }
+        }
+
+        sealed class DelayFramePromise : IUniTaskSource, IPlayerLoopItem, ITaskPoolNode<DelayFramePromise>
+        {
+            static TaskPool<DelayFramePromise> pool;
+            DelayFramePromise nextNode;
+            public ref DelayFramePromise NextNode => ref nextNode;
+
+            static DelayFramePromise()
+            {
+                TaskPool.RegisterSizeGetter(typeof(DelayFramePromise), () => pool.Size);
+            }
+
+            int initialFrame;
+            int delayFrameCount;
+            CancellationToken cancellationToken;
+
+            int currentFrameCount;
+            UniTaskCompletionSourceCore<AsyncUnit> core;
+
+            DelayFramePromise()
+            {
+            }
+
+            public static IUniTaskSource Create(int delayFrameCount, PlayerLoopTiming timing, CancellationToken cancellationToken, out short token)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return AutoResetUniTaskCompletionSource.CreateFromCanceled(cancellationToken, out token);
+                }
+
+                if (!pool.TryPop(out var result))
+                {
+                    result = new DelayFramePromise();
+                }
+
+                result.delayFrameCount = delayFrameCount;
+                result.cancellationToken = cancellationToken;
+                result.initialFrame = PlayerLoopHelper.IsMainThread ? Time.frameCount : -1;
+
+                TaskTracker.TrackActiveTask(result, 3);
+
+                PlayerLoopHelper.AddAction(timing, result);
+
+                token = result.core.Version;
+                return result;
+            }
+
+            public void GetResult(short token)
+            {
+                try
+                {
+                    core.GetResult(token);
+                }
+                finally
+                {
+                    TryReturn();
+                }
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+
+            public bool MoveNext()
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    core.TrySetCanceled(cancellationToken);
+                    return false;
+                }
+
+                if (currentFrameCount == 0)
+                {
+                    if (delayFrameCount == 0) // same as Yield
+                    {
+                        core.TrySetResult(AsyncUnit.Default);
+                        return false;
+                    }
+
+                    // skip in initial frame.
+                    if (initialFrame == Time.frameCount)
+                    {
+#if UNITY_EDITOR
+                        // force use Realtime.
+                        if (PlayerLoopHelper.IsMainThread && !UnityEditor.EditorApplication.isPlaying)
+                        {
+                            //goto ++currentFrameCount
+                        }
+                        else
+                        {
+                            return true;
+                        }
+#else
+                        return true;
+#endif
+                    }
+                }
+
+                if (++currentFrameCount >= delayFrameCount)
+                {
+                    core.TrySetResult(AsyncUnit.Default);
+                    return false;
+                }
+
+                return true;
+            }
+
+            bool TryReturn()
+            {
+                TaskTracker.RemoveTracking(this);
+                core.Reset();
+                currentFrameCount = default;
+                delayFrameCount = default;
+                cancellationToken = default;
+                return pool.TryPush(this);
+            }
+        }
+
+        sealed class DelayPromise : IUniTaskSource, IPlayerLoopItem, ITaskPoolNode<DelayPromise>
+        {
+            static TaskPool<DelayPromise> pool;
+            DelayPromise nextNode;
+            public ref DelayPromise NextNode => ref nextNode;
+
+            static DelayPromise()
+            {
+                TaskPool.RegisterSizeGetter(typeof(DelayPromise), () => pool.Size);
+            }
+
+            int initialFrame;
+            float delayTimeSpan;
+            float elapsed;
+            CancellationToken cancellationToken;
+
+            UniTaskCompletionSourceCore<object> core;
+
+            DelayPromise()
+            {
+            }
+
+            public static IUniTaskSource Create(TimeSpan delayTimeSpan, PlayerLoopTiming timing, CancellationToken cancellationToken, out short token)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return AutoResetUniTaskCompletionSource.CreateFromCanceled(cancellationToken, out token);
+                }
+
+                if (!pool.TryPop(out var result))
+                {
+                    result = new DelayPromise();
+                }
+
+                result.elapsed = 0.0f;
+                result.delayTimeSpan = (float)delayTimeSpan.TotalSeconds;
+                result.cancellationToken = cancellationToken;
+                result.initialFrame = PlayerLoopHelper.IsMainThread ? Time.frameCount : -1;
+
+                TaskTracker.TrackActiveTask(result, 3);
+
+                PlayerLoopHelper.AddAction(timing, result);
+
+                token = result.core.Version;
+                return result;
+            }
+
+            public void GetResult(short token)
+            {
+                try
+                {
+                    core.GetResult(token);
+                }
+                finally
+                {
+                    TryReturn();
+                }
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+
+            public bool MoveNext()
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    core.TrySetCanceled(cancellationToken);
+                    return false;
+                }
+
+                if (elapsed == 0.0f)
+                {
+                    if (initialFrame == Time.frameCount)
+                    {
+                        return true;
+                    }
+                }
+
+                elapsed += Time.deltaTime;
+                if (elapsed >= delayTimeSpan)
+                {
+                    core.TrySetResult(null);
+                    return false;
+                }
+
+                return true;
+            }
+
+            bool TryReturn()
+            {
+                TaskTracker.RemoveTracking(this);
+                core.Reset();
+                delayTimeSpan = default;
+                elapsed = default;
+                cancellationToken = default;
+                return pool.TryPush(this);
+            }
+        }
+
+        sealed class DelayIgnoreTimeScalePromise : IUniTaskSource, IPlayerLoopItem, ITaskPoolNode<DelayIgnoreTimeScalePromise>
+        {
+            static TaskPool<DelayIgnoreTimeScalePromise> pool;
+            DelayIgnoreTimeScalePromise nextNode;
+            public ref DelayIgnoreTimeScalePromise NextNode => ref nextNode;
+
+            static DelayIgnoreTimeScalePromise()
+            {
+                TaskPool.RegisterSizeGetter(typeof(DelayIgnoreTimeScalePromise), () => pool.Size);
+            }
+
+            float delayFrameTimeSpan;
+            float elapsed;
+            int initialFrame;
+            CancellationToken cancellationToken;
+
+            UniTaskCompletionSourceCore<object> core;
+
+            DelayIgnoreTimeScalePromise()
+            {
+            }
+
+            public static IUniTaskSource Create(TimeSpan delayFrameTimeSpan, PlayerLoopTiming timing, CancellationToken cancellationToken, out short token)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return AutoResetUniTaskCompletionSource.CreateFromCanceled(cancellationToken, out token);
+                }
+
+                if (!pool.TryPop(out var result))
+                {
+                    result = new DelayIgnoreTimeScalePromise();
+                }
+
+                result.elapsed = 0.0f;
+                result.delayFrameTimeSpan = (float)delayFrameTimeSpan.TotalSeconds;
+                result.initialFrame = PlayerLoopHelper.IsMainThread ? Time.frameCount : -1;
+                result.cancellationToken = cancellationToken;
+
+                TaskTracker.TrackActiveTask(result, 3);
+
+                PlayerLoopHelper.AddAction(timing, result);
+
+                token = result.core.Version;
+                return result;
+            }
+
+            public void GetResult(short token)
+            {
+                try
+                {
+                    core.GetResult(token);
+                }
+                finally
+                {
+                    TryReturn();
+                }
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+
+            public bool MoveNext()
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    core.TrySetCanceled(cancellationToken);
+                    return false;
+                }
+
+                if (elapsed == 0.0f)
+                {
+                    if (initialFrame == Time.frameCount)
+                    {
+                        return true;
+                    }
+                }
+
+                elapsed += Time.unscaledDeltaTime;
+                if (elapsed >= delayFrameTimeSpan)
+                {
+                    core.TrySetResult(null);
+                    return false;
+                }
+
+                return true;
+            }
+
+            bool TryReturn()
+            {
+                TaskTracker.RemoveTracking(this);
+                core.Reset();
+                delayFrameTimeSpan = default;
+                elapsed = default;
+                cancellationToken = default;
+                return pool.TryPush(this);
+            }
+        }
+
+        sealed class DelayRealtimePromise : IUniTaskSource, IPlayerLoopItem, ITaskPoolNode<DelayRealtimePromise>
+        {
+            static TaskPool<DelayRealtimePromise> pool;
+            DelayRealtimePromise nextNode;
+            public ref DelayRealtimePromise NextNode => ref nextNode;
+
+            static DelayRealtimePromise()
+            {
+                TaskPool.RegisterSizeGetter(typeof(DelayRealtimePromise), () => pool.Size);
+            }
+
+            long delayTimeSpanTicks;
+            ValueStopwatch stopwatch;
+            CancellationToken cancellationToken;
+
+            UniTaskCompletionSourceCore<AsyncUnit> core;
+
+            DelayRealtimePromise()
+            {
+            }
+
+            public static IUniTaskSource Create(TimeSpan delayTimeSpan, PlayerLoopTiming timing, CancellationToken cancellationToken, out short token)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return AutoResetUniTaskCompletionSource.CreateFromCanceled(cancellationToken, out token);
+                }
+
+                if (!pool.TryPop(out var result))
+                {
+                    result = new DelayRealtimePromise();
+                }
+
+                result.stopwatch = ValueStopwatch.StartNew();
+                result.delayTimeSpanTicks = delayTimeSpan.Ticks;
+                result.cancellationToken = cancellationToken;
+
+                TaskTracker.TrackActiveTask(result, 3);
+
+                PlayerLoopHelper.AddAction(timing, result);
+
+                token = result.core.Version;
+                return result;
+            }
+
+            public void GetResult(short token)
+            {
+                try
+                {
+                    core.GetResult(token);
+                }
+                finally
+                {
+                    TryReturn();
+                }
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+
+            public bool MoveNext()
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    core.TrySetCanceled(cancellationToken);
+                    return false;
+                }
+
+                if (stopwatch.IsInvalid)
+                {
+                    core.TrySetResult(AsyncUnit.Default);
+                    return false;
+                }
+
+                if (stopwatch.ElapsedTicks >= delayTimeSpanTicks)
+                {
+                    core.TrySetResult(AsyncUnit.Default);
+                    return false;
+                }
+
+                return true;
+            }
+
+            bool TryReturn()
+            {
+                TaskTracker.RemoveTracking(this);
+                core.Reset();
+                stopwatch = default;
+                cancellationToken = default;
+                return pool.TryPush(this);
+            }
+        }
+    }
+
+    public readonly struct YieldAwaitable
+    {
+        readonly PlayerLoopTiming timing;
+
+        public YieldAwaitable(PlayerLoopTiming timing)
+        {
+            this.timing = timing;
+        }
+
+        public Awaiter GetAwaiter()
+        {
+            return new Awaiter(timing);
+        }
+
+        public UniTask ToUniTask()
+        {
+            return UniTask.Yield(timing, CancellationToken.None);
+        }
+
+        public readonly struct Awaiter : ICriticalNotifyCompletion
+        {
+            readonly PlayerLoopTiming timing;
+
+            public Awaiter(PlayerLoopTiming timing)
+            {
+                this.timing = timing;
+            }
+
+            public bool IsCompleted => false;
+
+            public void GetResult() { }
+
+            public void OnCompleted(Action continuation)
+            {
+                PlayerLoopHelper.AddContinuation(timing, continuation);
+            }
+
+            public void UnsafeOnCompleted(Action continuation)
+            {
+                PlayerLoopHelper.AddContinuation(timing, continuation);
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/UniTask.Delay.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/UniTask.Delay.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ecff7972251de0848b2c0fa89bbd3489
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/UniTask.Factory.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/UniTask.Factory.cs
@@ -1,0 +1,499 @@
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using Cysharp.Threading.Tasks.Internal;
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks
+{
+    public partial struct UniTask
+    {
+        static readonly UniTask CanceledUniTask = new Func<UniTask>(() =>
+        {
+            return new UniTask(new CanceledResultSource(CancellationToken.None), 0);
+        })();
+
+        static class CanceledUniTaskCache<T>
+        {
+            public static readonly UniTask<T> Task;
+
+            static CanceledUniTaskCache()
+            {
+                Task = new UniTask<T>(new CanceledResultSource<T>(CancellationToken.None), 0);
+            }
+        }
+
+        public static readonly UniTask CompletedTask = new UniTask();
+
+        public static UniTask FromException(Exception ex)
+        {
+            if (ex is OperationCanceledException oce)
+            {
+                return FromCanceled(oce.CancellationToken);
+            }
+
+            return new UniTask(new ExceptionResultSource(ex), 0);
+        }
+
+        public static UniTask<T> FromException<T>(Exception ex)
+        {
+            if (ex is OperationCanceledException oce)
+            {
+                return FromCanceled<T>(oce.CancellationToken);
+            }
+
+            return new UniTask<T>(new ExceptionResultSource<T>(ex), 0);
+        }
+
+        public static UniTask<T> FromResult<T>(T value)
+        {
+            return new UniTask<T>(value);
+        }
+
+        public static UniTask FromCanceled(CancellationToken cancellationToken = default)
+        {
+            if (cancellationToken == CancellationToken.None)
+            {
+                return CanceledUniTask;
+            }
+            else
+            {
+                return new UniTask(new CanceledResultSource(cancellationToken), 0);
+            }
+        }
+
+        public static UniTask<T> FromCanceled<T>(CancellationToken cancellationToken = default)
+        {
+            if (cancellationToken == CancellationToken.None)
+            {
+                return CanceledUniTaskCache<T>.Task;
+            }
+            else
+            {
+                return new UniTask<T>(new CanceledResultSource<T>(cancellationToken), 0);
+            }
+        }
+
+        public static UniTask Create(Func<UniTask> factory)
+        {
+            return factory();
+        }
+
+        public static UniTask<T> Create<T>(Func<UniTask<T>> factory)
+        {
+            return factory();
+        }
+
+        public static AsyncLazy Lazy(Func<UniTask> factory)
+        {
+            return new AsyncLazy(factory);
+        }
+
+        public static AsyncLazy<T> Lazy<T>(Func<UniTask<T>> factory)
+        {
+            return new AsyncLazy<T>(factory);
+        }
+
+        /// <summary>
+        /// helper of fire and forget void action.
+        /// </summary>
+        public static void Void(Func<UniTaskVoid> asyncAction)
+        {
+            asyncAction().Forget();
+        }
+
+        /// <summary>
+        /// helper of fire and forget void action.
+        /// </summary>
+        public static void Void(Func<CancellationToken, UniTaskVoid> asyncAction, CancellationToken cancellationToken)
+        {
+            asyncAction(cancellationToken).Forget();
+        }
+
+        /// <summary>
+        /// helper of fire and forget void action.
+        /// </summary>
+        public static void Void<T>(Func<T, UniTaskVoid> asyncAction, T state)
+        {
+            asyncAction(state).Forget();
+        }
+
+        /// <summary>
+        /// helper of create add UniTaskVoid to delegate.
+        /// For example: FooAction = UniTask.Action(async () => { /* */ })
+        /// </summary>
+        public static Action Action(Func<UniTaskVoid> asyncAction)
+        {
+            return () => asyncAction().Forget();
+        }
+
+        /// <summary>
+        /// helper of create add UniTaskVoid to delegate.
+        /// </summary>
+        public static Action Action(Func<CancellationToken, UniTaskVoid> asyncAction, CancellationToken cancellationToken)
+        {
+            return () => asyncAction(cancellationToken).Forget();
+        }
+
+#if UNITY_2018_3_OR_NEWER
+
+        /// <summary>
+        /// Create async void(UniTaskVoid) UnityAction.
+        /// For exampe: onClick.AddListener(UniTask.UnityAction(async () => { /* */ } ))
+        /// </summary>
+        public static UnityEngine.Events.UnityAction UnityAction(Func<UniTaskVoid> asyncAction)
+        {
+            return () => asyncAction().Forget();
+        }
+
+        /// <summary>
+        /// Create async void(UniTaskVoid) UnityAction.
+        /// For exampe: onClick.AddListener(UniTask.UnityAction(FooAsync, this.GetCancellationTokenOnDestroy()))
+        /// </summary>
+        public static UnityEngine.Events.UnityAction UnityAction(Func<CancellationToken, UniTaskVoid> asyncAction, CancellationToken cancellationToken)
+        {
+            return () => asyncAction(cancellationToken).Forget();
+        }
+
+#endif
+
+        /// <summary>
+        /// Defer the task creation just before call await.
+        /// </summary>
+        public static UniTask Defer(Func<UniTask> factory)
+        {
+            return new UniTask(new DeferPromise(factory), 0);
+        }
+
+        /// <summary>
+        /// Defer the task creation just before call await.
+        /// </summary>
+        public static UniTask<T> Defer<T>(Func<UniTask<T>> factory)
+        {
+            return new UniTask<T>(new DeferPromise<T>(factory), 0);
+        }
+
+        /// <summary>
+        /// Never complete.
+        /// </summary>
+        public static UniTask Never(CancellationToken cancellationToken)
+        {
+            return new UniTask<AsyncUnit>(new NeverPromise<AsyncUnit>(cancellationToken), 0);
+        }
+
+        /// <summary>
+        /// Never complete.
+        /// </summary>
+        public static UniTask<T> Never<T>(CancellationToken cancellationToken)
+        {
+            return new UniTask<T>(new NeverPromise<T>(cancellationToken), 0);
+        }
+
+        sealed class ExceptionResultSource : IUniTaskSource
+        {
+            readonly ExceptionDispatchInfo exception;
+            bool calledGet;
+
+            public ExceptionResultSource(Exception exception)
+            {
+                this.exception = ExceptionDispatchInfo.Capture(exception);
+            }
+
+            public void GetResult(short token)
+            {
+                if (!calledGet)
+                {
+                    calledGet = true;
+                    GC.SuppressFinalize(this);
+                }
+                exception.Throw();
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return UniTaskStatus.Faulted;
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return UniTaskStatus.Faulted;
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                continuation(state);
+            }
+
+            ~ExceptionResultSource()
+            {
+                if (!calledGet)
+                {
+                    UniTaskScheduler.PublishUnobservedTaskException(exception.SourceException);
+                }
+            }
+        }
+
+        sealed class ExceptionResultSource<T> : IUniTaskSource<T>
+        {
+            readonly ExceptionDispatchInfo exception;
+            bool calledGet;
+
+            public ExceptionResultSource(Exception exception)
+            {
+                this.exception = ExceptionDispatchInfo.Capture(exception);
+            }
+
+            public T GetResult(short token)
+            {
+                if (!calledGet)
+                {
+                    calledGet = true;
+                    GC.SuppressFinalize(this);
+                }
+                exception.Throw();
+                return default;
+            }
+
+            void IUniTaskSource.GetResult(short token)
+            {
+                if (!calledGet)
+                {
+                    calledGet = true;
+                    GC.SuppressFinalize(this);
+                }
+                exception.Throw();
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return UniTaskStatus.Faulted;
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return UniTaskStatus.Faulted;
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                continuation(state);
+            }
+
+            ~ExceptionResultSource()
+            {
+                if (!calledGet)
+                {
+                    UniTaskScheduler.PublishUnobservedTaskException(exception.SourceException);
+                }
+            }
+        }
+
+        sealed class CanceledResultSource : IUniTaskSource
+        {
+            readonly CancellationToken cancellationToken;
+
+            public CanceledResultSource(CancellationToken cancellationToken)
+            {
+                this.cancellationToken = cancellationToken;
+            }
+
+            public void GetResult(short token)
+            {
+                throw new OperationCanceledException(cancellationToken);
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return UniTaskStatus.Canceled;
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return UniTaskStatus.Canceled;
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                continuation(state);
+            }
+        }
+
+        sealed class CanceledResultSource<T> : IUniTaskSource<T>
+        {
+            readonly CancellationToken cancellationToken;
+
+            public CanceledResultSource(CancellationToken cancellationToken)
+            {
+                this.cancellationToken = cancellationToken;
+            }
+
+            public T GetResult(short token)
+            {
+                throw new OperationCanceledException(cancellationToken);
+            }
+
+            void IUniTaskSource.GetResult(short token)
+            {
+                throw new OperationCanceledException(cancellationToken);
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return UniTaskStatus.Canceled;
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return UniTaskStatus.Canceled;
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                continuation(state);
+            }
+        }
+
+        sealed class DeferPromise : IUniTaskSource
+        {
+            Func<UniTask> factory;
+            UniTask task;
+            UniTask.Awaiter awaiter;
+
+            public DeferPromise(Func<UniTask> factory)
+            {
+                this.factory = factory;
+            }
+
+            public void GetResult(short token)
+            {
+                awaiter.GetResult();
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                var f = Interlocked.Exchange(ref factory, null);
+                if (f != null)
+                {
+                    task = f();
+                    awaiter = task.GetAwaiter();
+                }
+
+                return task.Status;
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                awaiter.SourceOnCompleted(continuation, state);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return task.Status;
+            }
+        }
+
+        sealed class DeferPromise<T> : IUniTaskSource<T>
+        {
+            Func<UniTask<T>> factory;
+            UniTask<T> task;
+            UniTask<T>.Awaiter awaiter;
+
+            public DeferPromise(Func<UniTask<T>> factory)
+            {
+                this.factory = factory;
+            }
+
+            public T GetResult(short token)
+            {
+                return awaiter.GetResult();
+            }
+
+            void IUniTaskSource.GetResult(short token)
+            {
+                awaiter.GetResult();
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                var f = Interlocked.Exchange(ref factory, null);
+                if (f != null)
+                {
+                    task = f();
+                    awaiter = task.GetAwaiter();
+                }
+
+                return task.Status;
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                awaiter.SourceOnCompleted(continuation, state);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return task.Status;
+            }
+        }
+
+        sealed class NeverPromise<T> : IUniTaskSource<T>
+        {
+            static readonly Action<object> cancellationCallback = CancellationCallback;
+
+            CancellationToken cancellationToken;
+            UniTaskCompletionSourceCore<T> core;
+
+            public NeverPromise(CancellationToken cancellationToken)
+            {
+                this.cancellationToken = cancellationToken;
+                if (this.cancellationToken.CanBeCanceled)
+                {
+                    this.cancellationToken.RegisterWithoutCaptureExecutionContext(cancellationCallback, this);
+                }
+            }
+
+            static void CancellationCallback(object state)
+            {
+                var self = (NeverPromise<T>)state;
+                self.core.TrySetCanceled(self.cancellationToken);
+            }
+
+            public T GetResult(short token)
+            {
+                return core.GetResult(token);
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+
+            void IUniTaskSource.GetResult(short token)
+            {
+                core.GetResult(token);
+            }
+        }
+    }
+
+    internal static class CompletedTasks
+    {
+        public static readonly UniTask<AsyncUnit> AsyncUnit = UniTask.FromResult(Cysharp.Threading.Tasks.AsyncUnit.Default);
+        public static readonly UniTask<bool> True = UniTask.FromResult(true);
+        public static readonly UniTask<bool> False = UniTask.FromResult(false);
+        public static readonly UniTask<int> Zero = UniTask.FromResult(0);
+        public static readonly UniTask<int> MinusOne = UniTask.FromResult(-1);
+        public static readonly UniTask<int> One = UniTask.FromResult(1);
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/UniTask.Factory.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/UniTask.Factory.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4e12b66d6b9bd7845b04a594cbe386b4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/UniTask.Run.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/UniTask.Run.cs
@@ -1,0 +1,289 @@
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks
+{
+    public partial struct UniTask
+    {
+        #region OBSOLETE_RUN
+
+        [Obsolete("UniTask.Run is similar as Task.Run, it uses ThreadPool. For equivalent behaviour, use UniTask.RunOnThreadPool instead. If you don't want to use ThreadPool, you can use UniTask.Void(async void) or UniTask.Create(async UniTask) too.")]
+        public static UniTask Run(Action action, bool configureAwait = true, CancellationToken cancellationToken = default)
+        {
+            return RunOnThreadPool(action, configureAwait, cancellationToken);
+        }
+
+        [Obsolete("UniTask.Run is similar as Task.Run, it uses ThreadPool. For equivalent behaviour, use UniTask.RunOnThreadPool instead. If you don't want to use ThreadPool, you can use UniTask.Void(async void) or UniTask.Create(async UniTask) too.")]
+        public static UniTask Run(Action<object> action, object state, bool configureAwait = true, CancellationToken cancellationToken = default)
+        {
+            return RunOnThreadPool(action, state, configureAwait, cancellationToken);
+        }
+
+        [Obsolete("UniTask.Run is similar as Task.Run, it uses ThreadPool. For equivalent behaviour, use UniTask.RunOnThreadPool instead. If you don't want to use ThreadPool, you can use UniTask.Void(async void) or UniTask.Create(async UniTask) too.")]
+        public static UniTask Run(Func<UniTask> action, bool configureAwait = true, CancellationToken cancellationToken = default)
+        {
+            return RunOnThreadPool(action, configureAwait, cancellationToken);
+        }
+
+        [Obsolete("UniTask.Run is similar as Task.Run, it uses ThreadPool. For equivalent behaviour, use UniTask.RunOnThreadPool instead. If you don't want to use ThreadPool, you can use UniTask.Void(async void) or UniTask.Create(async UniTask) too.")]
+        public static UniTask Run(Func<object, UniTask> action, object state, bool configureAwait = true, CancellationToken cancellationToken = default)
+        {
+            return RunOnThreadPool(action, state, configureAwait, cancellationToken);
+        }
+
+        [Obsolete("UniTask.Run is similar as Task.Run, it uses ThreadPool. For equivalent behaviour, use UniTask.RunOnThreadPool instead. If you don't want to use ThreadPool, you can use UniTask.Void(async void) or UniTask.Create(async UniTask) too.")]
+        public static UniTask<T> Run<T>(Func<T> func, bool configureAwait = true, CancellationToken cancellationToken = default)
+        {
+            return RunOnThreadPool(func, configureAwait, cancellationToken);
+        }
+
+        [Obsolete("UniTask.Run is similar as Task.Run, it uses ThreadPool. For equivalent behaviour, use UniTask.RunOnThreadPool instead. If you don't want to use ThreadPool, you can use UniTask.Void(async void) or UniTask.Create(async UniTask) too.")]
+        public static UniTask<T> Run<T>(Func<UniTask<T>> func, bool configureAwait = true, CancellationToken cancellationToken = default)
+        {
+            return RunOnThreadPool(func, configureAwait, cancellationToken);
+        }
+
+        [Obsolete("UniTask.Run is similar as Task.Run, it uses ThreadPool. For equivalent behaviour, use UniTask.RunOnThreadPool instead. If you don't want to use ThreadPool, you can use UniTask.Void(async void) or UniTask.Create(async UniTask) too.")]
+        public static UniTask<T> Run<T>(Func<object, T> func, object state, bool configureAwait = true, CancellationToken cancellationToken = default)
+        {
+            return RunOnThreadPool(func, state, configureAwait, cancellationToken);
+        }
+
+        [Obsolete("UniTask.Run is similar as Task.Run, it uses ThreadPool. For equivalent behaviour, use UniTask.RunOnThreadPool instead. If you don't want to use ThreadPool, you can use UniTask.Void(async void) or UniTask.Create(async UniTask) too.")]
+        public static UniTask<T> Run<T>(Func<object, UniTask<T>> func, object state, bool configureAwait = true, CancellationToken cancellationToken = default)
+        {
+            return RunOnThreadPool(func, state, configureAwait, cancellationToken);
+        }
+
+        #endregion
+
+        /// <summary>Run action on the threadPool and return to main thread if configureAwait = true.</summary>
+        public static async UniTask RunOnThreadPool(Action action, bool configureAwait = true, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            await UniTask.SwitchToThreadPool();
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (configureAwait)
+            {
+                try
+                {
+                    action();
+                }
+                finally
+                {
+                    await UniTask.Yield();
+                }
+            }
+            else
+            {
+                action();
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+        }
+
+        /// <summary>Run action on the threadPool and return to main thread if configureAwait = true.</summary>
+        public static async UniTask RunOnThreadPool(Action<object> action, object state, bool configureAwait = true, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            await UniTask.SwitchToThreadPool();
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (configureAwait)
+            {
+                try
+                {
+                    action(state);
+                }
+                finally
+                {
+                    await UniTask.Yield();
+                }
+            }
+            else
+            {
+                action(state);
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+        }
+
+        /// <summary>Run action on the threadPool and return to main thread if configureAwait = true.</summary>
+        public static async UniTask RunOnThreadPool(Func<UniTask> action, bool configureAwait = true, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            await UniTask.SwitchToThreadPool();
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (configureAwait)
+            {
+                try
+                {
+                    await action();
+                }
+                finally
+                {
+                    await UniTask.Yield();
+                }
+            }
+            else
+            {
+                await action();
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+        }
+
+        /// <summary>Run action on the threadPool and return to main thread if configureAwait = true.</summary>
+        public static async UniTask RunOnThreadPool(Func<object, UniTask> action, object state, bool configureAwait = true, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            await UniTask.SwitchToThreadPool();
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (configureAwait)
+            {
+                try
+                {
+                    await action(state);
+                }
+                finally
+                {
+                    await UniTask.Yield();
+                }
+            }
+            else
+            {
+                await action(state);
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+        }
+
+        /// <summary>Run action on the threadPool and return to main thread if configureAwait = true.</summary>
+        public static async UniTask<T> RunOnThreadPool<T>(Func<T> func, bool configureAwait = true, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            await UniTask.SwitchToThreadPool();
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (configureAwait)
+            {
+                try
+                {
+                    return func();
+                }
+                finally
+                {
+                    await UniTask.Yield();
+                    cancellationToken.ThrowIfCancellationRequested();
+                }
+            }
+            else
+            {
+                return func();
+            }
+        }
+
+        /// <summary>Run action on the threadPool and return to main thread if configureAwait = true.</summary>
+        public static async UniTask<T> RunOnThreadPool<T>(Func<UniTask<T>> func, bool configureAwait = true, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            await UniTask.SwitchToThreadPool();
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (configureAwait)
+            {
+                try
+                {
+                    return await func();
+                }
+                finally
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    await UniTask.Yield();
+                    cancellationToken.ThrowIfCancellationRequested();
+                }
+            }
+            else
+            {
+                var result = await func();
+                cancellationToken.ThrowIfCancellationRequested();
+                return result;
+            }
+        }
+
+        /// <summary>Run action on the threadPool and return to main thread if configureAwait = true.</summary>
+        public static async UniTask<T> RunOnThreadPool<T>(Func<object, T> func, object state, bool configureAwait = true, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            await UniTask.SwitchToThreadPool();
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (configureAwait)
+            {
+                try
+                {
+                    return func(state);
+                }
+                finally
+                {
+                    await UniTask.Yield();
+                    cancellationToken.ThrowIfCancellationRequested();
+                }
+            }
+            else
+            {
+                return func(state);
+            }
+        }
+
+        /// <summary>Run action on the threadPool and return to main thread if configureAwait = true.</summary>
+        public static async UniTask<T> RunOnThreadPool<T>(Func<object, UniTask<T>> func, object state, bool configureAwait = true, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            await UniTask.SwitchToThreadPool();
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (configureAwait)
+            {
+                try
+                {
+                    return await func(state);
+                }
+                finally
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    await UniTask.Yield();
+                    cancellationToken.ThrowIfCancellationRequested();
+                }
+            }
+            else
+            {
+                var result = await func(state);
+                cancellationToken.ThrowIfCancellationRequested();
+                return result;
+            }
+        }
+    }
+}
+

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/UniTask.Run.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/UniTask.Run.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8473162fc285a5f44bcca90f7da073e7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/UniTask.Threading.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/UniTask.Threading.cs
@@ -1,0 +1,412 @@
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Cysharp.Threading.Tasks.Internal;
+
+namespace Cysharp.Threading.Tasks
+{
+    public partial struct UniTask
+    {
+#if UNITY_2018_3_OR_NEWER
+
+        /// <summary>
+        /// If running on mainthread, do nothing. Otherwise, same as UniTask.Yield(PlayerLoopTiming.Update).
+        /// </summary>
+        public static SwitchToMainThreadAwaitable SwitchToMainThread(CancellationToken cancellationToken = default)
+        {
+            return new SwitchToMainThreadAwaitable(PlayerLoopTiming.Update, cancellationToken);
+        }
+
+        /// <summary>
+        /// If running on mainthread, do nothing. Otherwise, same as UniTask.Yield(timing).
+        /// </summary>
+        public static SwitchToMainThreadAwaitable SwitchToMainThread(PlayerLoopTiming timing, CancellationToken cancellationToken = default)
+        {
+            return new SwitchToMainThreadAwaitable(timing, cancellationToken);
+        }
+
+        /// <summary>
+        /// Return to mainthread(same as await SwitchToMainThread) after using scope is closed.
+        /// </summary>
+        public static ReturnToMainThread ReturnToMainThread(CancellationToken cancellationToken = default)
+        {
+            return new ReturnToMainThread(PlayerLoopTiming.Update, cancellationToken);
+        }
+
+        /// <summary>
+        /// Return to mainthread(same as await SwitchToMainThread) after using scope is closed.
+        /// </summary>
+        public static ReturnToMainThread ReturnToMainThread(PlayerLoopTiming timing, CancellationToken cancellationToken = default)
+        {
+            return new ReturnToMainThread(timing, cancellationToken);
+        }
+
+        /// <summary>
+        /// Queue the action to PlayerLoop.
+        /// </summary>
+        public static void Post(Action action, PlayerLoopTiming timing = PlayerLoopTiming.Update)
+        {
+            PlayerLoopHelper.AddContinuation(timing, action);
+        }
+
+#endif
+
+        public static SwitchToThreadPoolAwaitable SwitchToThreadPool()
+        {
+            return new SwitchToThreadPoolAwaitable();
+        }
+
+        /// <summary>
+        /// Note: use SwitchToThreadPool is recommended.
+        /// </summary>
+        public static SwitchToTaskPoolAwaitable SwitchToTaskPool()
+        {
+            return new SwitchToTaskPoolAwaitable();
+        }
+
+        public static SwitchToSynchronizationContextAwaitable SwitchToSynchronizationContext(SynchronizationContext synchronizationContext, CancellationToken cancellationToken = default)
+        {
+            Error.ThrowArgumentNullException(synchronizationContext, nameof(synchronizationContext));
+            return new SwitchToSynchronizationContextAwaitable(synchronizationContext, cancellationToken);
+        }
+
+        public static ReturnToSynchronizationContext ReturnToSynchronizationContext(SynchronizationContext synchronizationContext, CancellationToken cancellationToken = default)
+        {
+            return new ReturnToSynchronizationContext(synchronizationContext, false, cancellationToken);
+        }
+
+        public static ReturnToSynchronizationContext ReturnToCurrentSynchronizationContext(bool dontPostWhenSameContext = true, CancellationToken cancellationToken = default)
+        {
+            return new ReturnToSynchronizationContext(SynchronizationContext.Current, dontPostWhenSameContext, cancellationToken);
+        }
+    }
+
+#if UNITY_2018_3_OR_NEWER
+
+    public struct SwitchToMainThreadAwaitable
+    {
+        readonly PlayerLoopTiming playerLoopTiming;
+        readonly CancellationToken cancellationToken;
+
+        public SwitchToMainThreadAwaitable(PlayerLoopTiming playerLoopTiming, CancellationToken cancellationToken)
+        {
+            this.playerLoopTiming = playerLoopTiming;
+            this.cancellationToken = cancellationToken;
+        }
+
+        public Awaiter GetAwaiter() => new Awaiter(playerLoopTiming, cancellationToken);
+
+        public struct Awaiter : ICriticalNotifyCompletion
+        {
+            readonly PlayerLoopTiming playerLoopTiming;
+            readonly CancellationToken cancellationToken;
+
+            public Awaiter(PlayerLoopTiming playerLoopTiming, CancellationToken cancellationToken)
+            {
+                this.playerLoopTiming = playerLoopTiming;
+                this.cancellationToken = cancellationToken;
+            }
+
+            public bool IsCompleted
+            {
+                get
+                {
+                    var currentThreadId = System.Threading.Thread.CurrentThread.ManagedThreadId;
+                    if (PlayerLoopHelper.MainThreadId == currentThreadId)
+                    {
+                        return true; // run immediate.
+                    }
+                    else
+                    {
+                        return false; // register continuation.
+                    }
+                }
+            }
+
+            public void GetResult() { cancellationToken.ThrowIfCancellationRequested(); }
+
+            public void OnCompleted(Action continuation)
+            {
+                PlayerLoopHelper.AddContinuation(playerLoopTiming, continuation);
+            }
+
+            public void UnsafeOnCompleted(Action continuation)
+            {
+                PlayerLoopHelper.AddContinuation(playerLoopTiming, continuation);
+            }
+        }
+    }
+
+    public struct ReturnToMainThread
+    {
+        readonly PlayerLoopTiming playerLoopTiming;
+        readonly CancellationToken cancellationToken;
+
+        public ReturnToMainThread(PlayerLoopTiming playerLoopTiming, CancellationToken cancellationToken)
+        {
+            this.playerLoopTiming = playerLoopTiming;
+            this.cancellationToken = cancellationToken;
+        }
+
+        public Awaiter DisposeAsync()
+        {
+            return new Awaiter(playerLoopTiming, cancellationToken); // run immediate.
+        }
+
+        public readonly struct Awaiter : ICriticalNotifyCompletion
+        {
+            readonly PlayerLoopTiming timing;
+            readonly CancellationToken cancellationToken;
+
+            public Awaiter(PlayerLoopTiming timing, CancellationToken cancellationToken)
+            {
+                this.timing = timing;
+                this.cancellationToken = cancellationToken;
+            }
+
+            public Awaiter GetAwaiter() => this;
+
+            public bool IsCompleted => PlayerLoopHelper.MainThreadId == System.Threading.Thread.CurrentThread.ManagedThreadId;
+
+            public void GetResult() { cancellationToken.ThrowIfCancellationRequested(); }
+
+            public void OnCompleted(Action continuation)
+            {
+                PlayerLoopHelper.AddContinuation(timing, continuation);
+            }
+
+            public void UnsafeOnCompleted(Action continuation)
+            {
+                PlayerLoopHelper.AddContinuation(timing, continuation);
+            }
+        }
+    }
+
+#endif
+
+    public struct SwitchToThreadPoolAwaitable
+    {
+        public Awaiter GetAwaiter() => new Awaiter();
+
+        public struct Awaiter : ICriticalNotifyCompletion
+        {
+            static readonly WaitCallback switchToCallback = Callback;
+
+            public bool IsCompleted => false;
+            public void GetResult() { }
+
+            public void OnCompleted(Action continuation)
+            {
+                ThreadPool.QueueUserWorkItem(switchToCallback, continuation);
+            }
+
+            public void UnsafeOnCompleted(Action continuation)
+            {
+#if NETCOREAPP3_1
+                ThreadPool.UnsafeQueueUserWorkItem(ThreadPoolWorkItem.Create(continuation), false);
+#else
+                ThreadPool.UnsafeQueueUserWorkItem(switchToCallback, continuation);
+#endif
+            }
+
+            static void Callback(object state)
+            {
+                var continuation = (Action)state;
+                continuation();
+            }
+        }
+
+#if NETCOREAPP3_1
+
+        sealed class ThreadPoolWorkItem : IThreadPoolWorkItem, ITaskPoolNode<ThreadPoolWorkItem>
+        {
+            static TaskPool<ThreadPoolWorkItem> pool;
+            ThreadPoolWorkItem nextNode;
+            public ref ThreadPoolWorkItem NextNode => ref nextNode;
+
+            static ThreadPoolWorkItem()
+            {
+                TaskPool.RegisterSizeGetter(typeof(ThreadPoolWorkItem), () => pool.Size);
+            }
+
+            Action continuation;
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static ThreadPoolWorkItem Create(Action continuation)
+            {
+                if (!pool.TryPop(out var item))
+                {
+                    item = new ThreadPoolWorkItem();
+                }
+
+                item.continuation = continuation;
+                return item;
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public void Execute()
+            {
+                var call = continuation;
+                continuation = null;
+                if (call != null)
+                {
+                    pool.TryPush(this);
+                    call.Invoke();
+                }
+            }
+        }
+
+#endif
+    }
+
+    public struct SwitchToTaskPoolAwaitable
+    {
+        public Awaiter GetAwaiter() => new Awaiter();
+
+        public struct Awaiter : ICriticalNotifyCompletion
+        {
+            static readonly Action<object> switchToCallback = Callback;
+
+            public bool IsCompleted => false;
+            public void GetResult() { }
+
+            public void OnCompleted(Action continuation)
+            {
+                Task.Factory.StartNew(switchToCallback, continuation, CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
+            }
+
+            public void UnsafeOnCompleted(Action continuation)
+            {
+                Task.Factory.StartNew(switchToCallback, continuation, CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
+            }
+
+            static void Callback(object state)
+            {
+                var continuation = (Action)state;
+                continuation();
+            }
+        }
+    }
+
+    public struct SwitchToSynchronizationContextAwaitable
+    {
+        readonly SynchronizationContext synchronizationContext;
+        readonly CancellationToken cancellationToken;
+
+        public SwitchToSynchronizationContextAwaitable(SynchronizationContext synchronizationContext, CancellationToken cancellationToken)
+        {
+            this.synchronizationContext = synchronizationContext;
+            this.cancellationToken = cancellationToken;
+        }
+
+        public Awaiter GetAwaiter() => new Awaiter(synchronizationContext, cancellationToken);
+
+        public struct Awaiter : ICriticalNotifyCompletion
+        {
+            static readonly SendOrPostCallback switchToCallback = Callback;
+            readonly SynchronizationContext synchronizationContext;
+            readonly CancellationToken cancellationToken;
+
+            public Awaiter(SynchronizationContext synchronizationContext, CancellationToken cancellationToken)
+            {
+                this.synchronizationContext = synchronizationContext;
+                this.cancellationToken = cancellationToken;
+            }
+
+            public bool IsCompleted => false;
+            public void GetResult() { cancellationToken.ThrowIfCancellationRequested(); }
+
+            public void OnCompleted(Action continuation)
+            {
+                synchronizationContext.Post(switchToCallback, continuation);
+            }
+
+            public void UnsafeOnCompleted(Action continuation)
+            {
+                synchronizationContext.Post(switchToCallback, continuation);
+            }
+
+            static void Callback(object state)
+            {
+                var continuation = (Action)state;
+                continuation();
+            }
+        }
+    }
+
+    public struct ReturnToSynchronizationContext
+    {
+        readonly SynchronizationContext syncContext;
+        readonly bool dontPostWhenSameContext;
+        readonly CancellationToken cancellationToken;
+
+        public ReturnToSynchronizationContext(SynchronizationContext syncContext, bool dontPostWhenSameContext, CancellationToken cancellationToken)
+        {
+            this.syncContext = syncContext;
+            this.dontPostWhenSameContext = dontPostWhenSameContext;
+            this.cancellationToken = cancellationToken;
+        }
+
+        public Awaiter DisposeAsync()
+        {
+            return new Awaiter(syncContext, dontPostWhenSameContext, cancellationToken);
+        }
+
+        public struct Awaiter : ICriticalNotifyCompletion
+        {
+            static readonly SendOrPostCallback switchToCallback = Callback;
+
+            readonly SynchronizationContext synchronizationContext;
+            readonly bool dontPostWhenSameContext;
+            readonly CancellationToken cancellationToken;
+
+            public Awaiter(SynchronizationContext synchronizationContext, bool dontPostWhenSameContext, CancellationToken cancellationToken)
+            {
+                this.synchronizationContext = synchronizationContext;
+                this.dontPostWhenSameContext = dontPostWhenSameContext;
+                this.cancellationToken = cancellationToken;
+            }
+
+            public Awaiter GetAwaiter() => this;
+
+            public bool IsCompleted
+            {
+                get
+                {
+                    if (!dontPostWhenSameContext) return false;
+
+                    var current = SynchronizationContext.Current;
+                    if (current == synchronizationContext)
+                    {
+                        return true;
+                    }
+                    else
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            public void GetResult() { cancellationToken.ThrowIfCancellationRequested(); }
+
+            public void OnCompleted(Action continuation)
+            {
+                synchronizationContext.Post(switchToCallback, continuation);
+            }
+
+            public void UnsafeOnCompleted(Action continuation)
+            {
+                synchronizationContext.Post(switchToCallback, continuation);
+            }
+
+            static void Callback(object state)
+            {
+                var continuation = (Action)state;
+                continuation();
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/UniTask.Threading.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/UniTask.Threading.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4132ea600454134439fa2c7eb931b5e6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/UniTask.WaitUntil.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/UniTask.WaitUntil.cs
@@ -1,0 +1,582 @@
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Cysharp.Threading.Tasks.Internal;
+
+namespace Cysharp.Threading.Tasks
+{
+    public partial struct UniTask
+    {
+        public static UniTask WaitUntil(Func<bool> predicate, PlayerLoopTiming timing = PlayerLoopTiming.Update, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return new UniTask(WaitUntilPromise.Create(predicate, timing, cancellationToken, out var token), token);
+        }
+
+        public static UniTask WaitWhile(Func<bool> predicate, PlayerLoopTiming timing = PlayerLoopTiming.Update, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return new UniTask(WaitWhilePromise.Create(predicate, timing, cancellationToken, out var token), token);
+        }
+
+        public static UniTask WaitUntilCanceled(CancellationToken cancellationToken, PlayerLoopTiming timing = PlayerLoopTiming.Update)
+        {
+            return new UniTask(WaitUntilCanceledPromise.Create(cancellationToken, timing, out var token), token);
+        }
+
+        public static UniTask<U> WaitUntilValueChanged<T, U>(T target, Func<T, U> monitorFunction, PlayerLoopTiming monitorTiming = PlayerLoopTiming.Update, IEqualityComparer<U> equalityComparer = null, CancellationToken cancellationToken = default(CancellationToken))
+          where T : class
+        {
+            var unityObject = target as UnityEngine.Object;
+            var isUnityObject = target is UnityEngine.Object; // don't use (unityObject == null)
+
+            return new UniTask<U>(isUnityObject
+                ? WaitUntilValueChangedUnityObjectPromise<T, U>.Create(target, monitorFunction, equalityComparer, monitorTiming, cancellationToken, out var token)
+                : WaitUntilValueChangedStandardObjectPromise<T, U>.Create(target, monitorFunction, equalityComparer, monitorTiming, cancellationToken, out token), token);
+        }
+
+        sealed class WaitUntilPromise : IUniTaskSource, IPlayerLoopItem, ITaskPoolNode<WaitUntilPromise>
+        {
+            static TaskPool<WaitUntilPromise> pool;
+            WaitUntilPromise nextNode;
+            public ref WaitUntilPromise NextNode => ref nextNode;
+
+            static WaitUntilPromise()
+            {
+                TaskPool.RegisterSizeGetter(typeof(WaitUntilPromise), () => pool.Size);
+            }
+
+            Func<bool> predicate;
+            CancellationToken cancellationToken;
+
+            UniTaskCompletionSourceCore<object> core;
+
+            WaitUntilPromise()
+            {
+            }
+
+            public static IUniTaskSource Create(Func<bool> predicate, PlayerLoopTiming timing, CancellationToken cancellationToken, out short token)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return AutoResetUniTaskCompletionSource.CreateFromCanceled(cancellationToken, out token);
+                }
+
+                if (!pool.TryPop(out var result))
+                {
+                    result = new WaitUntilPromise();
+                }
+
+                result.predicate = predicate;
+                result.cancellationToken = cancellationToken;
+
+                TaskTracker.TrackActiveTask(result, 3);
+
+                PlayerLoopHelper.AddAction(timing, result);
+
+                token = result.core.Version;
+                return result;
+            }
+
+            public void GetResult(short token)
+            {
+                try
+                {
+                    core.GetResult(token);
+                }
+                finally
+                {
+                    TryReturn();
+                }
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+
+            public bool MoveNext()
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    core.TrySetCanceled(cancellationToken);
+                    return false;
+                }
+
+                try
+                {
+                    if (!predicate())
+                    {
+                        return true;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    core.TrySetException(ex);
+                    return false;
+                }
+
+                core.TrySetResult(null);
+                return false;
+            }
+
+            bool TryReturn()
+            {
+                TaskTracker.RemoveTracking(this);
+                core.Reset();
+                predicate = default;
+                cancellationToken = default;
+                return pool.TryPush(this);
+            }
+        }
+
+        sealed class WaitWhilePromise : IUniTaskSource, IPlayerLoopItem, ITaskPoolNode<WaitWhilePromise>
+        {
+            static TaskPool<WaitWhilePromise> pool;
+            WaitWhilePromise nextNode;
+            public ref WaitWhilePromise NextNode => ref nextNode;
+
+            static WaitWhilePromise()
+            {
+                TaskPool.RegisterSizeGetter(typeof(WaitWhilePromise), () => pool.Size);
+            }
+
+            Func<bool> predicate;
+            CancellationToken cancellationToken;
+
+            UniTaskCompletionSourceCore<object> core;
+
+            WaitWhilePromise()
+            {
+            }
+
+            public static IUniTaskSource Create(Func<bool> predicate, PlayerLoopTiming timing, CancellationToken cancellationToken, out short token)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return AutoResetUniTaskCompletionSource.CreateFromCanceled(cancellationToken, out token);
+                }
+
+                if (!pool.TryPop(out var result))
+                {
+                    result = new WaitWhilePromise();
+                }
+
+                result.predicate = predicate;
+                result.cancellationToken = cancellationToken;
+
+                TaskTracker.TrackActiveTask(result, 3);
+
+                PlayerLoopHelper.AddAction(timing, result);
+
+                token = result.core.Version;
+                return result;
+            }
+
+            public void GetResult(short token)
+            {
+                try
+                {
+                    core.GetResult(token);
+                }
+                finally
+                {
+                    TryReturn();
+                }
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+
+            public bool MoveNext()
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    core.TrySetCanceled(cancellationToken);
+                    return false;
+                }
+
+                try
+                {
+                    if (predicate())
+                    {
+                        return true;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    core.TrySetException(ex);
+                    return false;
+                }
+
+                core.TrySetResult(null);
+                return false;
+            }
+
+            bool TryReturn()
+            {
+                TaskTracker.RemoveTracking(this);
+                core.Reset();
+                predicate = default;
+                cancellationToken = default;
+                return pool.TryPush(this);
+            }
+        }
+
+        sealed class WaitUntilCanceledPromise : IUniTaskSource, IPlayerLoopItem, ITaskPoolNode<WaitUntilCanceledPromise>
+        {
+            static TaskPool<WaitUntilCanceledPromise> pool;
+            WaitUntilCanceledPromise nextNode;
+            public ref WaitUntilCanceledPromise NextNode => ref nextNode;
+
+            static WaitUntilCanceledPromise()
+            {
+                TaskPool.RegisterSizeGetter(typeof(WaitUntilCanceledPromise), () => pool.Size);
+            }
+
+            CancellationToken cancellationToken;
+
+            UniTaskCompletionSourceCore<object> core;
+
+            WaitUntilCanceledPromise()
+            {
+            }
+
+            public static IUniTaskSource Create(CancellationToken cancellationToken, PlayerLoopTiming timing, out short token)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return AutoResetUniTaskCompletionSource.CreateFromCanceled(cancellationToken, out token);
+                }
+
+                if (!pool.TryPop(out var result))
+                {
+                    result = new WaitUntilCanceledPromise();
+                }
+
+                result.cancellationToken = cancellationToken;
+
+                TaskTracker.TrackActiveTask(result, 3);
+
+                PlayerLoopHelper.AddAction(timing, result);
+
+                token = result.core.Version;
+                return result;
+            }
+
+            public void GetResult(short token)
+            {
+                try
+                {
+                    core.GetResult(token);
+                }
+                finally
+                {
+                    TryReturn();
+                }
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+
+            public bool MoveNext()
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    core.TrySetResult(null);
+                    return false;
+                }
+
+                return true;
+            }
+
+            bool TryReturn()
+            {
+                TaskTracker.RemoveTracking(this);
+                core.Reset();
+                cancellationToken = default;
+                return pool.TryPush(this);
+            }
+        }
+
+        // where T : UnityEngine.Object, can not add constraint
+        sealed class WaitUntilValueChangedUnityObjectPromise<T, U> : IUniTaskSource<U>, IPlayerLoopItem, ITaskPoolNode<WaitUntilValueChangedUnityObjectPromise<T, U>>
+        {
+            static TaskPool<WaitUntilValueChangedUnityObjectPromise<T, U>> pool;
+            WaitUntilValueChangedUnityObjectPromise<T, U> nextNode;
+            public ref WaitUntilValueChangedUnityObjectPromise<T, U> NextNode => ref nextNode;
+
+            static WaitUntilValueChangedUnityObjectPromise()
+            {
+                TaskPool.RegisterSizeGetter(typeof(WaitUntilValueChangedUnityObjectPromise<T, U>), () => pool.Size);
+            }
+
+            T target;
+            UnityEngine.Object targetAsUnityObject;
+            U currentValue;
+            Func<T, U> monitorFunction;
+            IEqualityComparer<U> equalityComparer;
+            CancellationToken cancellationToken;
+
+            UniTaskCompletionSourceCore<U> core;
+
+            WaitUntilValueChangedUnityObjectPromise()
+            {
+            }
+
+            public static IUniTaskSource<U> Create(T target, Func<T, U> monitorFunction, IEqualityComparer<U> equalityComparer, PlayerLoopTiming timing, CancellationToken cancellationToken, out short token)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return AutoResetUniTaskCompletionSource<U>.CreateFromCanceled(cancellationToken, out token);
+                }
+
+                if (!pool.TryPop(out var result))
+                {
+                    result = new WaitUntilValueChangedUnityObjectPromise<T, U>();
+                }
+
+                result.target = target;
+                result.targetAsUnityObject = target as UnityEngine.Object;
+                result.monitorFunction = monitorFunction;
+                result.currentValue = monitorFunction(target);
+                result.equalityComparer = equalityComparer ?? UnityEqualityComparer.GetDefault<U>();
+                result.cancellationToken = cancellationToken;
+
+                TaskTracker.TrackActiveTask(result, 3);
+
+                PlayerLoopHelper.AddAction(timing, result);
+
+                token = result.core.Version;
+                return result;
+            }
+
+            public U GetResult(short token)
+            {
+                try
+                {
+                    return core.GetResult(token);
+                }
+                finally
+                {
+                    TryReturn();
+                }
+            }
+
+            void IUniTaskSource.GetResult(short token)
+            {
+                GetResult(token);
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+
+            public bool MoveNext()
+            {
+                if (cancellationToken.IsCancellationRequested || targetAsUnityObject == null) // destroyed = cancel.
+                {
+                    core.TrySetCanceled(cancellationToken);
+                    return false;
+                }
+
+                U nextValue = default(U);
+                try
+                {
+                    nextValue = monitorFunction(target);
+                    if (equalityComparer.Equals(currentValue, nextValue))
+                    {
+                        return true;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    core.TrySetException(ex);
+                    return false;
+                }
+
+                core.TrySetResult(nextValue);
+                return false;
+            }
+
+            bool TryReturn()
+            {
+                TaskTracker.RemoveTracking(this);
+                core.Reset();
+                target = default;
+                currentValue = default;
+                monitorFunction = default;
+                equalityComparer = default;
+                cancellationToken = default;
+                return pool.TryPush(this);
+            }
+        }
+
+        sealed class WaitUntilValueChangedStandardObjectPromise<T, U> : IUniTaskSource<U>, IPlayerLoopItem, ITaskPoolNode<WaitUntilValueChangedStandardObjectPromise<T, U>>
+            where T : class
+        {
+            static TaskPool<WaitUntilValueChangedStandardObjectPromise<T, U>> pool;
+            WaitUntilValueChangedStandardObjectPromise<T, U> nextNode;
+            public ref WaitUntilValueChangedStandardObjectPromise<T, U> NextNode => ref nextNode;
+
+            static WaitUntilValueChangedStandardObjectPromise()
+            {
+                TaskPool.RegisterSizeGetter(typeof(WaitUntilValueChangedStandardObjectPromise<T, U>), () => pool.Size);
+            }
+
+            WeakReference<T> target;
+            U currentValue;
+            Func<T, U> monitorFunction;
+            IEqualityComparer<U> equalityComparer;
+            CancellationToken cancellationToken;
+
+            UniTaskCompletionSourceCore<U> core;
+
+            WaitUntilValueChangedStandardObjectPromise()
+            {
+            }
+
+            public static IUniTaskSource<U> Create(T target, Func<T, U> monitorFunction, IEqualityComparer<U> equalityComparer, PlayerLoopTiming timing, CancellationToken cancellationToken, out short token)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return AutoResetUniTaskCompletionSource<U>.CreateFromCanceled(cancellationToken, out token);
+                }
+
+                if (!pool.TryPop(out var result))
+                {
+                    result = new WaitUntilValueChangedStandardObjectPromise<T, U>();
+                }
+
+                result.target = new WeakReference<T>(target, false); // wrap in WeakReference.
+                result.monitorFunction = monitorFunction;
+                result.currentValue = monitorFunction(target);
+                result.equalityComparer = equalityComparer ?? UnityEqualityComparer.GetDefault<U>();
+                result.cancellationToken = cancellationToken;
+
+                TaskTracker.TrackActiveTask(result, 3);
+
+                PlayerLoopHelper.AddAction(timing, result);
+
+                token = result.core.Version;
+                return result;
+            }
+
+            public U GetResult(short token)
+            {
+                try
+                {
+                    return core.GetResult(token);
+                }
+                finally
+                {
+                    TryReturn();
+                }
+            }
+
+            void IUniTaskSource.GetResult(short token)
+            {
+                GetResult(token);
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+
+            public bool MoveNext()
+            {
+                if (cancellationToken.IsCancellationRequested || !target.TryGetTarget(out var t)) // doesn't find = cancel.
+                {
+                    core.TrySetCanceled(cancellationToken);
+                    return false;
+                }
+
+                U nextValue = default(U);
+                try
+                {
+                    nextValue = monitorFunction(t);
+                    if (equalityComparer.Equals(currentValue, nextValue))
+                    {
+                        return true;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    core.TrySetException(ex);
+                    return false;
+                }
+
+                core.TrySetResult(nextValue);
+                return false;
+            }
+
+            bool TryReturn()
+            {
+                TaskTracker.RemoveTracking(this);
+                core.Reset();
+                target = default;
+                currentValue = default;
+                monitorFunction = default;
+                equalityComparer = default;
+                cancellationToken = default;
+                return pool.TryPush(this);
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/UniTask.WaitUntil.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/UniTask.WaitUntil.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 87c9c533491903a4288536b5ac173db8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/UniTask.WhenAll.Generated.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/UniTask.WhenAll.Generated.cs
@@ -1,0 +1,5011 @@
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using Cysharp.Threading.Tasks.Internal;
+
+namespace Cysharp.Threading.Tasks
+{
+    public partial struct UniTask
+    {
+        
+        public static UniTask<(T1, T2)> WhenAll<T1, T2>(UniTask<T1> task1, UniTask<T2> task2)
+        {
+            if (task1.Status.IsCompletedSuccessfully() && task2.Status.IsCompletedSuccessfully())
+            {
+                return new UniTask<(T1, T2)>((task1.GetAwaiter().GetResult(), task2.GetAwaiter().GetResult()));
+            }
+
+            return new UniTask<(T1, T2)>(new WhenAllPromise<T1, T2>(task1, task2), 0);
+        }
+
+        sealed class WhenAllPromise<T1, T2> : IUniTaskSource<(T1, T2)>
+        {
+            T1 t1 = default;
+            T2 t2 = default;
+            int completedCount;
+            UniTaskCompletionSourceCore<(T1, T2)> core;
+
+            public WhenAllPromise(UniTask<T1> task1, UniTask<T2> task2)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                this.completedCount = 0;
+                {
+                    var awaiter = task1.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT1(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2>, UniTask<T1>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT1(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task2.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT2(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2>, UniTask<T2>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT2(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+            }
+
+            static void TryInvokeContinuationT1(WhenAllPromise<T1, T2> self, in UniTask<T1>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t1 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 2)
+                {
+                    self.core.TrySetResult((self.t1, self.t2));
+                }
+            }
+
+            static void TryInvokeContinuationT2(WhenAllPromise<T1, T2> self, in UniTask<T2>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t2 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 2)
+                {
+                    self.core.TrySetResult((self.t1, self.t2));
+                }
+            }
+
+
+            public (T1, T2) GetResult(short token)
+            {
+                TaskTracker.RemoveTracking(this);
+                GC.SuppressFinalize(this);
+                return core.GetResult(token);
+            }
+
+            void IUniTaskSource.GetResult(short token)
+            {
+                GetResult(token);
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+        }
+        
+        public static UniTask<(T1, T2, T3)> WhenAll<T1, T2, T3>(UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3)
+        {
+            if (task1.Status.IsCompletedSuccessfully() && task2.Status.IsCompletedSuccessfully() && task3.Status.IsCompletedSuccessfully())
+            {
+                return new UniTask<(T1, T2, T3)>((task1.GetAwaiter().GetResult(), task2.GetAwaiter().GetResult(), task3.GetAwaiter().GetResult()));
+            }
+
+            return new UniTask<(T1, T2, T3)>(new WhenAllPromise<T1, T2, T3>(task1, task2, task3), 0);
+        }
+
+        sealed class WhenAllPromise<T1, T2, T3> : IUniTaskSource<(T1, T2, T3)>
+        {
+            T1 t1 = default;
+            T2 t2 = default;
+            T3 t3 = default;
+            int completedCount;
+            UniTaskCompletionSourceCore<(T1, T2, T3)> core;
+
+            public WhenAllPromise(UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                this.completedCount = 0;
+                {
+                    var awaiter = task1.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT1(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3>, UniTask<T1>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT1(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task2.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT2(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3>, UniTask<T2>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT2(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task3.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT3(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3>, UniTask<T3>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT3(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+            }
+
+            static void TryInvokeContinuationT1(WhenAllPromise<T1, T2, T3> self, in UniTask<T1>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t1 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 3)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3));
+                }
+            }
+
+            static void TryInvokeContinuationT2(WhenAllPromise<T1, T2, T3> self, in UniTask<T2>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t2 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 3)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3));
+                }
+            }
+
+            static void TryInvokeContinuationT3(WhenAllPromise<T1, T2, T3> self, in UniTask<T3>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t3 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 3)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3));
+                }
+            }
+
+
+            public (T1, T2, T3) GetResult(short token)
+            {
+                TaskTracker.RemoveTracking(this);
+                GC.SuppressFinalize(this);
+                return core.GetResult(token);
+            }
+
+            void IUniTaskSource.GetResult(short token)
+            {
+                GetResult(token);
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+        }
+        
+        public static UniTask<(T1, T2, T3, T4)> WhenAll<T1, T2, T3, T4>(UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4)
+        {
+            if (task1.Status.IsCompletedSuccessfully() && task2.Status.IsCompletedSuccessfully() && task3.Status.IsCompletedSuccessfully() && task4.Status.IsCompletedSuccessfully())
+            {
+                return new UniTask<(T1, T2, T3, T4)>((task1.GetAwaiter().GetResult(), task2.GetAwaiter().GetResult(), task3.GetAwaiter().GetResult(), task4.GetAwaiter().GetResult()));
+            }
+
+            return new UniTask<(T1, T2, T3, T4)>(new WhenAllPromise<T1, T2, T3, T4>(task1, task2, task3, task4), 0);
+        }
+
+        sealed class WhenAllPromise<T1, T2, T3, T4> : IUniTaskSource<(T1, T2, T3, T4)>
+        {
+            T1 t1 = default;
+            T2 t2 = default;
+            T3 t3 = default;
+            T4 t4 = default;
+            int completedCount;
+            UniTaskCompletionSourceCore<(T1, T2, T3, T4)> core;
+
+            public WhenAllPromise(UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                this.completedCount = 0;
+                {
+                    var awaiter = task1.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT1(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4>, UniTask<T1>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT1(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task2.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT2(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4>, UniTask<T2>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT2(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task3.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT3(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4>, UniTask<T3>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT3(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task4.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT4(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4>, UniTask<T4>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT4(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+            }
+
+            static void TryInvokeContinuationT1(WhenAllPromise<T1, T2, T3, T4> self, in UniTask<T1>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t1 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 4)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4));
+                }
+            }
+
+            static void TryInvokeContinuationT2(WhenAllPromise<T1, T2, T3, T4> self, in UniTask<T2>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t2 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 4)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4));
+                }
+            }
+
+            static void TryInvokeContinuationT3(WhenAllPromise<T1, T2, T3, T4> self, in UniTask<T3>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t3 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 4)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4));
+                }
+            }
+
+            static void TryInvokeContinuationT4(WhenAllPromise<T1, T2, T3, T4> self, in UniTask<T4>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t4 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 4)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4));
+                }
+            }
+
+
+            public (T1, T2, T3, T4) GetResult(short token)
+            {
+                TaskTracker.RemoveTracking(this);
+                GC.SuppressFinalize(this);
+                return core.GetResult(token);
+            }
+
+            void IUniTaskSource.GetResult(short token)
+            {
+                GetResult(token);
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+        }
+        
+        public static UniTask<(T1, T2, T3, T4, T5)> WhenAll<T1, T2, T3, T4, T5>(UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4, UniTask<T5> task5)
+        {
+            if (task1.Status.IsCompletedSuccessfully() && task2.Status.IsCompletedSuccessfully() && task3.Status.IsCompletedSuccessfully() && task4.Status.IsCompletedSuccessfully() && task5.Status.IsCompletedSuccessfully())
+            {
+                return new UniTask<(T1, T2, T3, T4, T5)>((task1.GetAwaiter().GetResult(), task2.GetAwaiter().GetResult(), task3.GetAwaiter().GetResult(), task4.GetAwaiter().GetResult(), task5.GetAwaiter().GetResult()));
+            }
+
+            return new UniTask<(T1, T2, T3, T4, T5)>(new WhenAllPromise<T1, T2, T3, T4, T5>(task1, task2, task3, task4, task5), 0);
+        }
+
+        sealed class WhenAllPromise<T1, T2, T3, T4, T5> : IUniTaskSource<(T1, T2, T3, T4, T5)>
+        {
+            T1 t1 = default;
+            T2 t2 = default;
+            T3 t3 = default;
+            T4 t4 = default;
+            T5 t5 = default;
+            int completedCount;
+            UniTaskCompletionSourceCore<(T1, T2, T3, T4, T5)> core;
+
+            public WhenAllPromise(UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4, UniTask<T5> task5)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                this.completedCount = 0;
+                {
+                    var awaiter = task1.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT1(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5>, UniTask<T1>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT1(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task2.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT2(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5>, UniTask<T2>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT2(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task3.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT3(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5>, UniTask<T3>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT3(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task4.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT4(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5>, UniTask<T4>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT4(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task5.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT5(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5>, UniTask<T5>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT5(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+            }
+
+            static void TryInvokeContinuationT1(WhenAllPromise<T1, T2, T3, T4, T5> self, in UniTask<T1>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t1 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 5)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5));
+                }
+            }
+
+            static void TryInvokeContinuationT2(WhenAllPromise<T1, T2, T3, T4, T5> self, in UniTask<T2>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t2 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 5)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5));
+                }
+            }
+
+            static void TryInvokeContinuationT3(WhenAllPromise<T1, T2, T3, T4, T5> self, in UniTask<T3>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t3 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 5)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5));
+                }
+            }
+
+            static void TryInvokeContinuationT4(WhenAllPromise<T1, T2, T3, T4, T5> self, in UniTask<T4>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t4 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 5)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5));
+                }
+            }
+
+            static void TryInvokeContinuationT5(WhenAllPromise<T1, T2, T3, T4, T5> self, in UniTask<T5>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t5 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 5)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5));
+                }
+            }
+
+
+            public (T1, T2, T3, T4, T5) GetResult(short token)
+            {
+                TaskTracker.RemoveTracking(this);
+                GC.SuppressFinalize(this);
+                return core.GetResult(token);
+            }
+
+            void IUniTaskSource.GetResult(short token)
+            {
+                GetResult(token);
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+        }
+        
+        public static UniTask<(T1, T2, T3, T4, T5, T6)> WhenAll<T1, T2, T3, T4, T5, T6>(UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4, UniTask<T5> task5, UniTask<T6> task6)
+        {
+            if (task1.Status.IsCompletedSuccessfully() && task2.Status.IsCompletedSuccessfully() && task3.Status.IsCompletedSuccessfully() && task4.Status.IsCompletedSuccessfully() && task5.Status.IsCompletedSuccessfully() && task6.Status.IsCompletedSuccessfully())
+            {
+                return new UniTask<(T1, T2, T3, T4, T5, T6)>((task1.GetAwaiter().GetResult(), task2.GetAwaiter().GetResult(), task3.GetAwaiter().GetResult(), task4.GetAwaiter().GetResult(), task5.GetAwaiter().GetResult(), task6.GetAwaiter().GetResult()));
+            }
+
+            return new UniTask<(T1, T2, T3, T4, T5, T6)>(new WhenAllPromise<T1, T2, T3, T4, T5, T6>(task1, task2, task3, task4, task5, task6), 0);
+        }
+
+        sealed class WhenAllPromise<T1, T2, T3, T4, T5, T6> : IUniTaskSource<(T1, T2, T3, T4, T5, T6)>
+        {
+            T1 t1 = default;
+            T2 t2 = default;
+            T3 t3 = default;
+            T4 t4 = default;
+            T5 t5 = default;
+            T6 t6 = default;
+            int completedCount;
+            UniTaskCompletionSourceCore<(T1, T2, T3, T4, T5, T6)> core;
+
+            public WhenAllPromise(UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4, UniTask<T5> task5, UniTask<T6> task6)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                this.completedCount = 0;
+                {
+                    var awaiter = task1.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT1(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6>, UniTask<T1>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT1(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task2.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT2(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6>, UniTask<T2>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT2(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task3.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT3(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6>, UniTask<T3>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT3(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task4.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT4(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6>, UniTask<T4>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT4(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task5.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT5(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6>, UniTask<T5>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT5(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task6.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT6(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6>, UniTask<T6>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT6(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+            }
+
+            static void TryInvokeContinuationT1(WhenAllPromise<T1, T2, T3, T4, T5, T6> self, in UniTask<T1>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t1 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 6)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6));
+                }
+            }
+
+            static void TryInvokeContinuationT2(WhenAllPromise<T1, T2, T3, T4, T5, T6> self, in UniTask<T2>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t2 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 6)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6));
+                }
+            }
+
+            static void TryInvokeContinuationT3(WhenAllPromise<T1, T2, T3, T4, T5, T6> self, in UniTask<T3>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t3 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 6)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6));
+                }
+            }
+
+            static void TryInvokeContinuationT4(WhenAllPromise<T1, T2, T3, T4, T5, T6> self, in UniTask<T4>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t4 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 6)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6));
+                }
+            }
+
+            static void TryInvokeContinuationT5(WhenAllPromise<T1, T2, T3, T4, T5, T6> self, in UniTask<T5>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t5 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 6)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6));
+                }
+            }
+
+            static void TryInvokeContinuationT6(WhenAllPromise<T1, T2, T3, T4, T5, T6> self, in UniTask<T6>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t6 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 6)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6));
+                }
+            }
+
+
+            public (T1, T2, T3, T4, T5, T6) GetResult(short token)
+            {
+                TaskTracker.RemoveTracking(this);
+                GC.SuppressFinalize(this);
+                return core.GetResult(token);
+            }
+
+            void IUniTaskSource.GetResult(short token)
+            {
+                GetResult(token);
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+        }
+        
+        public static UniTask<(T1, T2, T3, T4, T5, T6, T7)> WhenAll<T1, T2, T3, T4, T5, T6, T7>(UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4, UniTask<T5> task5, UniTask<T6> task6, UniTask<T7> task7)
+        {
+            if (task1.Status.IsCompletedSuccessfully() && task2.Status.IsCompletedSuccessfully() && task3.Status.IsCompletedSuccessfully() && task4.Status.IsCompletedSuccessfully() && task5.Status.IsCompletedSuccessfully() && task6.Status.IsCompletedSuccessfully() && task7.Status.IsCompletedSuccessfully())
+            {
+                return new UniTask<(T1, T2, T3, T4, T5, T6, T7)>((task1.GetAwaiter().GetResult(), task2.GetAwaiter().GetResult(), task3.GetAwaiter().GetResult(), task4.GetAwaiter().GetResult(), task5.GetAwaiter().GetResult(), task6.GetAwaiter().GetResult(), task7.GetAwaiter().GetResult()));
+            }
+
+            return new UniTask<(T1, T2, T3, T4, T5, T6, T7)>(new WhenAllPromise<T1, T2, T3, T4, T5, T6, T7>(task1, task2, task3, task4, task5, task6, task7), 0);
+        }
+
+        sealed class WhenAllPromise<T1, T2, T3, T4, T5, T6, T7> : IUniTaskSource<(T1, T2, T3, T4, T5, T6, T7)>
+        {
+            T1 t1 = default;
+            T2 t2 = default;
+            T3 t3 = default;
+            T4 t4 = default;
+            T5 t5 = default;
+            T6 t6 = default;
+            T7 t7 = default;
+            int completedCount;
+            UniTaskCompletionSourceCore<(T1, T2, T3, T4, T5, T6, T7)> core;
+
+            public WhenAllPromise(UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4, UniTask<T5> task5, UniTask<T6> task6, UniTask<T7> task7)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                this.completedCount = 0;
+                {
+                    var awaiter = task1.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT1(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7>, UniTask<T1>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT1(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task2.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT2(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7>, UniTask<T2>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT2(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task3.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT3(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7>, UniTask<T3>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT3(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task4.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT4(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7>, UniTask<T4>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT4(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task5.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT5(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7>, UniTask<T5>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT5(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task6.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT6(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7>, UniTask<T6>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT6(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task7.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT7(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7>, UniTask<T7>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT7(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+            }
+
+            static void TryInvokeContinuationT1(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7> self, in UniTask<T1>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t1 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 7)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7));
+                }
+            }
+
+            static void TryInvokeContinuationT2(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7> self, in UniTask<T2>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t2 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 7)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7));
+                }
+            }
+
+            static void TryInvokeContinuationT3(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7> self, in UniTask<T3>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t3 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 7)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7));
+                }
+            }
+
+            static void TryInvokeContinuationT4(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7> self, in UniTask<T4>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t4 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 7)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7));
+                }
+            }
+
+            static void TryInvokeContinuationT5(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7> self, in UniTask<T5>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t5 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 7)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7));
+                }
+            }
+
+            static void TryInvokeContinuationT6(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7> self, in UniTask<T6>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t6 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 7)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7));
+                }
+            }
+
+            static void TryInvokeContinuationT7(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7> self, in UniTask<T7>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t7 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 7)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7));
+                }
+            }
+
+
+            public (T1, T2, T3, T4, T5, T6, T7) GetResult(short token)
+            {
+                TaskTracker.RemoveTracking(this);
+                GC.SuppressFinalize(this);
+                return core.GetResult(token);
+            }
+
+            void IUniTaskSource.GetResult(short token)
+            {
+                GetResult(token);
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+        }
+        
+        public static UniTask<(T1, T2, T3, T4, T5, T6, T7, T8)> WhenAll<T1, T2, T3, T4, T5, T6, T7, T8>(UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4, UniTask<T5> task5, UniTask<T6> task6, UniTask<T7> task7, UniTask<T8> task8)
+        {
+            if (task1.Status.IsCompletedSuccessfully() && task2.Status.IsCompletedSuccessfully() && task3.Status.IsCompletedSuccessfully() && task4.Status.IsCompletedSuccessfully() && task5.Status.IsCompletedSuccessfully() && task6.Status.IsCompletedSuccessfully() && task7.Status.IsCompletedSuccessfully() && task8.Status.IsCompletedSuccessfully())
+            {
+                return new UniTask<(T1, T2, T3, T4, T5, T6, T7, T8)>((task1.GetAwaiter().GetResult(), task2.GetAwaiter().GetResult(), task3.GetAwaiter().GetResult(), task4.GetAwaiter().GetResult(), task5.GetAwaiter().GetResult(), task6.GetAwaiter().GetResult(), task7.GetAwaiter().GetResult(), task8.GetAwaiter().GetResult()));
+            }
+
+            return new UniTask<(T1, T2, T3, T4, T5, T6, T7, T8)>(new WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8>(task1, task2, task3, task4, task5, task6, task7, task8), 0);
+        }
+
+        sealed class WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8> : IUniTaskSource<(T1, T2, T3, T4, T5, T6, T7, T8)>
+        {
+            T1 t1 = default;
+            T2 t2 = default;
+            T3 t3 = default;
+            T4 t4 = default;
+            T5 t5 = default;
+            T6 t6 = default;
+            T7 t7 = default;
+            T8 t8 = default;
+            int completedCount;
+            UniTaskCompletionSourceCore<(T1, T2, T3, T4, T5, T6, T7, T8)> core;
+
+            public WhenAllPromise(UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4, UniTask<T5> task5, UniTask<T6> task6, UniTask<T7> task7, UniTask<T8> task8)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                this.completedCount = 0;
+                {
+                    var awaiter = task1.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT1(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8>, UniTask<T1>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT1(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task2.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT2(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8>, UniTask<T2>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT2(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task3.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT3(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8>, UniTask<T3>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT3(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task4.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT4(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8>, UniTask<T4>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT4(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task5.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT5(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8>, UniTask<T5>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT5(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task6.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT6(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8>, UniTask<T6>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT6(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task7.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT7(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8>, UniTask<T7>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT7(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task8.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT8(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8>, UniTask<T8>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT8(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+            }
+
+            static void TryInvokeContinuationT1(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8> self, in UniTask<T1>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t1 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 8)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8));
+                }
+            }
+
+            static void TryInvokeContinuationT2(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8> self, in UniTask<T2>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t2 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 8)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8));
+                }
+            }
+
+            static void TryInvokeContinuationT3(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8> self, in UniTask<T3>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t3 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 8)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8));
+                }
+            }
+
+            static void TryInvokeContinuationT4(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8> self, in UniTask<T4>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t4 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 8)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8));
+                }
+            }
+
+            static void TryInvokeContinuationT5(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8> self, in UniTask<T5>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t5 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 8)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8));
+                }
+            }
+
+            static void TryInvokeContinuationT6(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8> self, in UniTask<T6>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t6 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 8)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8));
+                }
+            }
+
+            static void TryInvokeContinuationT7(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8> self, in UniTask<T7>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t7 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 8)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8));
+                }
+            }
+
+            static void TryInvokeContinuationT8(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8> self, in UniTask<T8>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t8 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 8)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8));
+                }
+            }
+
+
+            public (T1, T2, T3, T4, T5, T6, T7, T8) GetResult(short token)
+            {
+                TaskTracker.RemoveTracking(this);
+                GC.SuppressFinalize(this);
+                return core.GetResult(token);
+            }
+
+            void IUniTaskSource.GetResult(short token)
+            {
+                GetResult(token);
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+        }
+        
+        public static UniTask<(T1, T2, T3, T4, T5, T6, T7, T8, T9)> WhenAll<T1, T2, T3, T4, T5, T6, T7, T8, T9>(UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4, UniTask<T5> task5, UniTask<T6> task6, UniTask<T7> task7, UniTask<T8> task8, UniTask<T9> task9)
+        {
+            if (task1.Status.IsCompletedSuccessfully() && task2.Status.IsCompletedSuccessfully() && task3.Status.IsCompletedSuccessfully() && task4.Status.IsCompletedSuccessfully() && task5.Status.IsCompletedSuccessfully() && task6.Status.IsCompletedSuccessfully() && task7.Status.IsCompletedSuccessfully() && task8.Status.IsCompletedSuccessfully() && task9.Status.IsCompletedSuccessfully())
+            {
+                return new UniTask<(T1, T2, T3, T4, T5, T6, T7, T8, T9)>((task1.GetAwaiter().GetResult(), task2.GetAwaiter().GetResult(), task3.GetAwaiter().GetResult(), task4.GetAwaiter().GetResult(), task5.GetAwaiter().GetResult(), task6.GetAwaiter().GetResult(), task7.GetAwaiter().GetResult(), task8.GetAwaiter().GetResult(), task9.GetAwaiter().GetResult()));
+            }
+
+            return new UniTask<(T1, T2, T3, T4, T5, T6, T7, T8, T9)>(new WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9>(task1, task2, task3, task4, task5, task6, task7, task8, task9), 0);
+        }
+
+        sealed class WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9> : IUniTaskSource<(T1, T2, T3, T4, T5, T6, T7, T8, T9)>
+        {
+            T1 t1 = default;
+            T2 t2 = default;
+            T3 t3 = default;
+            T4 t4 = default;
+            T5 t5 = default;
+            T6 t6 = default;
+            T7 t7 = default;
+            T8 t8 = default;
+            T9 t9 = default;
+            int completedCount;
+            UniTaskCompletionSourceCore<(T1, T2, T3, T4, T5, T6, T7, T8, T9)> core;
+
+            public WhenAllPromise(UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4, UniTask<T5> task5, UniTask<T6> task6, UniTask<T7> task7, UniTask<T8> task8, UniTask<T9> task9)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                this.completedCount = 0;
+                {
+                    var awaiter = task1.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT1(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9>, UniTask<T1>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT1(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task2.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT2(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9>, UniTask<T2>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT2(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task3.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT3(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9>, UniTask<T3>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT3(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task4.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT4(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9>, UniTask<T4>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT4(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task5.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT5(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9>, UniTask<T5>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT5(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task6.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT6(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9>, UniTask<T6>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT6(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task7.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT7(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9>, UniTask<T7>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT7(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task8.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT8(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9>, UniTask<T8>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT8(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task9.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT9(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9>, UniTask<T9>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT9(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+            }
+
+            static void TryInvokeContinuationT1(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9> self, in UniTask<T1>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t1 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 9)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9));
+                }
+            }
+
+            static void TryInvokeContinuationT2(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9> self, in UniTask<T2>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t2 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 9)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9));
+                }
+            }
+
+            static void TryInvokeContinuationT3(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9> self, in UniTask<T3>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t3 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 9)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9));
+                }
+            }
+
+            static void TryInvokeContinuationT4(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9> self, in UniTask<T4>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t4 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 9)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9));
+                }
+            }
+
+            static void TryInvokeContinuationT5(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9> self, in UniTask<T5>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t5 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 9)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9));
+                }
+            }
+
+            static void TryInvokeContinuationT6(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9> self, in UniTask<T6>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t6 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 9)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9));
+                }
+            }
+
+            static void TryInvokeContinuationT7(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9> self, in UniTask<T7>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t7 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 9)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9));
+                }
+            }
+
+            static void TryInvokeContinuationT8(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9> self, in UniTask<T8>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t8 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 9)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9));
+                }
+            }
+
+            static void TryInvokeContinuationT9(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9> self, in UniTask<T9>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t9 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 9)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9));
+                }
+            }
+
+
+            public (T1, T2, T3, T4, T5, T6, T7, T8, T9) GetResult(short token)
+            {
+                TaskTracker.RemoveTracking(this);
+                GC.SuppressFinalize(this);
+                return core.GetResult(token);
+            }
+
+            void IUniTaskSource.GetResult(short token)
+            {
+                GetResult(token);
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+        }
+        
+        public static UniTask<(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)> WhenAll<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4, UniTask<T5> task5, UniTask<T6> task6, UniTask<T7> task7, UniTask<T8> task8, UniTask<T9> task9, UniTask<T10> task10)
+        {
+            if (task1.Status.IsCompletedSuccessfully() && task2.Status.IsCompletedSuccessfully() && task3.Status.IsCompletedSuccessfully() && task4.Status.IsCompletedSuccessfully() && task5.Status.IsCompletedSuccessfully() && task6.Status.IsCompletedSuccessfully() && task7.Status.IsCompletedSuccessfully() && task8.Status.IsCompletedSuccessfully() && task9.Status.IsCompletedSuccessfully() && task10.Status.IsCompletedSuccessfully())
+            {
+                return new UniTask<(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)>((task1.GetAwaiter().GetResult(), task2.GetAwaiter().GetResult(), task3.GetAwaiter().GetResult(), task4.GetAwaiter().GetResult(), task5.GetAwaiter().GetResult(), task6.GetAwaiter().GetResult(), task7.GetAwaiter().GetResult(), task8.GetAwaiter().GetResult(), task9.GetAwaiter().GetResult(), task10.GetAwaiter().GetResult()));
+            }
+
+            return new UniTask<(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)>(new WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(task1, task2, task3, task4, task5, task6, task7, task8, task9, task10), 0);
+        }
+
+        sealed class WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> : IUniTaskSource<(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)>
+        {
+            T1 t1 = default;
+            T2 t2 = default;
+            T3 t3 = default;
+            T4 t4 = default;
+            T5 t5 = default;
+            T6 t6 = default;
+            T7 t7 = default;
+            T8 t8 = default;
+            T9 t9 = default;
+            T10 t10 = default;
+            int completedCount;
+            UniTaskCompletionSourceCore<(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)> core;
+
+            public WhenAllPromise(UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4, UniTask<T5> task5, UniTask<T6> task6, UniTask<T7> task7, UniTask<T8> task8, UniTask<T9> task9, UniTask<T10> task10)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                this.completedCount = 0;
+                {
+                    var awaiter = task1.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT1(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>, UniTask<T1>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT1(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task2.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT2(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>, UniTask<T2>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT2(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task3.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT3(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>, UniTask<T3>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT3(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task4.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT4(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>, UniTask<T4>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT4(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task5.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT5(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>, UniTask<T5>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT5(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task6.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT6(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>, UniTask<T6>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT6(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task7.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT7(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>, UniTask<T7>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT7(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task8.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT8(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>, UniTask<T8>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT8(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task9.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT9(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>, UniTask<T9>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT9(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task10.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT10(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>, UniTask<T10>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT10(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+            }
+
+            static void TryInvokeContinuationT1(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> self, in UniTask<T1>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t1 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 10)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10));
+                }
+            }
+
+            static void TryInvokeContinuationT2(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> self, in UniTask<T2>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t2 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 10)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10));
+                }
+            }
+
+            static void TryInvokeContinuationT3(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> self, in UniTask<T3>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t3 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 10)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10));
+                }
+            }
+
+            static void TryInvokeContinuationT4(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> self, in UniTask<T4>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t4 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 10)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10));
+                }
+            }
+
+            static void TryInvokeContinuationT5(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> self, in UniTask<T5>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t5 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 10)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10));
+                }
+            }
+
+            static void TryInvokeContinuationT6(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> self, in UniTask<T6>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t6 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 10)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10));
+                }
+            }
+
+            static void TryInvokeContinuationT7(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> self, in UniTask<T7>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t7 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 10)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10));
+                }
+            }
+
+            static void TryInvokeContinuationT8(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> self, in UniTask<T8>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t8 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 10)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10));
+                }
+            }
+
+            static void TryInvokeContinuationT9(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> self, in UniTask<T9>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t9 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 10)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10));
+                }
+            }
+
+            static void TryInvokeContinuationT10(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> self, in UniTask<T10>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t10 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 10)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10));
+                }
+            }
+
+
+            public (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10) GetResult(short token)
+            {
+                TaskTracker.RemoveTracking(this);
+                GC.SuppressFinalize(this);
+                return core.GetResult(token);
+            }
+
+            void IUniTaskSource.GetResult(short token)
+            {
+                GetResult(token);
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+        }
+        
+        public static UniTask<(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)> WhenAll<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4, UniTask<T5> task5, UniTask<T6> task6, UniTask<T7> task7, UniTask<T8> task8, UniTask<T9> task9, UniTask<T10> task10, UniTask<T11> task11)
+        {
+            if (task1.Status.IsCompletedSuccessfully() && task2.Status.IsCompletedSuccessfully() && task3.Status.IsCompletedSuccessfully() && task4.Status.IsCompletedSuccessfully() && task5.Status.IsCompletedSuccessfully() && task6.Status.IsCompletedSuccessfully() && task7.Status.IsCompletedSuccessfully() && task8.Status.IsCompletedSuccessfully() && task9.Status.IsCompletedSuccessfully() && task10.Status.IsCompletedSuccessfully() && task11.Status.IsCompletedSuccessfully())
+            {
+                return new UniTask<(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)>((task1.GetAwaiter().GetResult(), task2.GetAwaiter().GetResult(), task3.GetAwaiter().GetResult(), task4.GetAwaiter().GetResult(), task5.GetAwaiter().GetResult(), task6.GetAwaiter().GetResult(), task7.GetAwaiter().GetResult(), task8.GetAwaiter().GetResult(), task9.GetAwaiter().GetResult(), task10.GetAwaiter().GetResult(), task11.GetAwaiter().GetResult()));
+            }
+
+            return new UniTask<(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)>(new WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(task1, task2, task3, task4, task5, task6, task7, task8, task9, task10, task11), 0);
+        }
+
+        sealed class WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> : IUniTaskSource<(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)>
+        {
+            T1 t1 = default;
+            T2 t2 = default;
+            T3 t3 = default;
+            T4 t4 = default;
+            T5 t5 = default;
+            T6 t6 = default;
+            T7 t7 = default;
+            T8 t8 = default;
+            T9 t9 = default;
+            T10 t10 = default;
+            T11 t11 = default;
+            int completedCount;
+            UniTaskCompletionSourceCore<(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)> core;
+
+            public WhenAllPromise(UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4, UniTask<T5> task5, UniTask<T6> task6, UniTask<T7> task7, UniTask<T8> task8, UniTask<T9> task9, UniTask<T10> task10, UniTask<T11> task11)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                this.completedCount = 0;
+                {
+                    var awaiter = task1.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT1(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>, UniTask<T1>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT1(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task2.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT2(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>, UniTask<T2>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT2(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task3.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT3(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>, UniTask<T3>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT3(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task4.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT4(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>, UniTask<T4>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT4(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task5.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT5(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>, UniTask<T5>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT5(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task6.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT6(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>, UniTask<T6>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT6(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task7.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT7(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>, UniTask<T7>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT7(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task8.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT8(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>, UniTask<T8>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT8(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task9.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT9(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>, UniTask<T9>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT9(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task10.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT10(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>, UniTask<T10>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT10(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task11.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT11(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>, UniTask<T11>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT11(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+            }
+
+            static void TryInvokeContinuationT1(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> self, in UniTask<T1>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t1 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 11)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11));
+                }
+            }
+
+            static void TryInvokeContinuationT2(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> self, in UniTask<T2>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t2 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 11)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11));
+                }
+            }
+
+            static void TryInvokeContinuationT3(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> self, in UniTask<T3>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t3 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 11)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11));
+                }
+            }
+
+            static void TryInvokeContinuationT4(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> self, in UniTask<T4>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t4 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 11)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11));
+                }
+            }
+
+            static void TryInvokeContinuationT5(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> self, in UniTask<T5>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t5 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 11)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11));
+                }
+            }
+
+            static void TryInvokeContinuationT6(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> self, in UniTask<T6>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t6 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 11)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11));
+                }
+            }
+
+            static void TryInvokeContinuationT7(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> self, in UniTask<T7>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t7 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 11)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11));
+                }
+            }
+
+            static void TryInvokeContinuationT8(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> self, in UniTask<T8>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t8 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 11)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11));
+                }
+            }
+
+            static void TryInvokeContinuationT9(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> self, in UniTask<T9>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t9 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 11)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11));
+                }
+            }
+
+            static void TryInvokeContinuationT10(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> self, in UniTask<T10>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t10 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 11)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11));
+                }
+            }
+
+            static void TryInvokeContinuationT11(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> self, in UniTask<T11>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t11 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 11)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11));
+                }
+            }
+
+
+            public (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11) GetResult(short token)
+            {
+                TaskTracker.RemoveTracking(this);
+                GC.SuppressFinalize(this);
+                return core.GetResult(token);
+            }
+
+            void IUniTaskSource.GetResult(short token)
+            {
+                GetResult(token);
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+        }
+        
+        public static UniTask<(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)> WhenAll<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4, UniTask<T5> task5, UniTask<T6> task6, UniTask<T7> task7, UniTask<T8> task8, UniTask<T9> task9, UniTask<T10> task10, UniTask<T11> task11, UniTask<T12> task12)
+        {
+            if (task1.Status.IsCompletedSuccessfully() && task2.Status.IsCompletedSuccessfully() && task3.Status.IsCompletedSuccessfully() && task4.Status.IsCompletedSuccessfully() && task5.Status.IsCompletedSuccessfully() && task6.Status.IsCompletedSuccessfully() && task7.Status.IsCompletedSuccessfully() && task8.Status.IsCompletedSuccessfully() && task9.Status.IsCompletedSuccessfully() && task10.Status.IsCompletedSuccessfully() && task11.Status.IsCompletedSuccessfully() && task12.Status.IsCompletedSuccessfully())
+            {
+                return new UniTask<(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)>((task1.GetAwaiter().GetResult(), task2.GetAwaiter().GetResult(), task3.GetAwaiter().GetResult(), task4.GetAwaiter().GetResult(), task5.GetAwaiter().GetResult(), task6.GetAwaiter().GetResult(), task7.GetAwaiter().GetResult(), task8.GetAwaiter().GetResult(), task9.GetAwaiter().GetResult(), task10.GetAwaiter().GetResult(), task11.GetAwaiter().GetResult(), task12.GetAwaiter().GetResult()));
+            }
+
+            return new UniTask<(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)>(new WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(task1, task2, task3, task4, task5, task6, task7, task8, task9, task10, task11, task12), 0);
+        }
+
+        sealed class WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> : IUniTaskSource<(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)>
+        {
+            T1 t1 = default;
+            T2 t2 = default;
+            T3 t3 = default;
+            T4 t4 = default;
+            T5 t5 = default;
+            T6 t6 = default;
+            T7 t7 = default;
+            T8 t8 = default;
+            T9 t9 = default;
+            T10 t10 = default;
+            T11 t11 = default;
+            T12 t12 = default;
+            int completedCount;
+            UniTaskCompletionSourceCore<(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)> core;
+
+            public WhenAllPromise(UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4, UniTask<T5> task5, UniTask<T6> task6, UniTask<T7> task7, UniTask<T8> task8, UniTask<T9> task9, UniTask<T10> task10, UniTask<T11> task11, UniTask<T12> task12)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                this.completedCount = 0;
+                {
+                    var awaiter = task1.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT1(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>, UniTask<T1>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT1(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task2.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT2(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>, UniTask<T2>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT2(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task3.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT3(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>, UniTask<T3>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT3(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task4.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT4(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>, UniTask<T4>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT4(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task5.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT5(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>, UniTask<T5>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT5(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task6.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT6(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>, UniTask<T6>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT6(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task7.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT7(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>, UniTask<T7>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT7(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task8.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT8(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>, UniTask<T8>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT8(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task9.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT9(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>, UniTask<T9>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT9(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task10.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT10(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>, UniTask<T10>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT10(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task11.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT11(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>, UniTask<T11>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT11(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task12.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT12(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>, UniTask<T12>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT12(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+            }
+
+            static void TryInvokeContinuationT1(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> self, in UniTask<T1>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t1 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 12)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11, self.t12));
+                }
+            }
+
+            static void TryInvokeContinuationT2(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> self, in UniTask<T2>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t2 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 12)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11, self.t12));
+                }
+            }
+
+            static void TryInvokeContinuationT3(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> self, in UniTask<T3>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t3 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 12)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11, self.t12));
+                }
+            }
+
+            static void TryInvokeContinuationT4(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> self, in UniTask<T4>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t4 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 12)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11, self.t12));
+                }
+            }
+
+            static void TryInvokeContinuationT5(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> self, in UniTask<T5>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t5 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 12)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11, self.t12));
+                }
+            }
+
+            static void TryInvokeContinuationT6(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> self, in UniTask<T6>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t6 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 12)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11, self.t12));
+                }
+            }
+
+            static void TryInvokeContinuationT7(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> self, in UniTask<T7>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t7 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 12)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11, self.t12));
+                }
+            }
+
+            static void TryInvokeContinuationT8(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> self, in UniTask<T8>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t8 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 12)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11, self.t12));
+                }
+            }
+
+            static void TryInvokeContinuationT9(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> self, in UniTask<T9>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t9 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 12)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11, self.t12));
+                }
+            }
+
+            static void TryInvokeContinuationT10(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> self, in UniTask<T10>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t10 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 12)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11, self.t12));
+                }
+            }
+
+            static void TryInvokeContinuationT11(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> self, in UniTask<T11>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t11 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 12)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11, self.t12));
+                }
+            }
+
+            static void TryInvokeContinuationT12(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> self, in UniTask<T12>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t12 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 12)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11, self.t12));
+                }
+            }
+
+
+            public (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12) GetResult(short token)
+            {
+                TaskTracker.RemoveTracking(this);
+                GC.SuppressFinalize(this);
+                return core.GetResult(token);
+            }
+
+            void IUniTaskSource.GetResult(short token)
+            {
+                GetResult(token);
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+        }
+        
+        public static UniTask<(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)> WhenAll<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4, UniTask<T5> task5, UniTask<T6> task6, UniTask<T7> task7, UniTask<T8> task8, UniTask<T9> task9, UniTask<T10> task10, UniTask<T11> task11, UniTask<T12> task12, UniTask<T13> task13)
+        {
+            if (task1.Status.IsCompletedSuccessfully() && task2.Status.IsCompletedSuccessfully() && task3.Status.IsCompletedSuccessfully() && task4.Status.IsCompletedSuccessfully() && task5.Status.IsCompletedSuccessfully() && task6.Status.IsCompletedSuccessfully() && task7.Status.IsCompletedSuccessfully() && task8.Status.IsCompletedSuccessfully() && task9.Status.IsCompletedSuccessfully() && task10.Status.IsCompletedSuccessfully() && task11.Status.IsCompletedSuccessfully() && task12.Status.IsCompletedSuccessfully() && task13.Status.IsCompletedSuccessfully())
+            {
+                return new UniTask<(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)>((task1.GetAwaiter().GetResult(), task2.GetAwaiter().GetResult(), task3.GetAwaiter().GetResult(), task4.GetAwaiter().GetResult(), task5.GetAwaiter().GetResult(), task6.GetAwaiter().GetResult(), task7.GetAwaiter().GetResult(), task8.GetAwaiter().GetResult(), task9.GetAwaiter().GetResult(), task10.GetAwaiter().GetResult(), task11.GetAwaiter().GetResult(), task12.GetAwaiter().GetResult(), task13.GetAwaiter().GetResult()));
+            }
+
+            return new UniTask<(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)>(new WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(task1, task2, task3, task4, task5, task6, task7, task8, task9, task10, task11, task12, task13), 0);
+        }
+
+        sealed class WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> : IUniTaskSource<(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)>
+        {
+            T1 t1 = default;
+            T2 t2 = default;
+            T3 t3 = default;
+            T4 t4 = default;
+            T5 t5 = default;
+            T6 t6 = default;
+            T7 t7 = default;
+            T8 t8 = default;
+            T9 t9 = default;
+            T10 t10 = default;
+            T11 t11 = default;
+            T12 t12 = default;
+            T13 t13 = default;
+            int completedCount;
+            UniTaskCompletionSourceCore<(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)> core;
+
+            public WhenAllPromise(UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4, UniTask<T5> task5, UniTask<T6> task6, UniTask<T7> task7, UniTask<T8> task8, UniTask<T9> task9, UniTask<T10> task10, UniTask<T11> task11, UniTask<T12> task12, UniTask<T13> task13)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                this.completedCount = 0;
+                {
+                    var awaiter = task1.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT1(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>, UniTask<T1>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT1(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task2.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT2(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>, UniTask<T2>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT2(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task3.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT3(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>, UniTask<T3>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT3(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task4.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT4(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>, UniTask<T4>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT4(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task5.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT5(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>, UniTask<T5>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT5(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task6.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT6(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>, UniTask<T6>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT6(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task7.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT7(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>, UniTask<T7>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT7(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task8.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT8(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>, UniTask<T8>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT8(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task9.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT9(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>, UniTask<T9>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT9(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task10.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT10(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>, UniTask<T10>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT10(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task11.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT11(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>, UniTask<T11>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT11(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task12.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT12(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>, UniTask<T12>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT12(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task13.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT13(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>, UniTask<T13>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT13(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+            }
+
+            static void TryInvokeContinuationT1(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> self, in UniTask<T1>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t1 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 13)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11, self.t12, self.t13));
+                }
+            }
+
+            static void TryInvokeContinuationT2(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> self, in UniTask<T2>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t2 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 13)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11, self.t12, self.t13));
+                }
+            }
+
+            static void TryInvokeContinuationT3(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> self, in UniTask<T3>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t3 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 13)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11, self.t12, self.t13));
+                }
+            }
+
+            static void TryInvokeContinuationT4(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> self, in UniTask<T4>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t4 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 13)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11, self.t12, self.t13));
+                }
+            }
+
+            static void TryInvokeContinuationT5(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> self, in UniTask<T5>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t5 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 13)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11, self.t12, self.t13));
+                }
+            }
+
+            static void TryInvokeContinuationT6(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> self, in UniTask<T6>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t6 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 13)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11, self.t12, self.t13));
+                }
+            }
+
+            static void TryInvokeContinuationT7(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> self, in UniTask<T7>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t7 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 13)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11, self.t12, self.t13));
+                }
+            }
+
+            static void TryInvokeContinuationT8(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> self, in UniTask<T8>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t8 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 13)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11, self.t12, self.t13));
+                }
+            }
+
+            static void TryInvokeContinuationT9(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> self, in UniTask<T9>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t9 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 13)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11, self.t12, self.t13));
+                }
+            }
+
+            static void TryInvokeContinuationT10(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> self, in UniTask<T10>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t10 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 13)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11, self.t12, self.t13));
+                }
+            }
+
+            static void TryInvokeContinuationT11(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> self, in UniTask<T11>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t11 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 13)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11, self.t12, self.t13));
+                }
+            }
+
+            static void TryInvokeContinuationT12(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> self, in UniTask<T12>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t12 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 13)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11, self.t12, self.t13));
+                }
+            }
+
+            static void TryInvokeContinuationT13(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> self, in UniTask<T13>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t13 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 13)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11, self.t12, self.t13));
+                }
+            }
+
+
+            public (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13) GetResult(short token)
+            {
+                TaskTracker.RemoveTracking(this);
+                GC.SuppressFinalize(this);
+                return core.GetResult(token);
+            }
+
+            void IUniTaskSource.GetResult(short token)
+            {
+                GetResult(token);
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+        }
+        
+        public static UniTask<(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)> WhenAll<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4, UniTask<T5> task5, UniTask<T6> task6, UniTask<T7> task7, UniTask<T8> task8, UniTask<T9> task9, UniTask<T10> task10, UniTask<T11> task11, UniTask<T12> task12, UniTask<T13> task13, UniTask<T14> task14)
+        {
+            if (task1.Status.IsCompletedSuccessfully() && task2.Status.IsCompletedSuccessfully() && task3.Status.IsCompletedSuccessfully() && task4.Status.IsCompletedSuccessfully() && task5.Status.IsCompletedSuccessfully() && task6.Status.IsCompletedSuccessfully() && task7.Status.IsCompletedSuccessfully() && task8.Status.IsCompletedSuccessfully() && task9.Status.IsCompletedSuccessfully() && task10.Status.IsCompletedSuccessfully() && task11.Status.IsCompletedSuccessfully() && task12.Status.IsCompletedSuccessfully() && task13.Status.IsCompletedSuccessfully() && task14.Status.IsCompletedSuccessfully())
+            {
+                return new UniTask<(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)>((task1.GetAwaiter().GetResult(), task2.GetAwaiter().GetResult(), task3.GetAwaiter().GetResult(), task4.GetAwaiter().GetResult(), task5.GetAwaiter().GetResult(), task6.GetAwaiter().GetResult(), task7.GetAwaiter().GetResult(), task8.GetAwaiter().GetResult(), task9.GetAwaiter().GetResult(), task10.GetAwaiter().GetResult(), task11.GetAwaiter().GetResult(), task12.GetAwaiter().GetResult(), task13.GetAwaiter().GetResult(), task14.GetAwaiter().GetResult()));
+            }
+
+            return new UniTask<(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)>(new WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(task1, task2, task3, task4, task5, task6, task7, task8, task9, task10, task11, task12, task13, task14), 0);
+        }
+
+        sealed class WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> : IUniTaskSource<(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)>
+        {
+            T1 t1 = default;
+            T2 t2 = default;
+            T3 t3 = default;
+            T4 t4 = default;
+            T5 t5 = default;
+            T6 t6 = default;
+            T7 t7 = default;
+            T8 t8 = default;
+            T9 t9 = default;
+            T10 t10 = default;
+            T11 t11 = default;
+            T12 t12 = default;
+            T13 t13 = default;
+            T14 t14 = default;
+            int completedCount;
+            UniTaskCompletionSourceCore<(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)> core;
+
+            public WhenAllPromise(UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4, UniTask<T5> task5, UniTask<T6> task6, UniTask<T7> task7, UniTask<T8> task8, UniTask<T9> task9, UniTask<T10> task10, UniTask<T11> task11, UniTask<T12> task12, UniTask<T13> task13, UniTask<T14> task14)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                this.completedCount = 0;
+                {
+                    var awaiter = task1.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT1(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>, UniTask<T1>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT1(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task2.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT2(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>, UniTask<T2>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT2(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task3.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT3(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>, UniTask<T3>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT3(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task4.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT4(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>, UniTask<T4>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT4(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task5.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT5(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>, UniTask<T5>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT5(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task6.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT6(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>, UniTask<T6>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT6(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task7.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT7(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>, UniTask<T7>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT7(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task8.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT8(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>, UniTask<T8>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT8(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task9.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT9(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>, UniTask<T9>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT9(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task10.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT10(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>, UniTask<T10>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT10(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task11.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT11(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>, UniTask<T11>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT11(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task12.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT12(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>, UniTask<T12>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT12(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task13.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT13(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>, UniTask<T13>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT13(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task14.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT14(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>, UniTask<T14>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT14(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+            }
+
+            static void TryInvokeContinuationT1(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> self, in UniTask<T1>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t1 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 14)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11, self.t12, self.t13, self.t14));
+                }
+            }
+
+            static void TryInvokeContinuationT2(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> self, in UniTask<T2>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t2 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 14)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11, self.t12, self.t13, self.t14));
+                }
+            }
+
+            static void TryInvokeContinuationT3(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> self, in UniTask<T3>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t3 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 14)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11, self.t12, self.t13, self.t14));
+                }
+            }
+
+            static void TryInvokeContinuationT4(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> self, in UniTask<T4>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t4 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 14)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11, self.t12, self.t13, self.t14));
+                }
+            }
+
+            static void TryInvokeContinuationT5(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> self, in UniTask<T5>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t5 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 14)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11, self.t12, self.t13, self.t14));
+                }
+            }
+
+            static void TryInvokeContinuationT6(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> self, in UniTask<T6>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t6 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 14)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11, self.t12, self.t13, self.t14));
+                }
+            }
+
+            static void TryInvokeContinuationT7(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> self, in UniTask<T7>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t7 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 14)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11, self.t12, self.t13, self.t14));
+                }
+            }
+
+            static void TryInvokeContinuationT8(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> self, in UniTask<T8>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t8 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 14)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11, self.t12, self.t13, self.t14));
+                }
+            }
+
+            static void TryInvokeContinuationT9(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> self, in UniTask<T9>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t9 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 14)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11, self.t12, self.t13, self.t14));
+                }
+            }
+
+            static void TryInvokeContinuationT10(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> self, in UniTask<T10>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t10 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 14)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11, self.t12, self.t13, self.t14));
+                }
+            }
+
+            static void TryInvokeContinuationT11(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> self, in UniTask<T11>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t11 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 14)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11, self.t12, self.t13, self.t14));
+                }
+            }
+
+            static void TryInvokeContinuationT12(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> self, in UniTask<T12>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t12 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 14)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11, self.t12, self.t13, self.t14));
+                }
+            }
+
+            static void TryInvokeContinuationT13(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> self, in UniTask<T13>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t13 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 14)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11, self.t12, self.t13, self.t14));
+                }
+            }
+
+            static void TryInvokeContinuationT14(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> self, in UniTask<T14>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t14 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 14)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11, self.t12, self.t13, self.t14));
+                }
+            }
+
+
+            public (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14) GetResult(short token)
+            {
+                TaskTracker.RemoveTracking(this);
+                GC.SuppressFinalize(this);
+                return core.GetResult(token);
+            }
+
+            void IUniTaskSource.GetResult(short token)
+            {
+                GetResult(token);
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+        }
+        
+        public static UniTask<(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)> WhenAll<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4, UniTask<T5> task5, UniTask<T6> task6, UniTask<T7> task7, UniTask<T8> task8, UniTask<T9> task9, UniTask<T10> task10, UniTask<T11> task11, UniTask<T12> task12, UniTask<T13> task13, UniTask<T14> task14, UniTask<T15> task15)
+        {
+            if (task1.Status.IsCompletedSuccessfully() && task2.Status.IsCompletedSuccessfully() && task3.Status.IsCompletedSuccessfully() && task4.Status.IsCompletedSuccessfully() && task5.Status.IsCompletedSuccessfully() && task6.Status.IsCompletedSuccessfully() && task7.Status.IsCompletedSuccessfully() && task8.Status.IsCompletedSuccessfully() && task9.Status.IsCompletedSuccessfully() && task10.Status.IsCompletedSuccessfully() && task11.Status.IsCompletedSuccessfully() && task12.Status.IsCompletedSuccessfully() && task13.Status.IsCompletedSuccessfully() && task14.Status.IsCompletedSuccessfully() && task15.Status.IsCompletedSuccessfully())
+            {
+                return new UniTask<(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)>((task1.GetAwaiter().GetResult(), task2.GetAwaiter().GetResult(), task3.GetAwaiter().GetResult(), task4.GetAwaiter().GetResult(), task5.GetAwaiter().GetResult(), task6.GetAwaiter().GetResult(), task7.GetAwaiter().GetResult(), task8.GetAwaiter().GetResult(), task9.GetAwaiter().GetResult(), task10.GetAwaiter().GetResult(), task11.GetAwaiter().GetResult(), task12.GetAwaiter().GetResult(), task13.GetAwaiter().GetResult(), task14.GetAwaiter().GetResult(), task15.GetAwaiter().GetResult()));
+            }
+
+            return new UniTask<(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)>(new WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(task1, task2, task3, task4, task5, task6, task7, task8, task9, task10, task11, task12, task13, task14, task15), 0);
+        }
+
+        sealed class WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> : IUniTaskSource<(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)>
+        {
+            T1 t1 = default;
+            T2 t2 = default;
+            T3 t3 = default;
+            T4 t4 = default;
+            T5 t5 = default;
+            T6 t6 = default;
+            T7 t7 = default;
+            T8 t8 = default;
+            T9 t9 = default;
+            T10 t10 = default;
+            T11 t11 = default;
+            T12 t12 = default;
+            T13 t13 = default;
+            T14 t14 = default;
+            T15 t15 = default;
+            int completedCount;
+            UniTaskCompletionSourceCore<(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)> core;
+
+            public WhenAllPromise(UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4, UniTask<T5> task5, UniTask<T6> task6, UniTask<T7> task7, UniTask<T8> task8, UniTask<T9> task9, UniTask<T10> task10, UniTask<T11> task11, UniTask<T12> task12, UniTask<T13> task13, UniTask<T14> task14, UniTask<T15> task15)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                this.completedCount = 0;
+                {
+                    var awaiter = task1.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT1(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>, UniTask<T1>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT1(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task2.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT2(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>, UniTask<T2>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT2(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task3.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT3(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>, UniTask<T3>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT3(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task4.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT4(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>, UniTask<T4>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT4(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task5.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT5(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>, UniTask<T5>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT5(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task6.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT6(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>, UniTask<T6>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT6(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task7.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT7(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>, UniTask<T7>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT7(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task8.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT8(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>, UniTask<T8>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT8(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task9.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT9(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>, UniTask<T9>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT9(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task10.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT10(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>, UniTask<T10>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT10(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task11.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT11(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>, UniTask<T11>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT11(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task12.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT12(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>, UniTask<T12>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT12(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task13.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT13(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>, UniTask<T13>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT13(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task14.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT14(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>, UniTask<T14>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT14(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task15.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT15(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>, UniTask<T15>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT15(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+            }
+
+            static void TryInvokeContinuationT1(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> self, in UniTask<T1>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t1 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 15)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11, self.t12, self.t13, self.t14, self.t15));
+                }
+            }
+
+            static void TryInvokeContinuationT2(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> self, in UniTask<T2>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t2 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 15)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11, self.t12, self.t13, self.t14, self.t15));
+                }
+            }
+
+            static void TryInvokeContinuationT3(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> self, in UniTask<T3>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t3 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 15)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11, self.t12, self.t13, self.t14, self.t15));
+                }
+            }
+
+            static void TryInvokeContinuationT4(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> self, in UniTask<T4>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t4 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 15)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11, self.t12, self.t13, self.t14, self.t15));
+                }
+            }
+
+            static void TryInvokeContinuationT5(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> self, in UniTask<T5>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t5 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 15)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11, self.t12, self.t13, self.t14, self.t15));
+                }
+            }
+
+            static void TryInvokeContinuationT6(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> self, in UniTask<T6>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t6 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 15)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11, self.t12, self.t13, self.t14, self.t15));
+                }
+            }
+
+            static void TryInvokeContinuationT7(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> self, in UniTask<T7>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t7 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 15)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11, self.t12, self.t13, self.t14, self.t15));
+                }
+            }
+
+            static void TryInvokeContinuationT8(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> self, in UniTask<T8>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t8 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 15)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11, self.t12, self.t13, self.t14, self.t15));
+                }
+            }
+
+            static void TryInvokeContinuationT9(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> self, in UniTask<T9>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t9 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 15)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11, self.t12, self.t13, self.t14, self.t15));
+                }
+            }
+
+            static void TryInvokeContinuationT10(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> self, in UniTask<T10>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t10 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 15)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11, self.t12, self.t13, self.t14, self.t15));
+                }
+            }
+
+            static void TryInvokeContinuationT11(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> self, in UniTask<T11>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t11 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 15)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11, self.t12, self.t13, self.t14, self.t15));
+                }
+            }
+
+            static void TryInvokeContinuationT12(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> self, in UniTask<T12>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t12 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 15)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11, self.t12, self.t13, self.t14, self.t15));
+                }
+            }
+
+            static void TryInvokeContinuationT13(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> self, in UniTask<T13>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t13 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 15)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11, self.t12, self.t13, self.t14, self.t15));
+                }
+            }
+
+            static void TryInvokeContinuationT14(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> self, in UniTask<T14>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t14 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 15)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11, self.t12, self.t13, self.t14, self.t15));
+                }
+            }
+
+            static void TryInvokeContinuationT15(WhenAllPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> self, in UniTask<T15>.Awaiter awaiter)
+            {
+                try
+                {
+                    self.t15 = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+                
+                if (Interlocked.Increment(ref self.completedCount) == 15)
+                {
+                    self.core.TrySetResult((self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11, self.t12, self.t13, self.t14, self.t15));
+                }
+            }
+
+
+            public (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15) GetResult(short token)
+            {
+                TaskTracker.RemoveTracking(this);
+                GC.SuppressFinalize(this);
+                return core.GetResult(token);
+            }
+
+            void IUniTaskSource.GetResult(short token)
+            {
+                GetResult(token);
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/UniTask.WhenAll.Generated.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/UniTask.WhenAll.Generated.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5110117231c8a6d4095fd0cbd3f4c142
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/UniTask.WhenAll.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/UniTask.WhenAll.cs
@@ -1,0 +1,237 @@
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Cysharp.Threading.Tasks.Internal;
+
+namespace Cysharp.Threading.Tasks
+{
+    public partial struct UniTask
+    {
+        public static UniTask<T[]> WhenAll<T>(params UniTask<T>[] tasks)
+        {
+            if (tasks.Length == 0)
+            {
+                return UniTask.FromResult(Array.Empty<T>());
+            }
+
+            return new UniTask<T[]>(new WhenAllPromise<T>(tasks, tasks.Length), 0);
+        }
+
+        public static UniTask<T[]> WhenAll<T>(IEnumerable<UniTask<T>> tasks)
+        {
+            using (var span = ArrayPoolUtil.Materialize(tasks))
+            {
+                var promise = new WhenAllPromise<T>(span.Array, span.Length); // consumed array in constructor.
+                return new UniTask<T[]>(promise, 0);
+            }
+        }
+
+        public static UniTask WhenAll(params UniTask[] tasks)
+        {
+            if (tasks.Length == 0)
+            {
+                return UniTask.CompletedTask;
+            }
+
+            return new UniTask(new WhenAllPromise(tasks, tasks.Length), 0);
+        }
+
+        public static UniTask WhenAll(IEnumerable<UniTask> tasks)
+        {
+            using (var span = ArrayPoolUtil.Materialize(tasks))
+            {
+                var promise = new WhenAllPromise(span.Array, span.Length); // consumed array in constructor.
+                return new UniTask(promise, 0);
+            }
+        }
+
+        sealed class WhenAllPromise<T> : IUniTaskSource<T[]>
+        {
+            T[] result;
+            int completeCount;
+            UniTaskCompletionSourceCore<T[]> core; // don't reset(called after GetResult, will invoke TrySetException.)
+
+            public WhenAllPromise(UniTask<T>[] tasks, int tasksLength)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                this.completeCount = 0;
+
+                if (tasksLength == 0)
+                {
+                    this.result = Array.Empty<T>();
+                    core.TrySetResult(result);
+                    return;
+                }
+
+                this.result = new T[tasksLength];
+
+                for (int i = 0; i < tasksLength; i++)
+                {
+                    UniTask<T>.Awaiter awaiter;
+                    try
+                    {
+                        awaiter = tasks[i].GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        core.TrySetException(ex);
+                        continue;
+                    }
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuation(this, awaiter, i);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise<T>, UniTask<T>.Awaiter, int>)state)
+                            {
+                                TryInvokeContinuation(t.Item1, t.Item2, t.Item3);
+                            }
+                        }, StateTuple.Create(this, awaiter, i));
+                    }
+                }
+            }
+
+            static void TryInvokeContinuation(WhenAllPromise<T> self, in UniTask<T>.Awaiter awaiter, int i)
+            {
+                try
+                {
+                    self.result[i] = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completeCount) == self.result.Length)
+                {
+                    self.core.TrySetResult(self.result);
+                }
+            }
+
+            public T[] GetResult(short token)
+            {
+                TaskTracker.RemoveTracking(this);
+                GC.SuppressFinalize(this);
+                return core.GetResult(token);
+            }
+
+            void IUniTaskSource.GetResult(short token)
+            {
+                GetResult(token);
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+        }
+
+        sealed class WhenAllPromise : IUniTaskSource
+        {
+            int completeCount;
+            int tasksLength;
+            UniTaskCompletionSourceCore<AsyncUnit> core; // don't reset(called after GetResult, will invoke TrySetException.)
+
+            public WhenAllPromise(UniTask[] tasks, int tasksLength)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                this.tasksLength = tasksLength;
+                this.completeCount = 0;
+
+                if (tasksLength == 0)
+                {
+                    core.TrySetResult(AsyncUnit.Default);
+                    return;
+                }
+
+                for (int i = 0; i < tasksLength; i++)
+                {
+                    UniTask.Awaiter awaiter;
+                    try
+                    {
+                        awaiter = tasks[i].GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        core.TrySetException(ex);
+                        continue;
+                    }
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuation(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAllPromise, UniTask.Awaiter>)state)
+                            {
+                                TryInvokeContinuation(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+            }
+
+            static void TryInvokeContinuation(WhenAllPromise self, in UniTask.Awaiter awaiter)
+            {
+                try
+                {
+                    awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completeCount) == self.tasksLength)
+                {
+                    self.core.TrySetResult(AsyncUnit.Default);
+                }
+            }
+
+            public void GetResult(short token)
+            {
+                TaskTracker.RemoveTracking(this);
+                GC.SuppressFinalize(this);
+                core.GetResult(token);
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/UniTask.WhenAll.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/UniTask.WhenAll.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 355997a305ba64248822eec34998a1a0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/UniTask.WhenAny.Generated.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/UniTask.WhenAny.Generated.cs
@@ -1,0 +1,5060 @@
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using Cysharp.Threading.Tasks.Internal;
+
+namespace Cysharp.Threading.Tasks
+{
+    public partial struct UniTask
+    {
+        public static UniTask<(int winArgumentIndex, T1 result1, T2 result2)> WhenAny<T1, T2>(UniTask<T1> task1, UniTask<T2> task2)
+        {
+            return new UniTask<(int winArgumentIndex, T1 result1, T2 result2)>(new WhenAnyPromise<T1, T2>(task1, task2), 0);
+        }
+
+        sealed class WhenAnyPromise<T1, T2> : IUniTaskSource<(int, T1 result1, T2 result2)>
+        {
+            int completedCount;
+            UniTaskCompletionSourceCore<(int, T1 result1, T2 result2)> core;
+
+            public WhenAnyPromise(UniTask<T1> task1, UniTask<T2> task2)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                this.completedCount = 0;
+                {
+                    var awaiter = task1.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT1(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2>, UniTask<T1>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT1(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task2.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT2(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2>, UniTask<T2>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT2(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+            }
+
+            static void TryInvokeContinuationT1(WhenAnyPromise<T1, T2> self, in UniTask<T1>.Awaiter awaiter)
+            {
+                T1 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((0, result, default));
+                }
+            }
+
+            static void TryInvokeContinuationT2(WhenAnyPromise<T1, T2> self, in UniTask<T2>.Awaiter awaiter)
+            {
+                T2 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((1, default, result));
+                }
+            }
+
+
+            public (int, T1 result1, T2 result2) GetResult(short token)
+            {
+                TaskTracker.RemoveTracking(this);
+                GC.SuppressFinalize(this);
+                return core.GetResult(token);
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            void IUniTaskSource.GetResult(short token)
+            {
+                GetResult(token);
+            }
+        }
+
+        public static UniTask<(int winArgumentIndex, T1 result1, T2 result2, T3 result3)> WhenAny<T1, T2, T3>(UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3)
+        {
+            return new UniTask<(int winArgumentIndex, T1 result1, T2 result2, T3 result3)>(new WhenAnyPromise<T1, T2, T3>(task1, task2, task3), 0);
+        }
+
+        sealed class WhenAnyPromise<T1, T2, T3> : IUniTaskSource<(int, T1 result1, T2 result2, T3 result3)>
+        {
+            int completedCount;
+            UniTaskCompletionSourceCore<(int, T1 result1, T2 result2, T3 result3)> core;
+
+            public WhenAnyPromise(UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                this.completedCount = 0;
+                {
+                    var awaiter = task1.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT1(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3>, UniTask<T1>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT1(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task2.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT2(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3>, UniTask<T2>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT2(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task3.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT3(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3>, UniTask<T3>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT3(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+            }
+
+            static void TryInvokeContinuationT1(WhenAnyPromise<T1, T2, T3> self, in UniTask<T1>.Awaiter awaiter)
+            {
+                T1 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((0, result, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT2(WhenAnyPromise<T1, T2, T3> self, in UniTask<T2>.Awaiter awaiter)
+            {
+                T2 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((1, default, result, default));
+                }
+            }
+
+            static void TryInvokeContinuationT3(WhenAnyPromise<T1, T2, T3> self, in UniTask<T3>.Awaiter awaiter)
+            {
+                T3 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((2, default, default, result));
+                }
+            }
+
+
+            public (int, T1 result1, T2 result2, T3 result3) GetResult(short token)
+            {
+                TaskTracker.RemoveTracking(this);
+                GC.SuppressFinalize(this);
+                return core.GetResult(token);
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            void IUniTaskSource.GetResult(short token)
+            {
+                GetResult(token);
+            }
+        }
+
+        public static UniTask<(int winArgumentIndex, T1 result1, T2 result2, T3 result3, T4 result4)> WhenAny<T1, T2, T3, T4>(UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4)
+        {
+            return new UniTask<(int winArgumentIndex, T1 result1, T2 result2, T3 result3, T4 result4)>(new WhenAnyPromise<T1, T2, T3, T4>(task1, task2, task3, task4), 0);
+        }
+
+        sealed class WhenAnyPromise<T1, T2, T3, T4> : IUniTaskSource<(int, T1 result1, T2 result2, T3 result3, T4 result4)>
+        {
+            int completedCount;
+            UniTaskCompletionSourceCore<(int, T1 result1, T2 result2, T3 result3, T4 result4)> core;
+
+            public WhenAnyPromise(UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                this.completedCount = 0;
+                {
+                    var awaiter = task1.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT1(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4>, UniTask<T1>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT1(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task2.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT2(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4>, UniTask<T2>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT2(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task3.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT3(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4>, UniTask<T3>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT3(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task4.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT4(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4>, UniTask<T4>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT4(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+            }
+
+            static void TryInvokeContinuationT1(WhenAnyPromise<T1, T2, T3, T4> self, in UniTask<T1>.Awaiter awaiter)
+            {
+                T1 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((0, result, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT2(WhenAnyPromise<T1, T2, T3, T4> self, in UniTask<T2>.Awaiter awaiter)
+            {
+                T2 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((1, default, result, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT3(WhenAnyPromise<T1, T2, T3, T4> self, in UniTask<T3>.Awaiter awaiter)
+            {
+                T3 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((2, default, default, result, default));
+                }
+            }
+
+            static void TryInvokeContinuationT4(WhenAnyPromise<T1, T2, T3, T4> self, in UniTask<T4>.Awaiter awaiter)
+            {
+                T4 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((3, default, default, default, result));
+                }
+            }
+
+
+            public (int, T1 result1, T2 result2, T3 result3, T4 result4) GetResult(short token)
+            {
+                TaskTracker.RemoveTracking(this);
+                GC.SuppressFinalize(this);
+                return core.GetResult(token);
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            void IUniTaskSource.GetResult(short token)
+            {
+                GetResult(token);
+            }
+        }
+
+        public static UniTask<(int winArgumentIndex, T1 result1, T2 result2, T3 result3, T4 result4, T5 result5)> WhenAny<T1, T2, T3, T4, T5>(UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4, UniTask<T5> task5)
+        {
+            return new UniTask<(int winArgumentIndex, T1 result1, T2 result2, T3 result3, T4 result4, T5 result5)>(new WhenAnyPromise<T1, T2, T3, T4, T5>(task1, task2, task3, task4, task5), 0);
+        }
+
+        sealed class WhenAnyPromise<T1, T2, T3, T4, T5> : IUniTaskSource<(int, T1 result1, T2 result2, T3 result3, T4 result4, T5 result5)>
+        {
+            int completedCount;
+            UniTaskCompletionSourceCore<(int, T1 result1, T2 result2, T3 result3, T4 result4, T5 result5)> core;
+
+            public WhenAnyPromise(UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4, UniTask<T5> task5)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                this.completedCount = 0;
+                {
+                    var awaiter = task1.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT1(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5>, UniTask<T1>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT1(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task2.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT2(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5>, UniTask<T2>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT2(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task3.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT3(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5>, UniTask<T3>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT3(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task4.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT4(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5>, UniTask<T4>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT4(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task5.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT5(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5>, UniTask<T5>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT5(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+            }
+
+            static void TryInvokeContinuationT1(WhenAnyPromise<T1, T2, T3, T4, T5> self, in UniTask<T1>.Awaiter awaiter)
+            {
+                T1 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((0, result, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT2(WhenAnyPromise<T1, T2, T3, T4, T5> self, in UniTask<T2>.Awaiter awaiter)
+            {
+                T2 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((1, default, result, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT3(WhenAnyPromise<T1, T2, T3, T4, T5> self, in UniTask<T3>.Awaiter awaiter)
+            {
+                T3 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((2, default, default, result, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT4(WhenAnyPromise<T1, T2, T3, T4, T5> self, in UniTask<T4>.Awaiter awaiter)
+            {
+                T4 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((3, default, default, default, result, default));
+                }
+            }
+
+            static void TryInvokeContinuationT5(WhenAnyPromise<T1, T2, T3, T4, T5> self, in UniTask<T5>.Awaiter awaiter)
+            {
+                T5 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((4, default, default, default, default, result));
+                }
+            }
+
+
+            public (int, T1 result1, T2 result2, T3 result3, T4 result4, T5 result5) GetResult(short token)
+            {
+                TaskTracker.RemoveTracking(this);
+                GC.SuppressFinalize(this);
+                return core.GetResult(token);
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            void IUniTaskSource.GetResult(short token)
+            {
+                GetResult(token);
+            }
+        }
+
+        public static UniTask<(int winArgumentIndex, T1 result1, T2 result2, T3 result3, T4 result4, T5 result5, T6 result6)> WhenAny<T1, T2, T3, T4, T5, T6>(UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4, UniTask<T5> task5, UniTask<T6> task6)
+        {
+            return new UniTask<(int winArgumentIndex, T1 result1, T2 result2, T3 result3, T4 result4, T5 result5, T6 result6)>(new WhenAnyPromise<T1, T2, T3, T4, T5, T6>(task1, task2, task3, task4, task5, task6), 0);
+        }
+
+        sealed class WhenAnyPromise<T1, T2, T3, T4, T5, T6> : IUniTaskSource<(int, T1 result1, T2 result2, T3 result3, T4 result4, T5 result5, T6 result6)>
+        {
+            int completedCount;
+            UniTaskCompletionSourceCore<(int, T1 result1, T2 result2, T3 result3, T4 result4, T5 result5, T6 result6)> core;
+
+            public WhenAnyPromise(UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4, UniTask<T5> task5, UniTask<T6> task6)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                this.completedCount = 0;
+                {
+                    var awaiter = task1.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT1(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6>, UniTask<T1>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT1(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task2.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT2(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6>, UniTask<T2>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT2(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task3.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT3(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6>, UniTask<T3>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT3(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task4.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT4(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6>, UniTask<T4>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT4(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task5.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT5(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6>, UniTask<T5>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT5(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task6.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT6(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6>, UniTask<T6>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT6(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+            }
+
+            static void TryInvokeContinuationT1(WhenAnyPromise<T1, T2, T3, T4, T5, T6> self, in UniTask<T1>.Awaiter awaiter)
+            {
+                T1 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((0, result, default, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT2(WhenAnyPromise<T1, T2, T3, T4, T5, T6> self, in UniTask<T2>.Awaiter awaiter)
+            {
+                T2 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((1, default, result, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT3(WhenAnyPromise<T1, T2, T3, T4, T5, T6> self, in UniTask<T3>.Awaiter awaiter)
+            {
+                T3 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((2, default, default, result, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT4(WhenAnyPromise<T1, T2, T3, T4, T5, T6> self, in UniTask<T4>.Awaiter awaiter)
+            {
+                T4 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((3, default, default, default, result, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT5(WhenAnyPromise<T1, T2, T3, T4, T5, T6> self, in UniTask<T5>.Awaiter awaiter)
+            {
+                T5 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((4, default, default, default, default, result, default));
+                }
+            }
+
+            static void TryInvokeContinuationT6(WhenAnyPromise<T1, T2, T3, T4, T5, T6> self, in UniTask<T6>.Awaiter awaiter)
+            {
+                T6 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((5, default, default, default, default, default, result));
+                }
+            }
+
+
+            public (int, T1 result1, T2 result2, T3 result3, T4 result4, T5 result5, T6 result6) GetResult(short token)
+            {
+                TaskTracker.RemoveTracking(this);
+                GC.SuppressFinalize(this);
+                return core.GetResult(token);
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            void IUniTaskSource.GetResult(short token)
+            {
+                GetResult(token);
+            }
+        }
+
+        public static UniTask<(int winArgumentIndex, T1 result1, T2 result2, T3 result3, T4 result4, T5 result5, T6 result6, T7 result7)> WhenAny<T1, T2, T3, T4, T5, T6, T7>(UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4, UniTask<T5> task5, UniTask<T6> task6, UniTask<T7> task7)
+        {
+            return new UniTask<(int winArgumentIndex, T1 result1, T2 result2, T3 result3, T4 result4, T5 result5, T6 result6, T7 result7)>(new WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7>(task1, task2, task3, task4, task5, task6, task7), 0);
+        }
+
+        sealed class WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7> : IUniTaskSource<(int, T1 result1, T2 result2, T3 result3, T4 result4, T5 result5, T6 result6, T7 result7)>
+        {
+            int completedCount;
+            UniTaskCompletionSourceCore<(int, T1 result1, T2 result2, T3 result3, T4 result4, T5 result5, T6 result6, T7 result7)> core;
+
+            public WhenAnyPromise(UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4, UniTask<T5> task5, UniTask<T6> task6, UniTask<T7> task7)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                this.completedCount = 0;
+                {
+                    var awaiter = task1.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT1(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7>, UniTask<T1>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT1(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task2.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT2(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7>, UniTask<T2>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT2(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task3.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT3(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7>, UniTask<T3>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT3(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task4.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT4(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7>, UniTask<T4>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT4(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task5.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT5(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7>, UniTask<T5>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT5(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task6.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT6(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7>, UniTask<T6>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT6(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task7.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT7(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7>, UniTask<T7>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT7(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+            }
+
+            static void TryInvokeContinuationT1(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7> self, in UniTask<T1>.Awaiter awaiter)
+            {
+                T1 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((0, result, default, default, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT2(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7> self, in UniTask<T2>.Awaiter awaiter)
+            {
+                T2 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((1, default, result, default, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT3(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7> self, in UniTask<T3>.Awaiter awaiter)
+            {
+                T3 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((2, default, default, result, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT4(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7> self, in UniTask<T4>.Awaiter awaiter)
+            {
+                T4 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((3, default, default, default, result, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT5(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7> self, in UniTask<T5>.Awaiter awaiter)
+            {
+                T5 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((4, default, default, default, default, result, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT6(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7> self, in UniTask<T6>.Awaiter awaiter)
+            {
+                T6 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((5, default, default, default, default, default, result, default));
+                }
+            }
+
+            static void TryInvokeContinuationT7(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7> self, in UniTask<T7>.Awaiter awaiter)
+            {
+                T7 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((6, default, default, default, default, default, default, result));
+                }
+            }
+
+
+            public (int, T1 result1, T2 result2, T3 result3, T4 result4, T5 result5, T6 result6, T7 result7) GetResult(short token)
+            {
+                TaskTracker.RemoveTracking(this);
+                GC.SuppressFinalize(this);
+                return core.GetResult(token);
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            void IUniTaskSource.GetResult(short token)
+            {
+                GetResult(token);
+            }
+        }
+
+        public static UniTask<(int winArgumentIndex, T1 result1, T2 result2, T3 result3, T4 result4, T5 result5, T6 result6, T7 result7, T8 result8)> WhenAny<T1, T2, T3, T4, T5, T6, T7, T8>(UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4, UniTask<T5> task5, UniTask<T6> task6, UniTask<T7> task7, UniTask<T8> task8)
+        {
+            return new UniTask<(int winArgumentIndex, T1 result1, T2 result2, T3 result3, T4 result4, T5 result5, T6 result6, T7 result7, T8 result8)>(new WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8>(task1, task2, task3, task4, task5, task6, task7, task8), 0);
+        }
+
+        sealed class WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8> : IUniTaskSource<(int, T1 result1, T2 result2, T3 result3, T4 result4, T5 result5, T6 result6, T7 result7, T8 result8)>
+        {
+            int completedCount;
+            UniTaskCompletionSourceCore<(int, T1 result1, T2 result2, T3 result3, T4 result4, T5 result5, T6 result6, T7 result7, T8 result8)> core;
+
+            public WhenAnyPromise(UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4, UniTask<T5> task5, UniTask<T6> task6, UniTask<T7> task7, UniTask<T8> task8)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                this.completedCount = 0;
+                {
+                    var awaiter = task1.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT1(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8>, UniTask<T1>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT1(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task2.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT2(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8>, UniTask<T2>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT2(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task3.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT3(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8>, UniTask<T3>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT3(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task4.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT4(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8>, UniTask<T4>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT4(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task5.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT5(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8>, UniTask<T5>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT5(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task6.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT6(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8>, UniTask<T6>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT6(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task7.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT7(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8>, UniTask<T7>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT7(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task8.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT8(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8>, UniTask<T8>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT8(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+            }
+
+            static void TryInvokeContinuationT1(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8> self, in UniTask<T1>.Awaiter awaiter)
+            {
+                T1 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((0, result, default, default, default, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT2(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8> self, in UniTask<T2>.Awaiter awaiter)
+            {
+                T2 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((1, default, result, default, default, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT3(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8> self, in UniTask<T3>.Awaiter awaiter)
+            {
+                T3 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((2, default, default, result, default, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT4(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8> self, in UniTask<T4>.Awaiter awaiter)
+            {
+                T4 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((3, default, default, default, result, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT5(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8> self, in UniTask<T5>.Awaiter awaiter)
+            {
+                T5 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((4, default, default, default, default, result, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT6(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8> self, in UniTask<T6>.Awaiter awaiter)
+            {
+                T6 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((5, default, default, default, default, default, result, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT7(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8> self, in UniTask<T7>.Awaiter awaiter)
+            {
+                T7 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((6, default, default, default, default, default, default, result, default));
+                }
+            }
+
+            static void TryInvokeContinuationT8(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8> self, in UniTask<T8>.Awaiter awaiter)
+            {
+                T8 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((7, default, default, default, default, default, default, default, result));
+                }
+            }
+
+
+            public (int, T1 result1, T2 result2, T3 result3, T4 result4, T5 result5, T6 result6, T7 result7, T8 result8) GetResult(short token)
+            {
+                TaskTracker.RemoveTracking(this);
+                GC.SuppressFinalize(this);
+                return core.GetResult(token);
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            void IUniTaskSource.GetResult(short token)
+            {
+                GetResult(token);
+            }
+        }
+
+        public static UniTask<(int winArgumentIndex, T1 result1, T2 result2, T3 result3, T4 result4, T5 result5, T6 result6, T7 result7, T8 result8, T9 result9)> WhenAny<T1, T2, T3, T4, T5, T6, T7, T8, T9>(UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4, UniTask<T5> task5, UniTask<T6> task6, UniTask<T7> task7, UniTask<T8> task8, UniTask<T9> task9)
+        {
+            return new UniTask<(int winArgumentIndex, T1 result1, T2 result2, T3 result3, T4 result4, T5 result5, T6 result6, T7 result7, T8 result8, T9 result9)>(new WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9>(task1, task2, task3, task4, task5, task6, task7, task8, task9), 0);
+        }
+
+        sealed class WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9> : IUniTaskSource<(int, T1 result1, T2 result2, T3 result3, T4 result4, T5 result5, T6 result6, T7 result7, T8 result8, T9 result9)>
+        {
+            int completedCount;
+            UniTaskCompletionSourceCore<(int, T1 result1, T2 result2, T3 result3, T4 result4, T5 result5, T6 result6, T7 result7, T8 result8, T9 result9)> core;
+
+            public WhenAnyPromise(UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4, UniTask<T5> task5, UniTask<T6> task6, UniTask<T7> task7, UniTask<T8> task8, UniTask<T9> task9)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                this.completedCount = 0;
+                {
+                    var awaiter = task1.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT1(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9>, UniTask<T1>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT1(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task2.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT2(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9>, UniTask<T2>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT2(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task3.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT3(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9>, UniTask<T3>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT3(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task4.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT4(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9>, UniTask<T4>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT4(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task5.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT5(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9>, UniTask<T5>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT5(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task6.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT6(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9>, UniTask<T6>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT6(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task7.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT7(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9>, UniTask<T7>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT7(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task8.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT8(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9>, UniTask<T8>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT8(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task9.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT9(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9>, UniTask<T9>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT9(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+            }
+
+            static void TryInvokeContinuationT1(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9> self, in UniTask<T1>.Awaiter awaiter)
+            {
+                T1 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((0, result, default, default, default, default, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT2(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9> self, in UniTask<T2>.Awaiter awaiter)
+            {
+                T2 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((1, default, result, default, default, default, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT3(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9> self, in UniTask<T3>.Awaiter awaiter)
+            {
+                T3 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((2, default, default, result, default, default, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT4(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9> self, in UniTask<T4>.Awaiter awaiter)
+            {
+                T4 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((3, default, default, default, result, default, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT5(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9> self, in UniTask<T5>.Awaiter awaiter)
+            {
+                T5 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((4, default, default, default, default, result, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT6(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9> self, in UniTask<T6>.Awaiter awaiter)
+            {
+                T6 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((5, default, default, default, default, default, result, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT7(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9> self, in UniTask<T7>.Awaiter awaiter)
+            {
+                T7 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((6, default, default, default, default, default, default, result, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT8(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9> self, in UniTask<T8>.Awaiter awaiter)
+            {
+                T8 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((7, default, default, default, default, default, default, default, result, default));
+                }
+            }
+
+            static void TryInvokeContinuationT9(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9> self, in UniTask<T9>.Awaiter awaiter)
+            {
+                T9 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((8, default, default, default, default, default, default, default, default, result));
+                }
+            }
+
+
+            public (int, T1 result1, T2 result2, T3 result3, T4 result4, T5 result5, T6 result6, T7 result7, T8 result8, T9 result9) GetResult(short token)
+            {
+                TaskTracker.RemoveTracking(this);
+                GC.SuppressFinalize(this);
+                return core.GetResult(token);
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            void IUniTaskSource.GetResult(short token)
+            {
+                GetResult(token);
+            }
+        }
+
+        public static UniTask<(int winArgumentIndex, T1 result1, T2 result2, T3 result3, T4 result4, T5 result5, T6 result6, T7 result7, T8 result8, T9 result9, T10 result10)> WhenAny<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4, UniTask<T5> task5, UniTask<T6> task6, UniTask<T7> task7, UniTask<T8> task8, UniTask<T9> task9, UniTask<T10> task10)
+        {
+            return new UniTask<(int winArgumentIndex, T1 result1, T2 result2, T3 result3, T4 result4, T5 result5, T6 result6, T7 result7, T8 result8, T9 result9, T10 result10)>(new WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(task1, task2, task3, task4, task5, task6, task7, task8, task9, task10), 0);
+        }
+
+        sealed class WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> : IUniTaskSource<(int, T1 result1, T2 result2, T3 result3, T4 result4, T5 result5, T6 result6, T7 result7, T8 result8, T9 result9, T10 result10)>
+        {
+            int completedCount;
+            UniTaskCompletionSourceCore<(int, T1 result1, T2 result2, T3 result3, T4 result4, T5 result5, T6 result6, T7 result7, T8 result8, T9 result9, T10 result10)> core;
+
+            public WhenAnyPromise(UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4, UniTask<T5> task5, UniTask<T6> task6, UniTask<T7> task7, UniTask<T8> task8, UniTask<T9> task9, UniTask<T10> task10)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                this.completedCount = 0;
+                {
+                    var awaiter = task1.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT1(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>, UniTask<T1>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT1(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task2.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT2(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>, UniTask<T2>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT2(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task3.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT3(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>, UniTask<T3>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT3(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task4.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT4(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>, UniTask<T4>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT4(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task5.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT5(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>, UniTask<T5>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT5(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task6.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT6(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>, UniTask<T6>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT6(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task7.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT7(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>, UniTask<T7>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT7(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task8.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT8(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>, UniTask<T8>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT8(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task9.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT9(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>, UniTask<T9>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT9(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task10.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT10(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>, UniTask<T10>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT10(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+            }
+
+            static void TryInvokeContinuationT1(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> self, in UniTask<T1>.Awaiter awaiter)
+            {
+                T1 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((0, result, default, default, default, default, default, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT2(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> self, in UniTask<T2>.Awaiter awaiter)
+            {
+                T2 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((1, default, result, default, default, default, default, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT3(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> self, in UniTask<T3>.Awaiter awaiter)
+            {
+                T3 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((2, default, default, result, default, default, default, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT4(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> self, in UniTask<T4>.Awaiter awaiter)
+            {
+                T4 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((3, default, default, default, result, default, default, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT5(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> self, in UniTask<T5>.Awaiter awaiter)
+            {
+                T5 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((4, default, default, default, default, result, default, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT6(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> self, in UniTask<T6>.Awaiter awaiter)
+            {
+                T6 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((5, default, default, default, default, default, result, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT7(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> self, in UniTask<T7>.Awaiter awaiter)
+            {
+                T7 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((6, default, default, default, default, default, default, result, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT8(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> self, in UniTask<T8>.Awaiter awaiter)
+            {
+                T8 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((7, default, default, default, default, default, default, default, result, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT9(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> self, in UniTask<T9>.Awaiter awaiter)
+            {
+                T9 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((8, default, default, default, default, default, default, default, default, result, default));
+                }
+            }
+
+            static void TryInvokeContinuationT10(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> self, in UniTask<T10>.Awaiter awaiter)
+            {
+                T10 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((9, default, default, default, default, default, default, default, default, default, result));
+                }
+            }
+
+
+            public (int, T1 result1, T2 result2, T3 result3, T4 result4, T5 result5, T6 result6, T7 result7, T8 result8, T9 result9, T10 result10) GetResult(short token)
+            {
+                TaskTracker.RemoveTracking(this);
+                GC.SuppressFinalize(this);
+                return core.GetResult(token);
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            void IUniTaskSource.GetResult(short token)
+            {
+                GetResult(token);
+            }
+        }
+
+        public static UniTask<(int winArgumentIndex, T1 result1, T2 result2, T3 result3, T4 result4, T5 result5, T6 result6, T7 result7, T8 result8, T9 result9, T10 result10, T11 result11)> WhenAny<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4, UniTask<T5> task5, UniTask<T6> task6, UniTask<T7> task7, UniTask<T8> task8, UniTask<T9> task9, UniTask<T10> task10, UniTask<T11> task11)
+        {
+            return new UniTask<(int winArgumentIndex, T1 result1, T2 result2, T3 result3, T4 result4, T5 result5, T6 result6, T7 result7, T8 result8, T9 result9, T10 result10, T11 result11)>(new WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(task1, task2, task3, task4, task5, task6, task7, task8, task9, task10, task11), 0);
+        }
+
+        sealed class WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> : IUniTaskSource<(int, T1 result1, T2 result2, T3 result3, T4 result4, T5 result5, T6 result6, T7 result7, T8 result8, T9 result9, T10 result10, T11 result11)>
+        {
+            int completedCount;
+            UniTaskCompletionSourceCore<(int, T1 result1, T2 result2, T3 result3, T4 result4, T5 result5, T6 result6, T7 result7, T8 result8, T9 result9, T10 result10, T11 result11)> core;
+
+            public WhenAnyPromise(UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4, UniTask<T5> task5, UniTask<T6> task6, UniTask<T7> task7, UniTask<T8> task8, UniTask<T9> task9, UniTask<T10> task10, UniTask<T11> task11)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                this.completedCount = 0;
+                {
+                    var awaiter = task1.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT1(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>, UniTask<T1>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT1(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task2.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT2(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>, UniTask<T2>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT2(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task3.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT3(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>, UniTask<T3>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT3(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task4.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT4(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>, UniTask<T4>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT4(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task5.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT5(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>, UniTask<T5>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT5(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task6.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT6(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>, UniTask<T6>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT6(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task7.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT7(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>, UniTask<T7>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT7(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task8.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT8(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>, UniTask<T8>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT8(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task9.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT9(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>, UniTask<T9>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT9(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task10.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT10(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>, UniTask<T10>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT10(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task11.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT11(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>, UniTask<T11>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT11(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+            }
+
+            static void TryInvokeContinuationT1(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> self, in UniTask<T1>.Awaiter awaiter)
+            {
+                T1 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((0, result, default, default, default, default, default, default, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT2(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> self, in UniTask<T2>.Awaiter awaiter)
+            {
+                T2 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((1, default, result, default, default, default, default, default, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT3(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> self, in UniTask<T3>.Awaiter awaiter)
+            {
+                T3 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((2, default, default, result, default, default, default, default, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT4(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> self, in UniTask<T4>.Awaiter awaiter)
+            {
+                T4 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((3, default, default, default, result, default, default, default, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT5(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> self, in UniTask<T5>.Awaiter awaiter)
+            {
+                T5 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((4, default, default, default, default, result, default, default, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT6(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> self, in UniTask<T6>.Awaiter awaiter)
+            {
+                T6 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((5, default, default, default, default, default, result, default, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT7(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> self, in UniTask<T7>.Awaiter awaiter)
+            {
+                T7 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((6, default, default, default, default, default, default, result, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT8(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> self, in UniTask<T8>.Awaiter awaiter)
+            {
+                T8 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((7, default, default, default, default, default, default, default, result, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT9(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> self, in UniTask<T9>.Awaiter awaiter)
+            {
+                T9 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((8, default, default, default, default, default, default, default, default, result, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT10(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> self, in UniTask<T10>.Awaiter awaiter)
+            {
+                T10 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((9, default, default, default, default, default, default, default, default, default, result, default));
+                }
+            }
+
+            static void TryInvokeContinuationT11(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> self, in UniTask<T11>.Awaiter awaiter)
+            {
+                T11 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((10, default, default, default, default, default, default, default, default, default, default, result));
+                }
+            }
+
+
+            public (int, T1 result1, T2 result2, T3 result3, T4 result4, T5 result5, T6 result6, T7 result7, T8 result8, T9 result9, T10 result10, T11 result11) GetResult(short token)
+            {
+                TaskTracker.RemoveTracking(this);
+                GC.SuppressFinalize(this);
+                return core.GetResult(token);
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            void IUniTaskSource.GetResult(short token)
+            {
+                GetResult(token);
+            }
+        }
+
+        public static UniTask<(int winArgumentIndex, T1 result1, T2 result2, T3 result3, T4 result4, T5 result5, T6 result6, T7 result7, T8 result8, T9 result9, T10 result10, T11 result11, T12 result12)> WhenAny<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4, UniTask<T5> task5, UniTask<T6> task6, UniTask<T7> task7, UniTask<T8> task8, UniTask<T9> task9, UniTask<T10> task10, UniTask<T11> task11, UniTask<T12> task12)
+        {
+            return new UniTask<(int winArgumentIndex, T1 result1, T2 result2, T3 result3, T4 result4, T5 result5, T6 result6, T7 result7, T8 result8, T9 result9, T10 result10, T11 result11, T12 result12)>(new WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(task1, task2, task3, task4, task5, task6, task7, task8, task9, task10, task11, task12), 0);
+        }
+
+        sealed class WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> : IUniTaskSource<(int, T1 result1, T2 result2, T3 result3, T4 result4, T5 result5, T6 result6, T7 result7, T8 result8, T9 result9, T10 result10, T11 result11, T12 result12)>
+        {
+            int completedCount;
+            UniTaskCompletionSourceCore<(int, T1 result1, T2 result2, T3 result3, T4 result4, T5 result5, T6 result6, T7 result7, T8 result8, T9 result9, T10 result10, T11 result11, T12 result12)> core;
+
+            public WhenAnyPromise(UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4, UniTask<T5> task5, UniTask<T6> task6, UniTask<T7> task7, UniTask<T8> task8, UniTask<T9> task9, UniTask<T10> task10, UniTask<T11> task11, UniTask<T12> task12)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                this.completedCount = 0;
+                {
+                    var awaiter = task1.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT1(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>, UniTask<T1>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT1(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task2.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT2(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>, UniTask<T2>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT2(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task3.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT3(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>, UniTask<T3>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT3(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task4.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT4(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>, UniTask<T4>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT4(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task5.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT5(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>, UniTask<T5>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT5(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task6.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT6(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>, UniTask<T6>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT6(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task7.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT7(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>, UniTask<T7>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT7(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task8.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT8(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>, UniTask<T8>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT8(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task9.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT9(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>, UniTask<T9>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT9(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task10.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT10(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>, UniTask<T10>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT10(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task11.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT11(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>, UniTask<T11>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT11(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task12.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT12(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>, UniTask<T12>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT12(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+            }
+
+            static void TryInvokeContinuationT1(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> self, in UniTask<T1>.Awaiter awaiter)
+            {
+                T1 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((0, result, default, default, default, default, default, default, default, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT2(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> self, in UniTask<T2>.Awaiter awaiter)
+            {
+                T2 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((1, default, result, default, default, default, default, default, default, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT3(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> self, in UniTask<T3>.Awaiter awaiter)
+            {
+                T3 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((2, default, default, result, default, default, default, default, default, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT4(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> self, in UniTask<T4>.Awaiter awaiter)
+            {
+                T4 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((3, default, default, default, result, default, default, default, default, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT5(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> self, in UniTask<T5>.Awaiter awaiter)
+            {
+                T5 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((4, default, default, default, default, result, default, default, default, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT6(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> self, in UniTask<T6>.Awaiter awaiter)
+            {
+                T6 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((5, default, default, default, default, default, result, default, default, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT7(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> self, in UniTask<T7>.Awaiter awaiter)
+            {
+                T7 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((6, default, default, default, default, default, default, result, default, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT8(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> self, in UniTask<T8>.Awaiter awaiter)
+            {
+                T8 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((7, default, default, default, default, default, default, default, result, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT9(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> self, in UniTask<T9>.Awaiter awaiter)
+            {
+                T9 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((8, default, default, default, default, default, default, default, default, result, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT10(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> self, in UniTask<T10>.Awaiter awaiter)
+            {
+                T10 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((9, default, default, default, default, default, default, default, default, default, result, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT11(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> self, in UniTask<T11>.Awaiter awaiter)
+            {
+                T11 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((10, default, default, default, default, default, default, default, default, default, default, result, default));
+                }
+            }
+
+            static void TryInvokeContinuationT12(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> self, in UniTask<T12>.Awaiter awaiter)
+            {
+                T12 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((11, default, default, default, default, default, default, default, default, default, default, default, result));
+                }
+            }
+
+
+            public (int, T1 result1, T2 result2, T3 result3, T4 result4, T5 result5, T6 result6, T7 result7, T8 result8, T9 result9, T10 result10, T11 result11, T12 result12) GetResult(short token)
+            {
+                TaskTracker.RemoveTracking(this);
+                GC.SuppressFinalize(this);
+                return core.GetResult(token);
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            void IUniTaskSource.GetResult(short token)
+            {
+                GetResult(token);
+            }
+        }
+
+        public static UniTask<(int winArgumentIndex, T1 result1, T2 result2, T3 result3, T4 result4, T5 result5, T6 result6, T7 result7, T8 result8, T9 result9, T10 result10, T11 result11, T12 result12, T13 result13)> WhenAny<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4, UniTask<T5> task5, UniTask<T6> task6, UniTask<T7> task7, UniTask<T8> task8, UniTask<T9> task9, UniTask<T10> task10, UniTask<T11> task11, UniTask<T12> task12, UniTask<T13> task13)
+        {
+            return new UniTask<(int winArgumentIndex, T1 result1, T2 result2, T3 result3, T4 result4, T5 result5, T6 result6, T7 result7, T8 result8, T9 result9, T10 result10, T11 result11, T12 result12, T13 result13)>(new WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(task1, task2, task3, task4, task5, task6, task7, task8, task9, task10, task11, task12, task13), 0);
+        }
+
+        sealed class WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> : IUniTaskSource<(int, T1 result1, T2 result2, T3 result3, T4 result4, T5 result5, T6 result6, T7 result7, T8 result8, T9 result9, T10 result10, T11 result11, T12 result12, T13 result13)>
+        {
+            int completedCount;
+            UniTaskCompletionSourceCore<(int, T1 result1, T2 result2, T3 result3, T4 result4, T5 result5, T6 result6, T7 result7, T8 result8, T9 result9, T10 result10, T11 result11, T12 result12, T13 result13)> core;
+
+            public WhenAnyPromise(UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4, UniTask<T5> task5, UniTask<T6> task6, UniTask<T7> task7, UniTask<T8> task8, UniTask<T9> task9, UniTask<T10> task10, UniTask<T11> task11, UniTask<T12> task12, UniTask<T13> task13)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                this.completedCount = 0;
+                {
+                    var awaiter = task1.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT1(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>, UniTask<T1>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT1(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task2.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT2(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>, UniTask<T2>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT2(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task3.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT3(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>, UniTask<T3>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT3(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task4.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT4(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>, UniTask<T4>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT4(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task5.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT5(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>, UniTask<T5>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT5(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task6.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT6(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>, UniTask<T6>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT6(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task7.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT7(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>, UniTask<T7>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT7(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task8.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT8(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>, UniTask<T8>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT8(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task9.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT9(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>, UniTask<T9>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT9(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task10.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT10(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>, UniTask<T10>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT10(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task11.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT11(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>, UniTask<T11>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT11(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task12.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT12(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>, UniTask<T12>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT12(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task13.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT13(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>, UniTask<T13>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT13(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+            }
+
+            static void TryInvokeContinuationT1(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> self, in UniTask<T1>.Awaiter awaiter)
+            {
+                T1 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((0, result, default, default, default, default, default, default, default, default, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT2(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> self, in UniTask<T2>.Awaiter awaiter)
+            {
+                T2 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((1, default, result, default, default, default, default, default, default, default, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT3(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> self, in UniTask<T3>.Awaiter awaiter)
+            {
+                T3 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((2, default, default, result, default, default, default, default, default, default, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT4(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> self, in UniTask<T4>.Awaiter awaiter)
+            {
+                T4 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((3, default, default, default, result, default, default, default, default, default, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT5(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> self, in UniTask<T5>.Awaiter awaiter)
+            {
+                T5 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((4, default, default, default, default, result, default, default, default, default, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT6(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> self, in UniTask<T6>.Awaiter awaiter)
+            {
+                T6 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((5, default, default, default, default, default, result, default, default, default, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT7(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> self, in UniTask<T7>.Awaiter awaiter)
+            {
+                T7 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((6, default, default, default, default, default, default, result, default, default, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT8(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> self, in UniTask<T8>.Awaiter awaiter)
+            {
+                T8 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((7, default, default, default, default, default, default, default, result, default, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT9(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> self, in UniTask<T9>.Awaiter awaiter)
+            {
+                T9 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((8, default, default, default, default, default, default, default, default, result, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT10(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> self, in UniTask<T10>.Awaiter awaiter)
+            {
+                T10 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((9, default, default, default, default, default, default, default, default, default, result, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT11(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> self, in UniTask<T11>.Awaiter awaiter)
+            {
+                T11 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((10, default, default, default, default, default, default, default, default, default, default, result, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT12(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> self, in UniTask<T12>.Awaiter awaiter)
+            {
+                T12 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((11, default, default, default, default, default, default, default, default, default, default, default, result, default));
+                }
+            }
+
+            static void TryInvokeContinuationT13(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> self, in UniTask<T13>.Awaiter awaiter)
+            {
+                T13 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((12, default, default, default, default, default, default, default, default, default, default, default, default, result));
+                }
+            }
+
+
+            public (int, T1 result1, T2 result2, T3 result3, T4 result4, T5 result5, T6 result6, T7 result7, T8 result8, T9 result9, T10 result10, T11 result11, T12 result12, T13 result13) GetResult(short token)
+            {
+                TaskTracker.RemoveTracking(this);
+                GC.SuppressFinalize(this);
+                return core.GetResult(token);
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            void IUniTaskSource.GetResult(short token)
+            {
+                GetResult(token);
+            }
+        }
+
+        public static UniTask<(int winArgumentIndex, T1 result1, T2 result2, T3 result3, T4 result4, T5 result5, T6 result6, T7 result7, T8 result8, T9 result9, T10 result10, T11 result11, T12 result12, T13 result13, T14 result14)> WhenAny<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4, UniTask<T5> task5, UniTask<T6> task6, UniTask<T7> task7, UniTask<T8> task8, UniTask<T9> task9, UniTask<T10> task10, UniTask<T11> task11, UniTask<T12> task12, UniTask<T13> task13, UniTask<T14> task14)
+        {
+            return new UniTask<(int winArgumentIndex, T1 result1, T2 result2, T3 result3, T4 result4, T5 result5, T6 result6, T7 result7, T8 result8, T9 result9, T10 result10, T11 result11, T12 result12, T13 result13, T14 result14)>(new WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(task1, task2, task3, task4, task5, task6, task7, task8, task9, task10, task11, task12, task13, task14), 0);
+        }
+
+        sealed class WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> : IUniTaskSource<(int, T1 result1, T2 result2, T3 result3, T4 result4, T5 result5, T6 result6, T7 result7, T8 result8, T9 result9, T10 result10, T11 result11, T12 result12, T13 result13, T14 result14)>
+        {
+            int completedCount;
+            UniTaskCompletionSourceCore<(int, T1 result1, T2 result2, T3 result3, T4 result4, T5 result5, T6 result6, T7 result7, T8 result8, T9 result9, T10 result10, T11 result11, T12 result12, T13 result13, T14 result14)> core;
+
+            public WhenAnyPromise(UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4, UniTask<T5> task5, UniTask<T6> task6, UniTask<T7> task7, UniTask<T8> task8, UniTask<T9> task9, UniTask<T10> task10, UniTask<T11> task11, UniTask<T12> task12, UniTask<T13> task13, UniTask<T14> task14)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                this.completedCount = 0;
+                {
+                    var awaiter = task1.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT1(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>, UniTask<T1>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT1(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task2.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT2(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>, UniTask<T2>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT2(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task3.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT3(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>, UniTask<T3>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT3(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task4.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT4(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>, UniTask<T4>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT4(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task5.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT5(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>, UniTask<T5>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT5(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task6.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT6(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>, UniTask<T6>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT6(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task7.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT7(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>, UniTask<T7>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT7(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task8.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT8(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>, UniTask<T8>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT8(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task9.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT9(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>, UniTask<T9>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT9(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task10.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT10(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>, UniTask<T10>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT10(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task11.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT11(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>, UniTask<T11>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT11(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task12.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT12(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>, UniTask<T12>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT12(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task13.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT13(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>, UniTask<T13>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT13(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task14.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT14(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>, UniTask<T14>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT14(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+            }
+
+            static void TryInvokeContinuationT1(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> self, in UniTask<T1>.Awaiter awaiter)
+            {
+                T1 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((0, result, default, default, default, default, default, default, default, default, default, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT2(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> self, in UniTask<T2>.Awaiter awaiter)
+            {
+                T2 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((1, default, result, default, default, default, default, default, default, default, default, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT3(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> self, in UniTask<T3>.Awaiter awaiter)
+            {
+                T3 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((2, default, default, result, default, default, default, default, default, default, default, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT4(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> self, in UniTask<T4>.Awaiter awaiter)
+            {
+                T4 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((3, default, default, default, result, default, default, default, default, default, default, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT5(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> self, in UniTask<T5>.Awaiter awaiter)
+            {
+                T5 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((4, default, default, default, default, result, default, default, default, default, default, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT6(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> self, in UniTask<T6>.Awaiter awaiter)
+            {
+                T6 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((5, default, default, default, default, default, result, default, default, default, default, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT7(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> self, in UniTask<T7>.Awaiter awaiter)
+            {
+                T7 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((6, default, default, default, default, default, default, result, default, default, default, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT8(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> self, in UniTask<T8>.Awaiter awaiter)
+            {
+                T8 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((7, default, default, default, default, default, default, default, result, default, default, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT9(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> self, in UniTask<T9>.Awaiter awaiter)
+            {
+                T9 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((8, default, default, default, default, default, default, default, default, result, default, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT10(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> self, in UniTask<T10>.Awaiter awaiter)
+            {
+                T10 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((9, default, default, default, default, default, default, default, default, default, result, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT11(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> self, in UniTask<T11>.Awaiter awaiter)
+            {
+                T11 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((10, default, default, default, default, default, default, default, default, default, default, result, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT12(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> self, in UniTask<T12>.Awaiter awaiter)
+            {
+                T12 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((11, default, default, default, default, default, default, default, default, default, default, default, result, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT13(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> self, in UniTask<T13>.Awaiter awaiter)
+            {
+                T13 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((12, default, default, default, default, default, default, default, default, default, default, default, default, result, default));
+                }
+            }
+
+            static void TryInvokeContinuationT14(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> self, in UniTask<T14>.Awaiter awaiter)
+            {
+                T14 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((13, default, default, default, default, default, default, default, default, default, default, default, default, default, result));
+                }
+            }
+
+
+            public (int, T1 result1, T2 result2, T3 result3, T4 result4, T5 result5, T6 result6, T7 result7, T8 result8, T9 result9, T10 result10, T11 result11, T12 result12, T13 result13, T14 result14) GetResult(short token)
+            {
+                TaskTracker.RemoveTracking(this);
+                GC.SuppressFinalize(this);
+                return core.GetResult(token);
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            void IUniTaskSource.GetResult(short token)
+            {
+                GetResult(token);
+            }
+        }
+
+        public static UniTask<(int winArgumentIndex, T1 result1, T2 result2, T3 result3, T4 result4, T5 result5, T6 result6, T7 result7, T8 result8, T9 result9, T10 result10, T11 result11, T12 result12, T13 result13, T14 result14, T15 result15)> WhenAny<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4, UniTask<T5> task5, UniTask<T6> task6, UniTask<T7> task7, UniTask<T8> task8, UniTask<T9> task9, UniTask<T10> task10, UniTask<T11> task11, UniTask<T12> task12, UniTask<T13> task13, UniTask<T14> task14, UniTask<T15> task15)
+        {
+            return new UniTask<(int winArgumentIndex, T1 result1, T2 result2, T3 result3, T4 result4, T5 result5, T6 result6, T7 result7, T8 result8, T9 result9, T10 result10, T11 result11, T12 result12, T13 result13, T14 result14, T15 result15)>(new WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(task1, task2, task3, task4, task5, task6, task7, task8, task9, task10, task11, task12, task13, task14, task15), 0);
+        }
+
+        sealed class WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> : IUniTaskSource<(int, T1 result1, T2 result2, T3 result3, T4 result4, T5 result5, T6 result6, T7 result7, T8 result8, T9 result9, T10 result10, T11 result11, T12 result12, T13 result13, T14 result14, T15 result15)>
+        {
+            int completedCount;
+            UniTaskCompletionSourceCore<(int, T1 result1, T2 result2, T3 result3, T4 result4, T5 result5, T6 result6, T7 result7, T8 result8, T9 result9, T10 result10, T11 result11, T12 result12, T13 result13, T14 result14, T15 result15)> core;
+
+            public WhenAnyPromise(UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4, UniTask<T5> task5, UniTask<T6> task6, UniTask<T7> task7, UniTask<T8> task8, UniTask<T9> task9, UniTask<T10> task10, UniTask<T11> task11, UniTask<T12> task12, UniTask<T13> task13, UniTask<T14> task14, UniTask<T15> task15)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                this.completedCount = 0;
+                {
+                    var awaiter = task1.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT1(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>, UniTask<T1>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT1(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task2.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT2(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>, UniTask<T2>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT2(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task3.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT3(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>, UniTask<T3>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT3(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task4.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT4(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>, UniTask<T4>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT4(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task5.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT5(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>, UniTask<T5>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT5(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task6.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT6(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>, UniTask<T6>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT6(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task7.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT7(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>, UniTask<T7>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT7(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task8.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT8(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>, UniTask<T8>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT8(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task9.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT9(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>, UniTask<T9>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT9(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task10.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT10(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>, UniTask<T10>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT10(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task11.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT11(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>, UniTask<T11>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT11(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task12.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT12(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>, UniTask<T12>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT12(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task13.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT13(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>, UniTask<T13>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT13(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task14.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT14(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>, UniTask<T14>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT14(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                {
+                    var awaiter = task15.GetAwaiter();
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuationT15(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>, UniTask<T15>.Awaiter>)state)
+                            {
+                                TryInvokeContinuationT15(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+            }
+
+            static void TryInvokeContinuationT1(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> self, in UniTask<T1>.Awaiter awaiter)
+            {
+                T1 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((0, result, default, default, default, default, default, default, default, default, default, default, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT2(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> self, in UniTask<T2>.Awaiter awaiter)
+            {
+                T2 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((1, default, result, default, default, default, default, default, default, default, default, default, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT3(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> self, in UniTask<T3>.Awaiter awaiter)
+            {
+                T3 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((2, default, default, result, default, default, default, default, default, default, default, default, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT4(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> self, in UniTask<T4>.Awaiter awaiter)
+            {
+                T4 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((3, default, default, default, result, default, default, default, default, default, default, default, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT5(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> self, in UniTask<T5>.Awaiter awaiter)
+            {
+                T5 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((4, default, default, default, default, result, default, default, default, default, default, default, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT6(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> self, in UniTask<T6>.Awaiter awaiter)
+            {
+                T6 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((5, default, default, default, default, default, result, default, default, default, default, default, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT7(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> self, in UniTask<T7>.Awaiter awaiter)
+            {
+                T7 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((6, default, default, default, default, default, default, result, default, default, default, default, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT8(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> self, in UniTask<T8>.Awaiter awaiter)
+            {
+                T8 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((7, default, default, default, default, default, default, default, result, default, default, default, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT9(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> self, in UniTask<T9>.Awaiter awaiter)
+            {
+                T9 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((8, default, default, default, default, default, default, default, default, result, default, default, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT10(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> self, in UniTask<T10>.Awaiter awaiter)
+            {
+                T10 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((9, default, default, default, default, default, default, default, default, default, result, default, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT11(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> self, in UniTask<T11>.Awaiter awaiter)
+            {
+                T11 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((10, default, default, default, default, default, default, default, default, default, default, result, default, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT12(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> self, in UniTask<T12>.Awaiter awaiter)
+            {
+                T12 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((11, default, default, default, default, default, default, default, default, default, default, default, result, default, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT13(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> self, in UniTask<T13>.Awaiter awaiter)
+            {
+                T13 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((12, default, default, default, default, default, default, default, default, default, default, default, default, result, default, default));
+                }
+            }
+
+            static void TryInvokeContinuationT14(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> self, in UniTask<T14>.Awaiter awaiter)
+            {
+                T14 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((13, default, default, default, default, default, default, default, default, default, default, default, default, default, result, default));
+                }
+            }
+
+            static void TryInvokeContinuationT15(WhenAnyPromise<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> self, in UniTask<T15>.Awaiter awaiter)
+            {
+                T15 result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((14, default, default, default, default, default, default, default, default, default, default, default, default, default, default, result));
+                }
+            }
+
+
+            public (int, T1 result1, T2 result2, T3 result3, T4 result4, T5 result5, T6 result6, T7 result7, T8 result8, T9 result9, T10 result10, T11 result11, T12 result12, T13 result13, T14 result14, T15 result15) GetResult(short token)
+            {
+                TaskTracker.RemoveTracking(this);
+                GC.SuppressFinalize(this);
+                return core.GetResult(token);
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            void IUniTaskSource.GetResult(short token)
+            {
+                GetResult(token);
+            }
+        }
+
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/UniTask.WhenAny.Generated.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/UniTask.WhenAny.Generated.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 13d604ac281570c4eac9962429f19ca9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/UniTask.WhenAny.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/UniTask.WhenAny.cs
@@ -1,0 +1,359 @@
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Cysharp.Threading.Tasks.Internal;
+
+namespace Cysharp.Threading.Tasks
+{
+    public partial struct UniTask
+    {
+        public static UniTask<(bool hasResultLeft, T result)> WhenAny<T>(UniTask<T> leftTask, UniTask rightTask)
+        {
+            return new UniTask<(bool, T)>(new WhenAnyLRPromise<T>(leftTask, rightTask), 0);
+        }
+
+        public static UniTask<(int winArgumentIndex, T result)> WhenAny<T>(params UniTask<T>[] tasks)
+        {
+            return new UniTask<(int, T)>(new WhenAnyPromise<T>(tasks, tasks.Length), 0);
+        }
+
+        public static UniTask<(int winArgumentIndex, T result)> WhenAny<T>(IEnumerable<UniTask<T>> tasks)
+        {
+            using (var span = ArrayPoolUtil.Materialize(tasks))
+            {
+                return new UniTask<(int, T)>(new WhenAnyPromise<T>(span.Array, span.Length), 0);
+            }
+        }
+
+        /// <summary>Return value is winArgumentIndex</summary>
+        public static UniTask<int> WhenAny(params UniTask[] tasks)
+        {
+            return new UniTask<int>(new WhenAnyPromise(tasks, tasks.Length), 0);
+        }
+
+        /// <summary>Return value is winArgumentIndex</summary>
+        public static UniTask<int> WhenAny(IEnumerable<UniTask> tasks)
+        {
+            using (var span = ArrayPoolUtil.Materialize(tasks))
+            {
+                return new UniTask<int>(new WhenAnyPromise(span.Array, span.Length), 0);
+            }
+        }
+
+        sealed class WhenAnyLRPromise<T> : IUniTaskSource<(bool, T)>
+        {
+            int completedCount;
+            UniTaskCompletionSourceCore<(bool, T)> core;
+
+            public WhenAnyLRPromise(UniTask<T> leftTask, UniTask rightTask)
+            {
+                TaskTracker.TrackActiveTask(this, 3);
+
+                {
+                    UniTask<T>.Awaiter awaiter;
+                    try
+                    {
+                        awaiter = leftTask.GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        core.TrySetException(ex);
+                        goto RIGHT;
+                    }
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryLeftInvokeContinuation(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyLRPromise<T>, UniTask<T>.Awaiter>)state)
+                            {
+                                TryLeftInvokeContinuation(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+                RIGHT:
+                {
+                    UniTask.Awaiter awaiter;
+                    try
+                    {
+                        awaiter = rightTask.GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        core.TrySetException(ex);
+                        return;
+                    }
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryRightInvokeContinuation(this, awaiter);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyLRPromise<T>, UniTask.Awaiter>)state)
+                            {
+                                TryRightInvokeContinuation(t.Item1, t.Item2);
+                            }
+                        }, StateTuple.Create(this, awaiter));
+                    }
+                }
+            }
+
+            static void TryLeftInvokeContinuation(WhenAnyLRPromise<T> self, in UniTask<T>.Awaiter awaiter)
+            {
+                T result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((true, result));
+                }
+            }
+
+            static void TryRightInvokeContinuation(WhenAnyLRPromise<T> self, in UniTask.Awaiter awaiter)
+            {
+                try
+                {
+                    awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((false, default));
+                }
+            }
+
+            public (bool, T) GetResult(short token)
+            {
+                TaskTracker.RemoveTracking(this);
+                GC.SuppressFinalize(this);
+                return core.GetResult(token);
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            void IUniTaskSource.GetResult(short token)
+            {
+                GetResult(token);
+            }
+        }
+
+
+        sealed class WhenAnyPromise<T> : IUniTaskSource<(int, T)>
+        {
+            int completedCount;
+            UniTaskCompletionSourceCore<(int, T)> core;
+
+            public WhenAnyPromise(UniTask<T>[] tasks, int tasksLength)
+            {
+                if (tasksLength == 0)
+                {
+                    throw new ArgumentException("The tasks argument contains no tasks.");
+                }
+
+                TaskTracker.TrackActiveTask(this, 3);
+
+                for (int i = 0; i < tasksLength; i++)
+                {
+                    UniTask<T>.Awaiter awaiter;
+                    try
+                    {
+                        awaiter = tasks[i].GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        core.TrySetException(ex);
+                        continue; // consume others.
+                    }
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuation(this, awaiter, i);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise<T>, UniTask<T>.Awaiter, int>)state)
+                            {
+                                TryInvokeContinuation(t.Item1, t.Item2, t.Item3);
+                            }
+                        }, StateTuple.Create(this, awaiter, i));
+                    }
+                }
+            }
+
+            static void TryInvokeContinuation(WhenAnyPromise<T> self, in UniTask<T>.Awaiter awaiter, int i)
+            {
+                T result;
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult((i, result));
+                }
+            }
+
+            public (int, T) GetResult(short token)
+            {
+                TaskTracker.RemoveTracking(this);
+                GC.SuppressFinalize(this);
+                return core.GetResult(token);
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            void IUniTaskSource.GetResult(short token)
+            {
+                GetResult(token);
+            }
+        }
+
+        sealed class WhenAnyPromise : IUniTaskSource<int>
+        {
+            int completedCount;
+            UniTaskCompletionSourceCore<int> core;
+
+            public WhenAnyPromise(UniTask[] tasks, int tasksLength)
+            {
+                if (tasksLength == 0)
+                {
+                    throw new ArgumentException("The tasks argument contains no tasks.");
+                }
+
+                TaskTracker.TrackActiveTask(this, 3);
+
+                for (int i = 0; i < tasksLength; i++)
+                {
+                    UniTask.Awaiter awaiter;
+                    try
+                    {
+                        awaiter = tasks[i].GetAwaiter();
+                    }
+                    catch (Exception ex)
+                    {
+                        core.TrySetException(ex);
+                        continue; // consume others.
+                    }
+
+                    if (awaiter.IsCompleted)
+                    {
+                        TryInvokeContinuation(this, awaiter, i);
+                    }
+                    else
+                    {
+                        awaiter.SourceOnCompleted(state =>
+                        {
+                            using (var t = (StateTuple<WhenAnyPromise, UniTask.Awaiter, int>)state)
+                            {
+                                TryInvokeContinuation(t.Item1, t.Item2, t.Item3);
+                            }
+                        }, StateTuple.Create(this, awaiter, i));
+                    }
+                }
+            }
+
+            static void TryInvokeContinuation(WhenAnyPromise self, in UniTask.Awaiter awaiter, int i)
+            {
+                try
+                {
+                    awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    self.core.TrySetException(ex);
+                    return;
+                }
+
+                if (Interlocked.Increment(ref self.completedCount) == 1)
+                {
+                    self.core.TrySetResult(i);
+                }
+            }
+
+            public int GetResult(short token)
+            {
+                TaskTracker.RemoveTracking(this);
+                GC.SuppressFinalize(this);
+                return core.GetResult(token);
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            void IUniTaskSource.GetResult(short token)
+            {
+                GetResult(token);
+            }
+        }
+    }
+}
+

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/UniTask.WhenAny.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/UniTask.WhenAny.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c32578978c37eaf41bdd90e1b034637d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/UniTask.asmdef
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/UniTask.asmdef
@@ -1,0 +1,45 @@
+{
+    "name": "UniTask",
+    "rootNamespace": "",
+    "references": [],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.modules.assetbundle",
+            "expression": "",
+            "define": "UNITASK_ASSETBUNDLE_SUPPORT"
+        },
+        {
+            "name": "com.unity.modules.physics",
+            "expression": "",
+            "define": "UNITASK_PHYSICS_SUPPORT"
+        },
+        {
+            "name": "com.unity.modules.physics2d",
+            "expression": "",
+            "define": "UNITASK_PHYSICS2D_SUPPORT"
+        },
+        {
+            "name": "com.unity.modules.particlesystem",
+            "expression": "",
+            "define": "UNITASK_PARTICLESYSTEM_SUPPORT"
+        },
+        {
+            "name": "com.unity.ugui",
+            "expression": "",
+            "define": "UNITASK_UGUI_SUPPORT"
+        },
+        {
+            "name": "com.unity.modules.unitywebrequest",
+            "expression": "",
+            "define": "UNITASK_WEBREQUEST_SUPPORT"
+        }
+    ],
+    "noEngineReferences": false
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/UniTask.asmdef.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/UniTask.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f51ebe6a0ceec4240a699833d6309b23
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/UniTask.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/UniTask.cs
@@ -1,0 +1,707 @@
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+#pragma warning disable CS0436
+
+using Cysharp.Threading.Tasks.CompilerServices;
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.ExceptionServices;
+using System.Runtime.InteropServices;
+
+namespace Cysharp.Threading.Tasks
+{
+    internal static class AwaiterActions
+    {
+        internal static readonly Action<object> InvokeContinuationDelegate = Continuation;
+
+        [DebuggerHidden]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static void Continuation(object state)
+        {
+            ((Action)state).Invoke();
+        }
+    }
+
+    /// <summary>
+    /// Lightweight unity specified task-like object.
+    /// </summary>
+    [AsyncMethodBuilder(typeof(AsyncUniTaskMethodBuilder))]
+    [StructLayout(LayoutKind.Auto)]
+    public readonly partial struct UniTask
+    {
+        readonly IUniTaskSource source;
+        readonly short token;
+
+        [DebuggerHidden]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public UniTask(IUniTaskSource source, short token)
+        {
+            this.source = source;
+            this.token = token;
+        }
+
+        public UniTaskStatus Status
+        {
+            [DebuggerHidden]
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                if (source == null) return UniTaskStatus.Succeeded;
+                return source.GetStatus(token);
+            }
+        }
+
+        [DebuggerHidden]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Awaiter GetAwaiter()
+        {
+            return new Awaiter(this);
+        }
+
+        /// <summary>
+        /// returns (bool IsCanceled) instead of throws OperationCanceledException.
+        /// </summary>
+        public UniTask<bool> SuppressCancellationThrow()
+        {
+            var status = Status;
+            if (status == UniTaskStatus.Succeeded) return CompletedTasks.False;
+            if (status == UniTaskStatus.Canceled) return CompletedTasks.True;
+            return new UniTask<bool>(new IsCanceledSource(source), token);
+        }
+
+#if !UNITY_2018_3_OR_NEWER
+
+        public static implicit operator System.Threading.Tasks.ValueTask(in UniTask self)
+        {
+            if (self.source == null)
+            {
+                return default;
+            }
+
+#if NETSTANDARD2_0
+            return self.AsValueTask();
+#else
+            return new System.Threading.Tasks.ValueTask(self.source, self.token);
+#endif
+        }
+
+#endif
+
+        public override string ToString()
+        {
+            if (source == null) return "()";
+            return "(" + source.UnsafeGetStatus() + ")";
+        }
+
+        /// <summary>
+        /// Memoizing inner IValueTaskSource. The result UniTask can await multiple.
+        /// </summary>
+        public UniTask Preserve()
+        {
+            if (source == null)
+            {
+                return this;
+            }
+            else
+            {
+                return new UniTask(new MemoizeSource(source), token);
+            }
+        }
+
+        public UniTask<AsyncUnit> AsAsyncUnitUniTask()
+        {
+            if (this.source == null) return CompletedTasks.AsyncUnit;
+
+            var status = this.source.GetStatus(this.token);
+            if (status.IsCompletedSuccessfully())
+            {
+                this.source.GetResult(this.token);
+                return CompletedTasks.AsyncUnit;
+            }
+            else if(this.source is IUniTaskSource<AsyncUnit> asyncUnitSource)
+            {
+                return new UniTask<AsyncUnit>(asyncUnitSource, this.token);
+            }
+
+            return new UniTask<AsyncUnit>(new AsyncUnitSource(this.source), this.token);
+        }
+
+        sealed class AsyncUnitSource : IUniTaskSource<AsyncUnit>
+        {
+            readonly IUniTaskSource source;
+
+            public AsyncUnitSource(IUniTaskSource source)
+            {
+                this.source = source;
+            }
+
+            public AsyncUnit GetResult(short token)
+            {
+                source.GetResult(token);
+                return AsyncUnit.Default;
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return source.GetStatus(token);
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                source.OnCompleted(continuation, state, token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return source.UnsafeGetStatus();
+            }
+
+            void IUniTaskSource.GetResult(short token)
+            {
+                GetResult(token);
+            }
+        }
+
+        sealed class IsCanceledSource : IUniTaskSource<bool>
+        {
+            readonly IUniTaskSource source;
+
+            public IsCanceledSource(IUniTaskSource source)
+            {
+                this.source = source;
+            }
+
+            public bool GetResult(short token)
+            {
+                if (source.GetStatus(token) == UniTaskStatus.Canceled)
+                {
+                    return true;
+                }
+
+                source.GetResult(token);
+                return false;
+            }
+
+            void IUniTaskSource.GetResult(short token)
+            {
+                GetResult(token);
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return source.GetStatus(token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return source.UnsafeGetStatus();
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                source.OnCompleted(continuation, state, token);
+            }
+        }
+
+        sealed class MemoizeSource : IUniTaskSource
+        {
+            IUniTaskSource source;
+            ExceptionDispatchInfo exception;
+            UniTaskStatus status;
+
+            public MemoizeSource(IUniTaskSource source)
+            {
+                this.source = source;
+            }
+
+            public void GetResult(short token)
+            {
+                if (source == null)
+                {
+                    if (exception != null)
+                    {
+                        exception.Throw();
+                    }
+                }
+                else
+                {
+                    try
+                    {
+                        source.GetResult(token);
+                        status = UniTaskStatus.Succeeded;
+                    }
+                    catch (Exception ex)
+                    {
+                        exception = ExceptionDispatchInfo.Capture(ex);
+                        if (ex is OperationCanceledException)
+                        {
+                            status = UniTaskStatus.Canceled;
+                        }
+                        else
+                        {
+                            status = UniTaskStatus.Faulted;
+                        }
+                        throw;
+                    }
+                    finally
+                    {
+                        source = null;
+                    }
+                }
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                if (source == null)
+                {
+                    return status;
+                }
+
+                return source.GetStatus(token);
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                if (source == null)
+                {
+                    continuation(state);
+                }
+                else
+                {
+                    source.OnCompleted(continuation, state, token);
+                }
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                if (source == null)
+                {
+                    return status;
+                }
+
+                return source.UnsafeGetStatus();
+            }
+        }
+
+        public readonly struct Awaiter : ICriticalNotifyCompletion
+        {
+            readonly UniTask task;
+
+            [DebuggerHidden]
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public Awaiter(in UniTask task)
+            {
+                this.task = task;
+            }
+
+            public bool IsCompleted
+            {
+                [DebuggerHidden]
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                get
+                {
+                    return task.Status.IsCompleted();
+                }
+            }
+
+            [DebuggerHidden]
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public void GetResult()
+            {
+                if (task.source == null) return;
+                task.source.GetResult(task.token);
+            }
+
+            [DebuggerHidden]
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public void OnCompleted(Action continuation)
+            {
+                if (task.source == null)
+                {
+                    continuation();
+                }
+                else
+                {
+                    task.source.OnCompleted(AwaiterActions.InvokeContinuationDelegate, continuation, task.token);
+                }
+            }
+
+            [DebuggerHidden]
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public void UnsafeOnCompleted(Action continuation)
+            {
+                if (task.source == null)
+                {
+                    continuation();
+                }
+                else
+                {
+                    task.source.OnCompleted(AwaiterActions.InvokeContinuationDelegate, continuation, task.token);
+                }
+            }
+
+            /// <summary>
+            /// If register manually continuation, you can use it instead of for compiler OnCompleted methods.
+            /// </summary>
+            [DebuggerHidden]
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public void SourceOnCompleted(Action<object> continuation, object state)
+            {
+                if (task.source == null)
+                {
+                    continuation(state);
+                }
+                else
+                {
+                    task.source.OnCompleted(continuation, state, task.token);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Lightweight unity specified task-like object.
+    /// </summary>
+    [AsyncMethodBuilder(typeof(AsyncUniTaskMethodBuilder<>))]
+    [StructLayout(LayoutKind.Auto)]
+    public readonly struct UniTask<T>
+    {
+        readonly IUniTaskSource<T> source;
+        readonly T result;
+        readonly short token;
+
+        [DebuggerHidden]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public UniTask(T result)
+        {
+            this.source = default;
+            this.token = default;
+            this.result = result;
+        }
+
+        [DebuggerHidden]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public UniTask(IUniTaskSource<T> source, short token)
+        {
+            this.source = source;
+            this.token = token;
+            this.result = default;
+        }
+
+        public UniTaskStatus Status
+        {
+            [DebuggerHidden]
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                return (source == null) ? UniTaskStatus.Succeeded : source.GetStatus(token);
+            }
+        }
+
+        [DebuggerHidden]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Awaiter GetAwaiter()
+        {
+            return new Awaiter(this);
+        }
+
+        /// <summary>
+        /// Memoizing inner IValueTaskSource. The result UniTask can await multiple.
+        /// </summary>
+        public UniTask<T> Preserve()
+        {
+            if (source == null)
+            {
+                return this;
+            }
+            else
+            {
+                return new UniTask<T>(new MemoizeSource(source), token);
+            }
+        }
+
+        public UniTask AsUniTask()
+        {
+            if (this.source == null) return UniTask.CompletedTask;
+
+            var status = this.source.GetStatus(this.token);
+            if (status.IsCompletedSuccessfully())
+            {
+                this.source.GetResult(this.token);
+                return UniTask.CompletedTask;
+            }
+
+            // Converting UniTask<T> -> UniTask is zero overhead.
+            return new UniTask(this.source, this.token);
+        }
+
+        public static implicit operator UniTask(UniTask<T> self)
+        {
+            return self.AsUniTask();
+        }
+
+#if !UNITY_2018_3_OR_NEWER
+
+        public static implicit operator System.Threading.Tasks.ValueTask<T>(in UniTask<T> self)
+        {
+            if (self.source == null)
+            {
+                return new System.Threading.Tasks.ValueTask<T>(self.result);
+            }
+
+#if NETSTANDARD2_0
+            return self.AsValueTask();
+#else
+            return new System.Threading.Tasks.ValueTask<T>(self.source, self.token);
+#endif
+        }
+
+#endif
+
+        /// <summary>
+        /// returns (bool IsCanceled, T Result) instead of throws OperationCanceledException.
+        /// </summary>
+        public UniTask<(bool IsCanceled, T Result)> SuppressCancellationThrow()
+        {
+            if (source == null)
+            {
+                return new UniTask<(bool IsCanceled, T Result)>((false, result));
+            }
+
+            return new UniTask<(bool, T)>(new IsCanceledSource(source), token);
+        }
+
+        public override string ToString()
+        {
+            return (this.source == null) ? result?.ToString()
+                 : "(" + this.source.UnsafeGetStatus() + ")";
+        }
+
+        sealed class IsCanceledSource : IUniTaskSource<(bool, T)>
+        {
+            readonly IUniTaskSource<T> source;
+
+            [DebuggerHidden]
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public IsCanceledSource(IUniTaskSource<T> source)
+            {
+                this.source = source;
+            }
+
+            [DebuggerHidden]
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public (bool, T) GetResult(short token)
+            {
+                if (source.GetStatus(token) == UniTaskStatus.Canceled)
+                {
+                    return (true, default);
+                }
+
+                var result = source.GetResult(token);
+                return (false, result);
+            }
+
+            [DebuggerHidden]
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            void IUniTaskSource.GetResult(short token)
+            {
+                GetResult(token);
+            }
+
+            [DebuggerHidden]
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public UniTaskStatus GetStatus(short token)
+            {
+                return source.GetStatus(token);
+            }
+
+            [DebuggerHidden]
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return source.UnsafeGetStatus();
+            }
+
+            [DebuggerHidden]
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                source.OnCompleted(continuation, state, token);
+            }
+        }
+
+        sealed class MemoizeSource : IUniTaskSource<T>
+        {
+            IUniTaskSource<T> source;
+            T result;
+            ExceptionDispatchInfo exception;
+            UniTaskStatus status;
+
+            public MemoizeSource(IUniTaskSource<T> source)
+            {
+                this.source = source;
+            }
+
+            public T GetResult(short token)
+            {
+                if (source == null)
+                {
+                    if (exception != null)
+                    {
+                        exception.Throw();
+                    }
+                    return result;
+                }
+                else
+                {
+                    try
+                    {
+                        result = source.GetResult(token);
+                        status = UniTaskStatus.Succeeded;
+                        return result;
+                    }
+                    catch (Exception ex)
+                    {
+                        exception = ExceptionDispatchInfo.Capture(ex);
+                        if (ex is OperationCanceledException)
+                        {
+                            status = UniTaskStatus.Canceled;
+                        }
+                        else
+                        {
+                            status = UniTaskStatus.Faulted;
+                        }
+                        throw;
+                    }
+                    finally
+                    {
+                        source = null;
+                    }
+                }
+            }
+
+            void IUniTaskSource.GetResult(short token)
+            {
+                GetResult(token);
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                if (source == null)
+                {
+                    return status;
+                }
+
+                return source.GetStatus(token);
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                if (source == null)
+                {
+                    continuation(state);
+                }
+                else
+                {
+                    source.OnCompleted(continuation, state, token);
+                }
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                if (source == null)
+                {
+                    return status;
+                }
+
+                return source.UnsafeGetStatus();
+            }
+        }
+
+        public readonly struct Awaiter : ICriticalNotifyCompletion
+        {
+            readonly UniTask<T> task;
+
+            [DebuggerHidden]
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public Awaiter(in UniTask<T> task)
+            {
+                this.task = task;
+            }
+
+            public bool IsCompleted
+            {
+                [DebuggerHidden]
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                get
+                {
+                    return task.Status.IsCompleted();
+                }
+            }
+
+            [DebuggerHidden]
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public T GetResult()
+            {
+                var s = task.source;
+                if (s == null)
+                {
+                    return task.result;
+                }
+                else
+                {
+                    return s.GetResult(task.token);
+                }
+            }
+
+            [DebuggerHidden]
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public void OnCompleted(Action continuation)
+            {
+                var s = task.source;
+                if (s == null)
+                {
+                    continuation();
+                }
+                else
+                {
+                    s.OnCompleted(AwaiterActions.InvokeContinuationDelegate, continuation, task.token);
+                }
+            }
+
+            [DebuggerHidden]
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public void UnsafeOnCompleted(Action continuation)
+            {
+                var s = task.source;
+                if (s == null)
+                {
+                    continuation();
+                }
+                else
+                {
+                    s.OnCompleted(AwaiterActions.InvokeContinuationDelegate, continuation, task.token);
+                }
+            }
+
+            /// <summary>
+            /// If register manually continuation, you can use it instead of for compiler OnCompleted methods.
+            /// </summary>
+            [DebuggerHidden]
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public void SourceOnCompleted(Action<object> continuation, object state)
+            {
+                var s = task.source;
+                if (s == null)
+                {
+                    continuation(state);
+                }
+                else
+                {
+                    s.OnCompleted(continuation, state, task.token);
+                }
+            }
+        }
+    }
+}
+

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/UniTask.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/UniTask.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8947adf23181ff04db73829df217ca94
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/UniTaskCompletionSource.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/UniTaskCompletionSource.cs
@@ -1,0 +1,941 @@
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.ExceptionServices;
+using System.Runtime.InteropServices;
+using System.Threading;
+using Cysharp.Threading.Tasks.Internal;
+
+namespace Cysharp.Threading.Tasks
+{
+    public interface IResolvePromise
+    {
+        bool TrySetResult();
+    }
+
+    public interface IResolvePromise<T>
+    {
+        bool TrySetResult(T value);
+    }
+
+    public interface IRejectPromise
+    {
+        bool TrySetException(Exception exception);
+    }
+
+    public interface ICancelPromise
+    {
+        bool TrySetCanceled(CancellationToken cancellationToken = default);
+    }
+
+    public interface IPromise<T> : IResolvePromise<T>, IRejectPromise, ICancelPromise
+    {
+    }
+
+    public interface IPromise : IResolvePromise, IRejectPromise, ICancelPromise
+    {
+    }
+
+    internal class ExceptionHolder
+    {
+        ExceptionDispatchInfo exception;
+        bool calledGet = false;
+
+        public ExceptionHolder(ExceptionDispatchInfo exception)
+        {
+            this.exception = exception;
+        }
+
+        public ExceptionDispatchInfo GetException()
+        {
+            if (!calledGet)
+            {
+                calledGet = true;
+                GC.SuppressFinalize(this);
+            }
+            return exception;
+        }
+
+        ~ExceptionHolder()
+        {
+            if (!calledGet)
+            {
+                UniTaskScheduler.PublishUnobservedTaskException(exception.SourceException);
+            }
+        }
+    }
+
+    [StructLayout(LayoutKind.Auto)]
+    public struct UniTaskCompletionSourceCore<TResult>
+    {
+        // Struct Size: TResult + (8 + 2 + 1 + 1 + 8 + 8)
+
+        TResult result;
+        object error; // ExceptionHolder or OperationCanceledException
+        short version;
+        bool hasUnhandledError;
+        int completedCount; // 0: completed == false
+        Action<object> continuation;
+        object continuationState;
+
+        [DebuggerHidden]
+        public void Reset()
+        {
+            ReportUnhandledError();
+
+            unchecked
+            {
+                version += 1; // incr version.
+            }
+            completedCount = 0;
+            result = default;
+            error = null;
+            hasUnhandledError = false;
+            continuation = null;
+            continuationState = null;
+        }
+
+        void ReportUnhandledError()
+        {
+            if (hasUnhandledError)
+            {
+                try
+                {
+                    if (error is OperationCanceledException oc)
+                    {
+                        UniTaskScheduler.PublishUnobservedTaskException(oc);
+                    }
+                    else if (error is ExceptionHolder e)
+                    {
+                        UniTaskScheduler.PublishUnobservedTaskException(e.GetException().SourceException);
+                    }
+                }
+                catch
+                {
+                }
+            }
+        }
+
+        internal void MarkHandled()
+        {
+            hasUnhandledError = false;
+        }
+
+        /// <summary>Completes with a successful result.</summary>
+        /// <param name="result">The result.</param>
+        [DebuggerHidden]
+        public bool TrySetResult(TResult result)
+        {
+            if (Interlocked.Increment(ref completedCount) == 1)
+            {
+                // setup result
+                this.result = result;
+
+                if (continuation != null || Interlocked.CompareExchange(ref this.continuation, UniTaskCompletionSourceCoreShared.s_sentinel, null) != null)
+                {
+                    continuation(continuationState);
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>Completes with an error.</summary>
+        /// <param name="error">The exception.</param>
+        [DebuggerHidden]
+        public bool TrySetException(Exception error)
+        {
+            if (Interlocked.Increment(ref completedCount) == 1)
+            {
+                // setup result
+                this.hasUnhandledError = true;
+                if (error is OperationCanceledException)
+                {
+                    this.error = error;
+                }
+                else
+                {
+                    this.error = new ExceptionHolder(ExceptionDispatchInfo.Capture(error));
+                }
+
+                if (continuation != null || Interlocked.CompareExchange(ref this.continuation, UniTaskCompletionSourceCoreShared.s_sentinel, null) != null)
+                {
+                    continuation(continuationState);
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        [DebuggerHidden]
+        public bool TrySetCanceled(CancellationToken cancellationToken = default)
+        {
+            if (Interlocked.Increment(ref completedCount) == 1)
+            {
+                // setup result
+                this.hasUnhandledError = true;
+                this.error = new OperationCanceledException(cancellationToken);
+
+                if (continuation != null || Interlocked.CompareExchange(ref this.continuation, UniTaskCompletionSourceCoreShared.s_sentinel, null) != null)
+                {
+                    continuation(continuationState);
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>Gets the operation version.</summary>
+        [DebuggerHidden]
+        public short Version => version;
+
+        /// <summary>Gets the status of the operation.</summary>
+        /// <param name="token">Opaque value that was provided to the <see cref="UniTask"/>'s constructor.</param>
+        [DebuggerHidden]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public UniTaskStatus GetStatus(short token)
+        {
+            ValidateToken(token);
+            return (continuation == null || (completedCount == 0)) ? UniTaskStatus.Pending
+                 : (error == null) ? UniTaskStatus.Succeeded
+                 : (error is OperationCanceledException) ? UniTaskStatus.Canceled
+                 : UniTaskStatus.Faulted;
+        }
+
+        /// <summary>Gets the status of the operation without token validation.</summary>
+        [DebuggerHidden]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public UniTaskStatus UnsafeGetStatus()
+        {
+            return (continuation == null || (completedCount == 0)) ? UniTaskStatus.Pending
+                 : (error == null) ? UniTaskStatus.Succeeded
+                 : (error is OperationCanceledException) ? UniTaskStatus.Canceled
+                 : UniTaskStatus.Faulted;
+        }
+
+        /// <summary>Gets the result of the operation.</summary>
+        /// <param name="token">Opaque value that was provided to the <see cref="UniTask"/>'s constructor.</param>
+        // [StackTraceHidden]
+        [DebuggerHidden]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public TResult GetResult(short token)
+        {
+            ValidateToken(token);
+            if (completedCount == 0)
+            {
+                throw new InvalidOperationException("Not yet completed, UniTask only allow to use await.");
+            }
+
+            if (error != null)
+            {
+                hasUnhandledError = false;
+                if (error is OperationCanceledException oce)
+                {
+                    throw oce;
+                }
+                else if (error is ExceptionHolder eh)
+                {
+                    eh.GetException().Throw();
+                }
+
+                throw new InvalidOperationException("Critical: invalid exception type was held.");
+            }
+
+            return result;
+        }
+
+        /// <summary>Schedules the continuation action for this operation.</summary>
+        /// <param name="continuation">The continuation to invoke when the operation has completed.</param>
+        /// <param name="state">The state object to pass to <paramref name="continuation"/> when it's invoked.</param>
+        /// <param name="token">Opaque value that was provided to the <see cref="UniTask"/>'s constructor.</param>
+        [DebuggerHidden]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void OnCompleted(Action<object> continuation, object state, short token /*, ValueTaskSourceOnCompletedFlags flags */)
+        {
+            if (continuation == null)
+            {
+                throw new ArgumentNullException(nameof(continuation));
+            }
+            ValidateToken(token);
+
+            /* no use ValueTaskSourceOnCOmpletedFlags, always no capture ExecutionContext and SynchronizationContext. */
+
+            /*
+                PatternA: GetStatus=Pending => OnCompleted => TrySet*** => GetResult
+                PatternB: TrySet*** => GetStatus=!Pending => GetResult
+                PatternC: GetStatus=Pending => TrySet/OnCompleted(race condition) => GetResult
+                C.1: win OnCompleted -> TrySet invoke saved continuation
+                C.2: win TrySet -> should invoke continuation here.
+            */
+
+            // not set continuation yet.
+            object oldContinuation = this.continuation;
+            if (oldContinuation == null)
+            {
+                continuationState = state;
+                oldContinuation = Interlocked.CompareExchange(ref this.continuation, continuation, null);
+            }
+
+            if (oldContinuation != null)
+            {
+                // already running continuation in TrySet.
+                // It will cause call OnCompleted multiple time, invalid.
+                if (!ReferenceEquals(oldContinuation, UniTaskCompletionSourceCoreShared.s_sentinel))
+                {
+                    throw new InvalidOperationException("Already continuation registered, can not await twice or get Status after await.");
+                }
+
+                continuation(state);
+            }
+        }
+
+        [DebuggerHidden]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void ValidateToken(short token)
+        {
+            if (token != version)
+            {
+                throw new InvalidOperationException("Token version is not matched, can not await twice or get Status after await.");
+            }
+        }
+    }
+
+    internal static class UniTaskCompletionSourceCoreShared // separated out of generic to avoid unnecessary duplication
+    {
+        internal static readonly Action<object> s_sentinel = CompletionSentinel;
+
+        private static void CompletionSentinel(object _) // named method to aid debugging
+        {
+            throw new InvalidOperationException("The sentinel delegate should never be invoked.");
+        }
+    }
+
+    public class AutoResetUniTaskCompletionSource : IUniTaskSource, ITaskPoolNode<AutoResetUniTaskCompletionSource>, IPromise
+    {
+        static TaskPool<AutoResetUniTaskCompletionSource> pool;
+        AutoResetUniTaskCompletionSource nextNode;
+        public ref AutoResetUniTaskCompletionSource NextNode => ref nextNode;
+
+        static AutoResetUniTaskCompletionSource()
+        {
+            TaskPool.RegisterSizeGetter(typeof(AutoResetUniTaskCompletionSource), () => pool.Size);
+        }
+
+        UniTaskCompletionSourceCore<AsyncUnit> core;
+
+        AutoResetUniTaskCompletionSource()
+        {
+        }
+
+        [DebuggerHidden]
+        public static AutoResetUniTaskCompletionSource Create()
+        {
+            if (!pool.TryPop(out var result))
+            {
+                result = new AutoResetUniTaskCompletionSource();
+            }
+            TaskTracker.TrackActiveTask(result, 2);
+            return result;
+        }
+
+        [DebuggerHidden]
+        public static AutoResetUniTaskCompletionSource CreateFromCanceled(CancellationToken cancellationToken, out short token)
+        {
+            var source = Create();
+            source.TrySetCanceled(cancellationToken);
+            token = source.core.Version;
+            return source;
+        }
+
+        [DebuggerHidden]
+        public static AutoResetUniTaskCompletionSource CreateFromException(Exception exception, out short token)
+        {
+            var source = Create();
+            source.TrySetException(exception);
+            token = source.core.Version;
+            return source;
+        }
+
+        [DebuggerHidden]
+        public static AutoResetUniTaskCompletionSource CreateCompleted(out short token)
+        {
+            var source = Create();
+            source.TrySetResult();
+            token = source.core.Version;
+            return source;
+        }
+
+        public UniTask Task
+        {
+            [DebuggerHidden]
+            get
+            {
+                return new UniTask(this, core.Version);
+            }
+        }
+
+        [DebuggerHidden]
+        public bool TrySetResult()
+        {
+            return core.TrySetResult(AsyncUnit.Default);
+        }
+
+        [DebuggerHidden]
+        public bool TrySetCanceled(CancellationToken cancellationToken = default)
+        {
+            return core.TrySetCanceled(cancellationToken);
+        }
+
+        [DebuggerHidden]
+        public bool TrySetException(Exception exception)
+        {
+            return core.TrySetException(exception);
+        }
+
+        [DebuggerHidden]
+        public void GetResult(short token)
+        {
+            try
+            {
+                core.GetResult(token);
+            }
+            finally
+            {
+                TryReturn();
+            }
+
+        }
+
+        [DebuggerHidden]
+        public UniTaskStatus GetStatus(short token)
+        {
+            return core.GetStatus(token);
+        }
+
+        [DebuggerHidden]
+        public UniTaskStatus UnsafeGetStatus()
+        {
+            return core.UnsafeGetStatus();
+        }
+
+        [DebuggerHidden]
+        public void OnCompleted(Action<object> continuation, object state, short token)
+        {
+            core.OnCompleted(continuation, state, token);
+        }
+
+        [DebuggerHidden]
+        bool TryReturn()
+        {
+            TaskTracker.RemoveTracking(this);
+            core.Reset();
+            return pool.TryPush(this);
+        }
+    }
+
+    public class AutoResetUniTaskCompletionSource<T> : IUniTaskSource<T>, ITaskPoolNode<AutoResetUniTaskCompletionSource<T>>, IPromise<T>
+    {
+        static TaskPool<AutoResetUniTaskCompletionSource<T>> pool;
+        AutoResetUniTaskCompletionSource<T> nextNode;
+        public ref AutoResetUniTaskCompletionSource<T> NextNode => ref nextNode;
+
+        static AutoResetUniTaskCompletionSource()
+        {
+            TaskPool.RegisterSizeGetter(typeof(AutoResetUniTaskCompletionSource<T>), () => pool.Size);
+        }
+
+        UniTaskCompletionSourceCore<T> core;
+
+        AutoResetUniTaskCompletionSource()
+        {
+        }
+
+        [DebuggerHidden]
+        public static AutoResetUniTaskCompletionSource<T> Create()
+        {
+            if (!pool.TryPop(out var result))
+            {
+                result = new AutoResetUniTaskCompletionSource<T>();
+            }
+            TaskTracker.TrackActiveTask(result, 2);
+            return result;
+        }
+
+        [DebuggerHidden]
+        public static AutoResetUniTaskCompletionSource<T> CreateFromCanceled(CancellationToken cancellationToken, out short token)
+        {
+            var source = Create();
+            source.TrySetCanceled(cancellationToken);
+            token = source.core.Version;
+            return source;
+        }
+
+        [DebuggerHidden]
+        public static AutoResetUniTaskCompletionSource<T> CreateFromException(Exception exception, out short token)
+        {
+            var source = Create();
+            source.TrySetException(exception);
+            token = source.core.Version;
+            return source;
+        }
+
+        [DebuggerHidden]
+        public static AutoResetUniTaskCompletionSource<T> CreateFromResult(T result, out short token)
+        {
+            var source = Create();
+            source.TrySetResult(result);
+            token = source.core.Version;
+            return source;
+        }
+
+        public UniTask<T> Task
+        {
+            [DebuggerHidden]
+            get
+            {
+                return new UniTask<T>(this, core.Version);
+            }
+        }
+
+        [DebuggerHidden]
+        public bool TrySetResult(T result)
+        {
+            return core.TrySetResult(result);
+        }
+
+        [DebuggerHidden]
+        public bool TrySetCanceled(CancellationToken cancellationToken = default)
+        {
+            return core.TrySetCanceled(cancellationToken);
+        }
+
+        [DebuggerHidden]
+        public bool TrySetException(Exception exception)
+        {
+            return core.TrySetException(exception);
+        }
+
+        [DebuggerHidden]
+        public T GetResult(short token)
+        {
+            try
+            {
+                return core.GetResult(token);
+            }
+            finally
+            {
+                TryReturn();
+            }
+        }
+
+        [DebuggerHidden]
+        void IUniTaskSource.GetResult(short token)
+        {
+            GetResult(token);
+        }
+
+        [DebuggerHidden]
+        public UniTaskStatus GetStatus(short token)
+        {
+            return core.GetStatus(token);
+        }
+
+        [DebuggerHidden]
+        public UniTaskStatus UnsafeGetStatus()
+        {
+            return core.UnsafeGetStatus();
+        }
+
+        [DebuggerHidden]
+        public void OnCompleted(Action<object> continuation, object state, short token)
+        {
+            core.OnCompleted(continuation, state, token);
+        }
+
+        [DebuggerHidden]
+        bool TryReturn()
+        {
+            TaskTracker.RemoveTracking(this);
+            core.Reset();
+            return pool.TryPush(this);
+        }
+    }
+
+    public class UniTaskCompletionSource : IUniTaskSource, IPromise
+    {
+        CancellationToken cancellationToken;
+        ExceptionHolder exception;
+        object gate;
+        Action<object> singleContinuation;
+        object singleState;
+        List<(Action<object>, object)> secondaryContinuationList;
+
+        int intStatus; // UniTaskStatus
+        bool handled = false;
+
+        public UniTaskCompletionSource()
+        {
+            TaskTracker.TrackActiveTask(this, 2);
+        }
+
+        [DebuggerHidden]
+        internal void MarkHandled()
+        {
+            if (!handled)
+            {
+                handled = true;
+                TaskTracker.RemoveTracking(this);
+            }
+        }
+
+        public UniTask Task
+        {
+            [DebuggerHidden]
+            get
+            {
+                return new UniTask(this, 0);
+            }
+        }
+
+        [DebuggerHidden]
+        public bool TrySetResult()
+        {
+            return TrySignalCompletion(UniTaskStatus.Succeeded);
+        }
+
+        [DebuggerHidden]
+        public bool TrySetCanceled(CancellationToken cancellationToken = default)
+        {
+            if (UnsafeGetStatus() != UniTaskStatus.Pending) return false;
+
+            this.cancellationToken = cancellationToken;
+            return TrySignalCompletion(UniTaskStatus.Canceled);
+        }
+
+        [DebuggerHidden]
+        public bool TrySetException(Exception exception)
+        {
+            if (exception is OperationCanceledException oce)
+            {
+                return TrySetCanceled(oce.CancellationToken);
+            }
+
+            if (UnsafeGetStatus() != UniTaskStatus.Pending) return false;
+
+            this.exception = new ExceptionHolder(ExceptionDispatchInfo.Capture(exception));
+            return TrySignalCompletion(UniTaskStatus.Faulted);
+        }
+
+        [DebuggerHidden]
+        public void GetResult(short token)
+        {
+            MarkHandled();
+
+            var status = (UniTaskStatus)intStatus;
+            switch (status)
+            {
+                case UniTaskStatus.Succeeded:
+                    return;
+                case UniTaskStatus.Faulted:
+                    exception.GetException().Throw();
+                    return;
+                case UniTaskStatus.Canceled:
+                    throw new OperationCanceledException(cancellationToken);
+                default:
+                case UniTaskStatus.Pending:
+                    throw new InvalidOperationException("not yet completed.");
+            }
+        }
+
+        [DebuggerHidden]
+        public UniTaskStatus GetStatus(short token)
+        {
+            return (UniTaskStatus)intStatus;
+        }
+
+        [DebuggerHidden]
+        public UniTaskStatus UnsafeGetStatus()
+        {
+            return (UniTaskStatus)intStatus;
+        }
+
+        [DebuggerHidden]
+        public void OnCompleted(Action<object> continuation, object state, short token)
+        {
+            if (gate == null)
+            {
+                Interlocked.CompareExchange(ref gate, new object(), null);
+            }
+
+            var lockGate = Thread.VolatileRead(ref gate);
+            lock (lockGate) // wait TrySignalCompletion, after status is not pending.
+            {
+                if ((UniTaskStatus)intStatus != UniTaskStatus.Pending)
+                {
+                    continuation(state);
+                    return;
+                }
+
+                if (singleContinuation == null)
+                {
+                    singleContinuation = continuation;
+                    singleState = state;
+                }
+                else
+                {
+                    if (secondaryContinuationList == null)
+                    {
+                        secondaryContinuationList = new List<(Action<object>, object)>();
+                    }
+                    secondaryContinuationList.Add((continuation, state));
+                }
+            }
+        }
+
+        [DebuggerHidden]
+        bool TrySignalCompletion(UniTaskStatus status)
+        {
+            if (Interlocked.CompareExchange(ref intStatus, (int)status, (int)UniTaskStatus.Pending) == (int)UniTaskStatus.Pending)
+            {
+                if (gate == null)
+                {
+                    Interlocked.CompareExchange(ref gate, new object(), null);
+                }
+
+                var lockGate = Thread.VolatileRead(ref gate);
+                lock (lockGate) // wait OnCompleted.
+                {
+                    if (singleContinuation != null)
+                    {
+                        try
+                        {
+                            singleContinuation(singleState);
+                        }
+                        catch (Exception ex)
+                        {
+                            UniTaskScheduler.PublishUnobservedTaskException(ex);
+                        }
+                    }
+
+                    if (secondaryContinuationList != null)
+                    {
+                        foreach (var (c, state) in secondaryContinuationList)
+                        {
+                            try
+                            {
+                                c(state);
+                            }
+                            catch (Exception ex)
+                            {
+                                UniTaskScheduler.PublishUnobservedTaskException(ex);
+                            }
+                        }
+                    }
+
+                    singleContinuation = null;
+                    singleState = null;
+                    secondaryContinuationList = null;
+                }
+                return true;
+            }
+            return false;
+        }
+    }
+
+    public class UniTaskCompletionSource<T> : IUniTaskSource<T>, IPromise<T>
+    {
+        CancellationToken cancellationToken;
+        T result;
+        ExceptionHolder exception;
+        object gate;
+        Action<object> singleContinuation;
+        object singleState;
+        List<(Action<object>, object)> secondaryContinuationList;
+
+        int intStatus; // UniTaskStatus
+        bool handled = false;
+
+        public UniTaskCompletionSource()
+        {
+            TaskTracker.TrackActiveTask(this, 2);
+        }
+
+        [DebuggerHidden]
+        internal void MarkHandled()
+        {
+            if (!handled)
+            {
+                handled = true;
+                TaskTracker.RemoveTracking(this);
+            }
+        }
+
+        public UniTask<T> Task
+        {
+            [DebuggerHidden]
+            get
+            {
+                return new UniTask<T>(this, 0);
+            }
+        }
+
+        [DebuggerHidden]
+        public bool TrySetResult(T result)
+        {
+            if (UnsafeGetStatus() != UniTaskStatus.Pending) return false;
+
+            this.result = result;
+            return TrySignalCompletion(UniTaskStatus.Succeeded);
+        }
+
+        [DebuggerHidden]
+        public bool TrySetCanceled(CancellationToken cancellationToken = default)
+        {
+            if (UnsafeGetStatus() != UniTaskStatus.Pending) return false;
+
+            this.cancellationToken = cancellationToken;
+            return TrySignalCompletion(UniTaskStatus.Canceled);
+        }
+
+        [DebuggerHidden]
+        public bool TrySetException(Exception exception)
+        {
+            if (exception is OperationCanceledException oce)
+            {
+                return TrySetCanceled(oce.CancellationToken);
+            }
+
+            if (UnsafeGetStatus() != UniTaskStatus.Pending) return false;
+
+            this.exception = new ExceptionHolder(ExceptionDispatchInfo.Capture(exception));
+            return TrySignalCompletion(UniTaskStatus.Faulted);
+        }
+
+        [DebuggerHidden]
+        public T GetResult(short token)
+        {
+            MarkHandled();
+
+            var status = (UniTaskStatus)intStatus;
+            switch (status)
+            {
+                case UniTaskStatus.Succeeded:
+                    return result;
+                case UniTaskStatus.Faulted:
+                    exception.GetException().Throw();
+                    return default;
+                case UniTaskStatus.Canceled:
+                    throw new OperationCanceledException(cancellationToken);
+                default:
+                case UniTaskStatus.Pending:
+                    throw new InvalidOperationException("not yet completed.");
+            }
+        }
+
+        [DebuggerHidden]
+        void IUniTaskSource.GetResult(short token)
+        {
+            GetResult(token);
+        }
+
+        [DebuggerHidden]
+        public UniTaskStatus GetStatus(short token)
+        {
+            return (UniTaskStatus)intStatus;
+        }
+
+        [DebuggerHidden]
+        public UniTaskStatus UnsafeGetStatus()
+        {
+            return (UniTaskStatus)intStatus;
+        }
+
+        [DebuggerHidden]
+        public void OnCompleted(Action<object> continuation, object state, short token)
+        {
+            if (gate == null)
+            {
+                Interlocked.CompareExchange(ref gate, new object(), null);
+            }
+
+            var lockGate = Thread.VolatileRead(ref gate);
+            lock (lockGate) // wait TrySignalCompletion, after status is not pending.
+            {
+                if ((UniTaskStatus)intStatus != UniTaskStatus.Pending)
+                {
+                    continuation(state);
+                    return;
+                }
+
+                if (singleContinuation == null)
+                {
+                    singleContinuation = continuation;
+                    singleState = state;
+                }
+                else
+                {
+                    if (secondaryContinuationList == null)
+                    {
+                        secondaryContinuationList = new List<(Action<object>, object)>();
+                    }
+                    secondaryContinuationList.Add((continuation, state));
+                }
+            }
+        }
+
+        [DebuggerHidden]
+        bool TrySignalCompletion(UniTaskStatus status)
+        {
+            if (Interlocked.CompareExchange(ref intStatus, (int)status, (int)UniTaskStatus.Pending) == (int)UniTaskStatus.Pending)
+            {
+                if (gate == null)
+                {
+                    Interlocked.CompareExchange(ref gate, new object(), null);
+                }
+
+                var lockGate = Thread.VolatileRead(ref gate);
+                lock (lockGate) // wait OnCompleted.
+                {
+                    if (singleContinuation != null)
+                    {
+                        try
+                        {
+                            singleContinuation(singleState);
+                        }
+                        catch (Exception ex)
+                        {
+                            UniTaskScheduler.PublishUnobservedTaskException(ex);
+                        }
+                    }
+
+                    if (secondaryContinuationList != null)
+                    {
+                        foreach (var (c, state) in secondaryContinuationList)
+                        {
+                            try
+                            {
+                                c(state);
+                            }
+                            catch (Exception ex)
+                            {
+                                UniTaskScheduler.PublishUnobservedTaskException(ex);
+                            }
+                        }
+                    }
+
+                    singleContinuation = null;
+                    singleState = null;
+                    secondaryContinuationList = null;
+                }
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/UniTaskCompletionSource.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/UniTaskCompletionSource.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ed03524d09e7eb24a9fb9137198feb84
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/UniTaskExtensions.Shorthand.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/UniTaskExtensions.Shorthand.cs
@@ -1,0 +1,187 @@
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+using System.Collections.Generic;
+
+namespace Cysharp.Threading.Tasks
+{
+    public static partial class UniTaskExtensions
+    {
+        // shorthand of WhenAll
+    
+        public static UniTask.Awaiter GetAwaiter(this UniTask[] tasks)
+        {
+            return UniTask.WhenAll(tasks).GetAwaiter();
+        }
+
+        public static UniTask.Awaiter GetAwaiter(this IEnumerable<UniTask> tasks)
+        {
+            return UniTask.WhenAll(tasks).GetAwaiter();
+        }
+
+        public static UniTask<T[]>.Awaiter GetAwaiter<T>(this UniTask<T>[] tasks)
+        {
+            return UniTask.WhenAll(tasks).GetAwaiter();
+        }
+
+        public static UniTask<T[]>.Awaiter GetAwaiter<T>(this IEnumerable<UniTask<T>> tasks)
+        {
+            return UniTask.WhenAll(tasks).GetAwaiter();
+        }
+
+        public static UniTask<(T1, T2)>.Awaiter GetAwaiter<T1, T2>(this (UniTask<T1> task1, UniTask<T2> task2) tasks)
+        {
+            return UniTask.WhenAll(tasks.Item1, tasks.Item2).GetAwaiter();
+        }
+
+        public static UniTask<(T1, T2, T3)>.Awaiter GetAwaiter<T1, T2, T3>(this (UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3) tasks)
+        {
+            return UniTask.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3).GetAwaiter();
+        }
+
+        public static UniTask<(T1, T2, T3, T4)>.Awaiter GetAwaiter<T1, T2, T3, T4>(this (UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4) tasks)
+        {
+            return UniTask.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4).GetAwaiter();
+        }
+
+        public static UniTask<(T1, T2, T3, T4, T5)>.Awaiter GetAwaiter<T1, T2, T3, T4, T5>(this (UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4, UniTask<T5> task5) tasks)
+        {
+            return UniTask.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5).GetAwaiter();
+        }
+
+        public static UniTask<(T1, T2, T3, T4, T5, T6)>.Awaiter GetAwaiter<T1, T2, T3, T4, T5, T6>(this (UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4, UniTask<T5> task5, UniTask<T6> task6) tasks)
+        {
+            return UniTask.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, tasks.Item6).GetAwaiter();
+        }
+
+        public static UniTask<(T1, T2, T3, T4, T5, T6, T7)>.Awaiter GetAwaiter<T1, T2, T3, T4, T5, T6, T7>(this (UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4, UniTask<T5> task5, UniTask<T6> task6, UniTask<T7> task7) tasks)
+        {
+            return UniTask.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, tasks.Item6, tasks.Item7).GetAwaiter();
+        }
+
+        public static UniTask<(T1, T2, T3, T4, T5, T6, T7, T8)>.Awaiter GetAwaiter<T1, T2, T3, T4, T5, T6, T7, T8>(this (UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4, UniTask<T5> task5, UniTask<T6> task6, UniTask<T7> task7, UniTask<T8> task8) tasks)
+        {
+            return UniTask.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, tasks.Item6, tasks.Item7, tasks.Item8).GetAwaiter();
+        }
+
+        public static UniTask<(T1, T2, T3, T4, T5, T6, T7, T8, T9)>.Awaiter GetAwaiter<T1, T2, T3, T4, T5, T6, T7, T8, T9>(this (UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4, UniTask<T5> task5, UniTask<T6> task6, UniTask<T7> task7, UniTask<T8> task8, UniTask<T9> task9) tasks)
+        {
+            return UniTask.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, tasks.Item6, tasks.Item7, tasks.Item8, tasks.Item9).GetAwaiter();
+        }
+
+        public static UniTask<(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)>.Awaiter GetAwaiter<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this (UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4, UniTask<T5> task5, UniTask<T6> task6, UniTask<T7> task7, UniTask<T8> task8, UniTask<T9> task9, UniTask<T10> task10) tasks)
+        {
+            return UniTask.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, tasks.Item6, tasks.Item7, tasks.Item8, tasks.Item9, tasks.Item10).GetAwaiter();
+        }
+
+        public static UniTask<(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)>.Awaiter GetAwaiter<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this (UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4, UniTask<T5> task5, UniTask<T6> task6, UniTask<T7> task7, UniTask<T8> task8, UniTask<T9> task9, UniTask<T10> task10, UniTask<T11> task11) tasks)
+        {
+            return UniTask.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, tasks.Item6, tasks.Item7, tasks.Item8, tasks.Item9, tasks.Item10, tasks.Item11).GetAwaiter();
+        }
+
+        public static UniTask<(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)>.Awaiter GetAwaiter<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this (UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4, UniTask<T5> task5, UniTask<T6> task6, UniTask<T7> task7, UniTask<T8> task8, UniTask<T9> task9, UniTask<T10> task10, UniTask<T11> task11, UniTask<T12> task12) tasks)
+        {
+            return UniTask.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, tasks.Item6, tasks.Item7, tasks.Item8, tasks.Item9, tasks.Item10, tasks.Item11, tasks.Item12).GetAwaiter();
+        }
+
+        public static UniTask<(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)>.Awaiter GetAwaiter<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this (UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4, UniTask<T5> task5, UniTask<T6> task6, UniTask<T7> task7, UniTask<T8> task8, UniTask<T9> task9, UniTask<T10> task10, UniTask<T11> task11, UniTask<T12> task12, UniTask<T13> task13) tasks)
+        {
+            return UniTask.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, tasks.Item6, tasks.Item7, tasks.Item8, tasks.Item9, tasks.Item10, tasks.Item11, tasks.Item12, tasks.Item13).GetAwaiter();
+        }
+
+        public static UniTask<(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)>.Awaiter GetAwaiter<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this (UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4, UniTask<T5> task5, UniTask<T6> task6, UniTask<T7> task7, UniTask<T8> task8, UniTask<T9> task9, UniTask<T10> task10, UniTask<T11> task11, UniTask<T12> task12, UniTask<T13> task13, UniTask<T14> task14) tasks)
+        {
+            return UniTask.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, tasks.Item6, tasks.Item7, tasks.Item8, tasks.Item9, tasks.Item10, tasks.Item11, tasks.Item12, tasks.Item13, tasks.Item14).GetAwaiter();
+        }
+
+        public static UniTask<(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)>.Awaiter GetAwaiter<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(this (UniTask<T1> task1, UniTask<T2> task2, UniTask<T3> task3, UniTask<T4> task4, UniTask<T5> task5, UniTask<T6> task6, UniTask<T7> task7, UniTask<T8> task8, UniTask<T9> task9, UniTask<T10> task10, UniTask<T11> task11, UniTask<T12> task12, UniTask<T13> task13, UniTask<T14> task14, UniTask<T15> task15) tasks)
+        {
+            return UniTask.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, tasks.Item6, tasks.Item7, tasks.Item8, tasks.Item9, tasks.Item10, tasks.Item11, tasks.Item12, tasks.Item13, tasks.Item14, tasks.Item15).GetAwaiter();
+        }
+
+
+
+        public static UniTask.Awaiter GetAwaiter(this (UniTask task1, UniTask task2) tasks)
+        {
+            return UniTask.WhenAll(tasks.Item1, tasks.Item2).GetAwaiter();
+        }
+
+
+        public static UniTask.Awaiter GetAwaiter(this (UniTask task1, UniTask task2, UniTask task3) tasks)
+        {
+            return UniTask.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3).GetAwaiter();
+        }
+
+
+        public static UniTask.Awaiter GetAwaiter(this (UniTask task1, UniTask task2, UniTask task3, UniTask task4) tasks)
+        {
+            return UniTask.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4).GetAwaiter();
+        }
+
+
+        public static UniTask.Awaiter GetAwaiter(this (UniTask task1, UniTask task2, UniTask task3, UniTask task4, UniTask task5) tasks)
+        {
+            return UniTask.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5).GetAwaiter();
+        }
+
+
+        public static UniTask.Awaiter GetAwaiter(this (UniTask task1, UniTask task2, UniTask task3, UniTask task4, UniTask task5, UniTask task6) tasks)
+        {
+            return UniTask.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, tasks.Item6).GetAwaiter();
+        }
+
+
+        public static UniTask.Awaiter GetAwaiter(this (UniTask task1, UniTask task2, UniTask task3, UniTask task4, UniTask task5, UniTask task6, UniTask task7) tasks)
+        {
+            return UniTask.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, tasks.Item6, tasks.Item7).GetAwaiter();
+        }
+
+
+        public static UniTask.Awaiter GetAwaiter(this (UniTask task1, UniTask task2, UniTask task3, UniTask task4, UniTask task5, UniTask task6, UniTask task7, UniTask task8) tasks)
+        {
+            return UniTask.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, tasks.Item6, tasks.Item7, tasks.Item8).GetAwaiter();
+        }
+
+
+        public static UniTask.Awaiter GetAwaiter(this (UniTask task1, UniTask task2, UniTask task3, UniTask task4, UniTask task5, UniTask task6, UniTask task7, UniTask task8, UniTask task9) tasks)
+        {
+            return UniTask.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, tasks.Item6, tasks.Item7, tasks.Item8, tasks.Item9).GetAwaiter();
+        }
+
+
+        public static UniTask.Awaiter GetAwaiter(this (UniTask task1, UniTask task2, UniTask task3, UniTask task4, UniTask task5, UniTask task6, UniTask task7, UniTask task8, UniTask task9, UniTask task10) tasks)
+        {
+            return UniTask.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, tasks.Item6, tasks.Item7, tasks.Item8, tasks.Item9, tasks.Item10).GetAwaiter();
+        }
+
+
+        public static UniTask.Awaiter GetAwaiter(this (UniTask task1, UniTask task2, UniTask task3, UniTask task4, UniTask task5, UniTask task6, UniTask task7, UniTask task8, UniTask task9, UniTask task10, UniTask task11) tasks)
+        {
+            return UniTask.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, tasks.Item6, tasks.Item7, tasks.Item8, tasks.Item9, tasks.Item10, tasks.Item11).GetAwaiter();
+        }
+
+
+        public static UniTask.Awaiter GetAwaiter(this (UniTask task1, UniTask task2, UniTask task3, UniTask task4, UniTask task5, UniTask task6, UniTask task7, UniTask task8, UniTask task9, UniTask task10, UniTask task11, UniTask task12) tasks)
+        {
+            return UniTask.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, tasks.Item6, tasks.Item7, tasks.Item8, tasks.Item9, tasks.Item10, tasks.Item11, tasks.Item12).GetAwaiter();
+        }
+
+
+        public static UniTask.Awaiter GetAwaiter(this (UniTask task1, UniTask task2, UniTask task3, UniTask task4, UniTask task5, UniTask task6, UniTask task7, UniTask task8, UniTask task9, UniTask task10, UniTask task11, UniTask task12, UniTask task13) tasks)
+        {
+            return UniTask.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, tasks.Item6, tasks.Item7, tasks.Item8, tasks.Item9, tasks.Item10, tasks.Item11, tasks.Item12, tasks.Item13).GetAwaiter();
+        }
+
+
+        public static UniTask.Awaiter GetAwaiter(this (UniTask task1, UniTask task2, UniTask task3, UniTask task4, UniTask task5, UniTask task6, UniTask task7, UniTask task8, UniTask task9, UniTask task10, UniTask task11, UniTask task12, UniTask task13, UniTask task14) tasks)
+        {
+            return UniTask.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, tasks.Item6, tasks.Item7, tasks.Item8, tasks.Item9, tasks.Item10, tasks.Item11, tasks.Item12, tasks.Item13, tasks.Item14).GetAwaiter();
+        }
+
+
+        public static UniTask.Awaiter GetAwaiter(this (UniTask task1, UniTask task2, UniTask task3, UniTask task4, UniTask task5, UniTask task6, UniTask task7, UniTask task8, UniTask task9, UniTask task10, UniTask task11, UniTask task12, UniTask task13, UniTask task14, UniTask task15) tasks)
+        {
+            return UniTask.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, tasks.Item6, tasks.Item7, tasks.Item8, tasks.Item9, tasks.Item10, tasks.Item11, tasks.Item12, tasks.Item13, tasks.Item14, tasks.Item15).GetAwaiter();
+        }
+
+
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/UniTaskExtensions.Shorthand.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/UniTaskExtensions.Shorthand.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4b4ff020f73dc6d4b8ebd4760d61fb43
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/UniTaskExtensions.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/UniTaskExtensions.cs
@@ -1,0 +1,921 @@
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System;
+using System.Collections;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Cysharp.Threading.Tasks.Internal;
+
+namespace Cysharp.Threading.Tasks
+{
+    public static partial class UniTaskExtensions
+    {
+        /// <summary>
+        /// Convert Task[T] -> UniTask[T].
+        /// </summary>
+        public static UniTask<T> AsUniTask<T>(this Task<T> task, bool useCurrentSynchronizationContext = true)
+        {
+            var promise = new UniTaskCompletionSource<T>();
+
+            task.ContinueWith((x, state) =>
+            {
+                var p = (UniTaskCompletionSource<T>)state;
+
+                switch (x.Status)
+                {
+                    case TaskStatus.Canceled:
+                        p.TrySetCanceled();
+                        break;
+                    case TaskStatus.Faulted:
+                        p.TrySetException(x.Exception);
+                        break;
+                    case TaskStatus.RanToCompletion:
+                        p.TrySetResult(x.Result);
+                        break;
+                    default:
+                        throw new NotSupportedException();
+                }
+            }, promise, useCurrentSynchronizationContext ? TaskScheduler.FromCurrentSynchronizationContext() : TaskScheduler.Current);
+
+            return promise.Task;
+        }
+
+        /// <summary>
+        /// Convert Task -> UniTask.
+        /// </summary>
+        public static UniTask AsUniTask(this Task task, bool useCurrentSynchronizationContext = true)
+        {
+            var promise = new UniTaskCompletionSource();
+
+            task.ContinueWith((x, state) =>
+            {
+                var p = (UniTaskCompletionSource)state;
+
+                switch (x.Status)
+                {
+                    case TaskStatus.Canceled:
+                        p.TrySetCanceled();
+                        break;
+                    case TaskStatus.Faulted:
+                        p.TrySetException(x.Exception);
+                        break;
+                    case TaskStatus.RanToCompletion:
+                        p.TrySetResult();
+                        break;
+                    default:
+                        throw new NotSupportedException();
+                }
+            }, promise, useCurrentSynchronizationContext ? TaskScheduler.FromCurrentSynchronizationContext() : TaskScheduler.Current);
+
+            return promise.Task;
+        }
+
+        public static Task<T> AsTask<T>(this UniTask<T> task)
+        {
+            try
+            {
+                UniTask<T>.Awaiter awaiter;
+                try
+                {
+                    awaiter = task.GetAwaiter();
+                }
+                catch (Exception ex)
+                {
+                    return Task.FromException<T>(ex);
+                }
+
+                if (awaiter.IsCompleted)
+                {
+                    try
+                    {
+                        var result = awaiter.GetResult();
+                        return Task.FromResult(result);
+                    }
+                    catch (Exception ex)
+                    {
+                        return Task.FromException<T>(ex);
+                    }
+                }
+
+                var tcs = new TaskCompletionSource<T>();
+
+                awaiter.SourceOnCompleted(state =>
+                {
+                    using (var tuple = (StateTuple<TaskCompletionSource<T>, UniTask<T>.Awaiter>)state)
+                    {
+                        var (inTcs, inAwaiter) = tuple;
+                        try
+                        {
+                            var result = inAwaiter.GetResult();
+                            inTcs.SetResult(result);
+                        }
+                        catch (Exception ex)
+                        {
+                            inTcs.SetException(ex);
+                        }
+                    }
+                }, StateTuple.Create(tcs, awaiter));
+
+                return tcs.Task;
+            }
+            catch (Exception ex)
+            {
+                return Task.FromException<T>(ex);
+            }
+        }
+
+        public static Task AsTask(this UniTask task)
+        {
+            try
+            {
+                UniTask.Awaiter awaiter;
+                try
+                {
+                    awaiter = task.GetAwaiter();
+                }
+                catch (Exception ex)
+                {
+                    return Task.FromException(ex);
+                }
+
+                if (awaiter.IsCompleted)
+                {
+                    try
+                    {
+                        awaiter.GetResult(); // check token valid on Succeeded
+                        return Task.CompletedTask;
+                    }
+                    catch (Exception ex)
+                    {
+                        return Task.FromException(ex);
+                    }
+                }
+
+                var tcs = new TaskCompletionSource<object>();
+
+                awaiter.SourceOnCompleted(state =>
+                {
+                    using (var tuple = (StateTuple<TaskCompletionSource<object>, UniTask.Awaiter>)state)
+                    {
+                        var (inTcs, inAwaiter) = tuple;
+                        try
+                        {
+                            inAwaiter.GetResult();
+                            inTcs.SetResult(null);
+                        }
+                        catch (Exception ex)
+                        {
+                            inTcs.SetException(ex);
+                        }
+                    }
+                }, StateTuple.Create(tcs, awaiter));
+
+                return tcs.Task;
+            }
+            catch (Exception ex)
+            {
+                return Task.FromException(ex);
+            }
+        }
+
+        public static AsyncLazy ToAsyncLazy(this UniTask task)
+        {
+            return new AsyncLazy(task);
+        }
+
+        public static AsyncLazy<T> ToAsyncLazy<T>(this UniTask<T> task)
+        {
+            return new AsyncLazy<T>(task);
+        }
+
+        /// <summary>
+        /// Ignore task result when cancel raised first.
+        /// </summary>
+        public static UniTask AttachExternalCancellation(this UniTask task, CancellationToken cancellationToken)
+        {
+            if (!cancellationToken.CanBeCanceled)
+            {
+                return task;
+            }
+
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return UniTask.FromCanceled(cancellationToken);
+            }
+
+            if (task.Status.IsCompleted())
+            {
+                return task;
+            }
+
+            return new UniTask(new AttachExternalCancellationSource(task, cancellationToken), 0);
+        }
+
+        /// <summary>
+        /// Ignore task result when cancel raised first.
+        /// </summary>
+        public static UniTask<T> AttachExternalCancellation<T>(this UniTask<T> task, CancellationToken cancellationToken)
+        {
+            if (!cancellationToken.CanBeCanceled)
+            {
+                return task;
+            }
+
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return UniTask.FromCanceled<T>(cancellationToken);
+            }
+
+            if (task.Status.IsCompleted())
+            {
+                return task;
+            }
+
+            return new UniTask<T>(new AttachExternalCancellationSource<T>(task, cancellationToken), 0);
+        }
+
+        sealed class AttachExternalCancellationSource : IUniTaskSource
+        {
+            static readonly Action<object> cancellationCallbackDelegate = CancellationCallback;
+
+            CancellationToken cancellationToken;
+            CancellationTokenRegistration tokenRegistration;
+            UniTaskCompletionSourceCore<AsyncUnit> core;
+
+            public AttachExternalCancellationSource(UniTask task, CancellationToken cancellationToken)
+            {
+                this.cancellationToken = cancellationToken;
+                this.tokenRegistration = cancellationToken.RegisterWithoutCaptureExecutionContext(cancellationCallbackDelegate, this);
+                RunTask(task).Forget();
+            }
+
+            async UniTaskVoid RunTask(UniTask task)
+            {
+                try
+                {
+                    await task;
+                    core.TrySetResult(AsyncUnit.Default);
+                }
+                catch (Exception ex)
+                {
+                    core.TrySetException(ex);
+                }
+                finally
+                {
+                    tokenRegistration.Dispose();
+                }
+            }
+
+            static void CancellationCallback(object state)
+            {
+                var self = (AttachExternalCancellationSource)state;
+                self.core.TrySetCanceled(self.cancellationToken);
+            }
+
+            public void GetResult(short token)
+            {
+                core.GetResult(token);
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+        }
+
+        sealed class AttachExternalCancellationSource<T> : IUniTaskSource<T>
+        {
+            static readonly Action<object> cancellationCallbackDelegate = CancellationCallback;
+
+            CancellationToken cancellationToken;
+            CancellationTokenRegistration tokenRegistration;
+            UniTaskCompletionSourceCore<T> core;
+
+            public AttachExternalCancellationSource(UniTask<T> task, CancellationToken cancellationToken)
+            {
+                this.cancellationToken = cancellationToken;
+                this.tokenRegistration = cancellationToken.RegisterWithoutCaptureExecutionContext(cancellationCallbackDelegate, this);
+                RunTask(task).Forget();
+            }
+
+            async UniTaskVoid RunTask(UniTask<T> task)
+            {
+                try
+                {
+                    core.TrySetResult(await task);
+                }
+                catch (Exception ex)
+                {
+                    core.TrySetException(ex);
+                }
+                finally
+                {
+                    tokenRegistration.Dispose();
+                }
+            }
+
+            static void CancellationCallback(object state)
+            {
+                var self = (AttachExternalCancellationSource<T>)state;
+                self.core.TrySetCanceled(self.cancellationToken);
+            }
+
+            void IUniTaskSource.GetResult(short token)
+            {
+                core.GetResult(token);
+            }
+
+            public T GetResult(short token)
+            {
+                return core.GetResult(token);
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+        }
+
+#if UNITY_2018_3_OR_NEWER
+
+        public static IEnumerator ToCoroutine<T>(this UniTask<T> task, Action<T> resultHandler = null, Action<Exception> exceptionHandler = null)
+        {
+            return new ToCoroutineEnumerator<T>(task, resultHandler, exceptionHandler);
+        }
+
+        public static IEnumerator ToCoroutine(this UniTask task, Action<Exception> exceptionHandler = null)
+        {
+            return new ToCoroutineEnumerator(task, exceptionHandler);
+        }
+
+        public static async UniTask Timeout(this UniTask task, TimeSpan timeout, DelayType delayType = DelayType.DeltaTime, PlayerLoopTiming timeoutCheckTiming = PlayerLoopTiming.Update, CancellationTokenSource taskCancellationTokenSource = null)
+        {
+            var delayCancellationTokenSource = new CancellationTokenSource();
+            var timeoutTask = UniTask.Delay(timeout, delayType, timeoutCheckTiming, delayCancellationTokenSource.Token).SuppressCancellationThrow();
+
+            int winArgIndex;
+            bool taskResultIsCanceled;
+            try
+            {
+                (winArgIndex, taskResultIsCanceled, _) = await UniTask.WhenAny(task.SuppressCancellationThrow(), timeoutTask);
+            }
+            catch
+            {
+                delayCancellationTokenSource.Cancel();
+                delayCancellationTokenSource.Dispose();
+                throw;
+            }
+
+            // timeout
+            if (winArgIndex == 1)
+            {
+                if (taskCancellationTokenSource != null)
+                {
+                    taskCancellationTokenSource.Cancel();
+                    taskCancellationTokenSource.Dispose();
+                }
+
+                throw new TimeoutException("Exceed Timeout:" + timeout);
+            }
+            else
+            {
+                delayCancellationTokenSource.Cancel();
+                delayCancellationTokenSource.Dispose();
+            }
+
+            if (taskResultIsCanceled)
+            {
+                Error.ThrowOperationCanceledException();
+            }
+        }
+
+        public static async UniTask<T> Timeout<T>(this UniTask<T> task, TimeSpan timeout, DelayType delayType = DelayType.DeltaTime, PlayerLoopTiming timeoutCheckTiming = PlayerLoopTiming.Update, CancellationTokenSource taskCancellationTokenSource = null)
+        {
+            var delayCancellationTokenSource = new CancellationTokenSource();
+            var timeoutTask = UniTask.Delay(timeout, delayType, timeoutCheckTiming, delayCancellationTokenSource.Token).SuppressCancellationThrow();
+
+            int winArgIndex;
+            (bool IsCanceled, T Result) taskResult;
+            try
+            {
+                (winArgIndex, taskResult, _) = await UniTask.WhenAny(task.SuppressCancellationThrow(), timeoutTask);
+            }
+            catch
+            {
+                delayCancellationTokenSource.Cancel();
+                delayCancellationTokenSource.Dispose();
+                throw;
+            }
+
+            // timeout
+            if (winArgIndex == 1)
+            {
+                if (taskCancellationTokenSource != null)
+                {
+                    taskCancellationTokenSource.Cancel();
+                    taskCancellationTokenSource.Dispose();
+                }
+
+                throw new TimeoutException("Exceed Timeout:" + timeout);
+            }
+            else
+            {
+                delayCancellationTokenSource.Cancel();
+                delayCancellationTokenSource.Dispose();
+            }
+
+            if (taskResult.IsCanceled)
+            {
+                Error.ThrowOperationCanceledException();
+            }
+
+            return taskResult.Result;
+        }
+
+        /// <summary>
+        /// Timeout with suppress OperationCanceledException. Returns (bool, IsCacneled).
+        /// </summary>
+        public static async UniTask<bool> TimeoutWithoutException(this UniTask task, TimeSpan timeout, DelayType delayType = DelayType.DeltaTime, PlayerLoopTiming timeoutCheckTiming = PlayerLoopTiming.Update, CancellationTokenSource taskCancellationTokenSource = null)
+        {
+            var delayCancellationTokenSource = new CancellationTokenSource();
+            var timeoutTask = UniTask.Delay(timeout, delayType, timeoutCheckTiming, delayCancellationTokenSource.Token).SuppressCancellationThrow();
+
+            int winArgIndex;
+            bool taskResultIsCanceled;
+            try
+            {
+                (winArgIndex, taskResultIsCanceled, _) = await UniTask.WhenAny(task.SuppressCancellationThrow(), timeoutTask);
+            }
+            catch
+            {
+                delayCancellationTokenSource.Cancel();
+                delayCancellationTokenSource.Dispose();
+                return true;
+            }
+
+            // timeout
+            if (winArgIndex == 1)
+            {
+                if (taskCancellationTokenSource != null)
+                {
+                    taskCancellationTokenSource.Cancel();
+                    taskCancellationTokenSource.Dispose();
+                }
+
+                return true;
+            }
+            else
+            {
+                delayCancellationTokenSource.Cancel();
+                delayCancellationTokenSource.Dispose();
+            }
+
+            if (taskResultIsCanceled)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Timeout with suppress OperationCanceledException. Returns (bool IsTimeout, T Result).
+        /// </summary>
+        public static async UniTask<(bool IsTimeout, T Result)> TimeoutWithoutException<T>(this UniTask<T> task, TimeSpan timeout, DelayType delayType = DelayType.DeltaTime, PlayerLoopTiming timeoutCheckTiming = PlayerLoopTiming.Update, CancellationTokenSource taskCancellationTokenSource = null)
+        {
+            var delayCancellationTokenSource = new CancellationTokenSource();
+            var timeoutTask = UniTask.Delay(timeout, delayType, timeoutCheckTiming, delayCancellationTokenSource.Token).SuppressCancellationThrow();
+
+            int winArgIndex;
+            (bool IsCanceled, T Result) taskResult;
+            try
+            {
+                (winArgIndex, taskResult, _) = await UniTask.WhenAny(task.SuppressCancellationThrow(), timeoutTask);
+            }
+            catch
+            {
+                delayCancellationTokenSource.Cancel();
+                delayCancellationTokenSource.Dispose();
+                return (true, default);
+            }
+
+            // timeout
+            if (winArgIndex == 1)
+            {
+                if (taskCancellationTokenSource != null)
+                {
+                    taskCancellationTokenSource.Cancel();
+                    taskCancellationTokenSource.Dispose();
+                }
+
+                return (true, default);
+            }
+            else
+            {
+                delayCancellationTokenSource.Cancel();
+                delayCancellationTokenSource.Dispose();
+            }
+
+            if (taskResult.IsCanceled)
+            {
+                return (true, default);
+            }
+
+            return (false, taskResult.Result);
+        }
+
+#endif
+
+        public static void Forget(this UniTask task)
+        {
+            var awaiter = task.GetAwaiter();
+            if (awaiter.IsCompleted)
+            {
+                try
+                {
+                    awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    UniTaskScheduler.PublishUnobservedTaskException(ex);
+                }
+            }
+            else
+            {
+                awaiter.SourceOnCompleted(state =>
+                {
+                    using (var t = (StateTuple<UniTask.Awaiter>)state)
+                    {
+                        try
+                        {
+                            t.Item1.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            UniTaskScheduler.PublishUnobservedTaskException(ex);
+                        }
+                    }
+                }, StateTuple.Create(awaiter));
+            }
+        }
+
+        public static void Forget(this UniTask task, Action<Exception> exceptionHandler, bool handleExceptionOnMainThread = true)
+        {
+            if (exceptionHandler == null)
+            {
+                Forget(task);
+            }
+            else
+            {
+                ForgetCoreWithCatch(task, exceptionHandler, handleExceptionOnMainThread).Forget();
+            }
+        }
+
+        static async UniTaskVoid ForgetCoreWithCatch(UniTask task, Action<Exception> exceptionHandler, bool handleExceptionOnMainThread)
+        {
+            try
+            {
+                await task;
+            }
+            catch (Exception ex)
+            {
+                try
+                {
+                    if (handleExceptionOnMainThread)
+                    {
+#if UNITY_2018_3_OR_NEWER
+                        await UniTask.SwitchToMainThread();
+#endif
+                    }
+                    exceptionHandler(ex);
+                }
+                catch (Exception ex2)
+                {
+                    UniTaskScheduler.PublishUnobservedTaskException(ex2);
+                }
+            }
+        }
+
+        public static void Forget<T>(this UniTask<T> task)
+        {
+            var awaiter = task.GetAwaiter();
+            if (awaiter.IsCompleted)
+            {
+                try
+                {
+                    awaiter.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    UniTaskScheduler.PublishUnobservedTaskException(ex);
+                }
+            }
+            else
+            {
+                awaiter.SourceOnCompleted(state =>
+                {
+                    using (var t = (StateTuple<UniTask<T>.Awaiter>)state)
+                    {
+                        try
+                        {
+                            t.Item1.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            UniTaskScheduler.PublishUnobservedTaskException(ex);
+                        }
+                    }
+                }, StateTuple.Create(awaiter));
+            }
+        }
+
+        public static void Forget<T>(this UniTask<T> task, Action<Exception> exceptionHandler, bool handleExceptionOnMainThread = true)
+        {
+            if (exceptionHandler == null)
+            {
+                task.Forget();
+            }
+            else
+            {
+                ForgetCoreWithCatch(task, exceptionHandler, handleExceptionOnMainThread).Forget();
+            }
+        }
+
+        static async UniTaskVoid ForgetCoreWithCatch<T>(UniTask<T> task, Action<Exception> exceptionHandler, bool handleExceptionOnMainThread)
+        {
+            try
+            {
+                await task;
+            }
+            catch (Exception ex)
+            {
+                try
+                {
+                    if (handleExceptionOnMainThread)
+                    {
+#if UNITY_2018_3_OR_NEWER
+                        await UniTask.SwitchToMainThread();
+#endif
+                    }
+                    exceptionHandler(ex);
+                }
+                catch (Exception ex2)
+                {
+                    UniTaskScheduler.PublishUnobservedTaskException(ex2);
+                }
+            }
+        }
+
+        public static async UniTask ContinueWith<T>(this UniTask<T> task, Action<T> continuationFunction)
+        {
+            continuationFunction(await task);
+        }
+
+        public static async UniTask ContinueWith<T>(this UniTask<T> task, Func<T, UniTask> continuationFunction)
+        {
+            await continuationFunction(await task);
+        }
+
+        public static async UniTask<TR> ContinueWith<T, TR>(this UniTask<T> task, Func<T, TR> continuationFunction)
+        {
+            return continuationFunction(await task);
+        }
+
+        public static async UniTask<TR> ContinueWith<T, TR>(this UniTask<T> task, Func<T, UniTask<TR>> continuationFunction)
+        {
+            return await continuationFunction(await task);
+        }
+
+        public static async UniTask ContinueWith(this UniTask task, Action continuationFunction)
+        {
+            await task;
+            continuationFunction();
+        }
+
+        public static async UniTask ContinueWith(this UniTask task, Func<UniTask> continuationFunction)
+        {
+            await task;
+            await continuationFunction();
+        }
+
+        public static async UniTask<T> ContinueWith<T>(this UniTask task, Func<T> continuationFunction)
+        {
+            await task;
+            return continuationFunction();
+        }
+
+        public static async UniTask<T> ContinueWith<T>(this UniTask task, Func<UniTask<T>> continuationFunction)
+        {
+            await task;
+            return await continuationFunction();
+        }
+
+        public static async UniTask<T> Unwrap<T>(this UniTask<UniTask<T>> task)
+        {
+            return await await task;
+        }
+
+        public static async UniTask Unwrap(this UniTask<UniTask> task)
+        {
+            await await task;
+        }
+
+        public static async UniTask<T> Unwrap<T>(this Task<UniTask<T>> task)
+        {
+            return await await task;
+        }
+
+        public static async UniTask<T> Unwrap<T>(this Task<UniTask<T>> task, bool continueOnCapturedContext)
+        {
+            return await await task.ConfigureAwait(continueOnCapturedContext);
+        }
+
+        public static async UniTask Unwrap(this Task<UniTask> task)
+        {
+            await await task;
+        }
+
+        public static async UniTask Unwrap(this Task<UniTask> task, bool continueOnCapturedContext)
+        {
+            await await task.ConfigureAwait(continueOnCapturedContext);
+        }
+
+        public static async UniTask<T> Unwrap<T>(this UniTask<Task<T>> task)
+        {
+            return await await task;
+        }
+
+        public static async UniTask<T> Unwrap<T>(this UniTask<Task<T>> task, bool continueOnCapturedContext)
+        {
+            return await (await task).ConfigureAwait(continueOnCapturedContext);
+        }
+
+        public static async UniTask Unwrap(this UniTask<Task> task)
+        {
+            await await task;
+        }
+
+        public static async UniTask Unwrap(this UniTask<Task> task, bool continueOnCapturedContext)
+        {
+            await (await task).ConfigureAwait(continueOnCapturedContext);
+        }
+
+#if UNITY_2018_3_OR_NEWER
+
+        sealed class ToCoroutineEnumerator : IEnumerator
+        {
+            bool completed;
+            UniTask task;
+            Action<Exception> exceptionHandler = null;
+            bool isStarted = false;
+            ExceptionDispatchInfo exception;
+
+            public ToCoroutineEnumerator(UniTask task, Action<Exception> exceptionHandler)
+            {
+                completed = false;
+                this.exceptionHandler = exceptionHandler;
+                this.task = task;
+            }
+
+            async UniTaskVoid RunTask(UniTask task)
+            {
+                try
+                {
+                    await task;
+                }
+                catch (Exception ex)
+                {
+                    if (exceptionHandler != null)
+                    {
+                        exceptionHandler(ex);
+                    }
+                    else
+                    {
+                        this.exception = ExceptionDispatchInfo.Capture(ex);
+                    }
+                }
+                finally
+                {
+                    completed = true;
+                }
+            }
+
+            public object Current => null;
+
+            public bool MoveNext()
+            {
+                if (!isStarted)
+                {
+                    isStarted = true;
+                    RunTask(task).Forget();
+                }
+
+                if (exception != null)
+                {
+                    exception.Throw();
+                    return false;
+                }
+
+                return !completed;
+            }
+
+            void IEnumerator.Reset()
+            {
+            }
+        }
+
+        sealed class ToCoroutineEnumerator<T> : IEnumerator
+        {
+            bool completed;
+            Action<T> resultHandler = null;
+            Action<Exception> exceptionHandler = null;
+            bool isStarted = false;
+            UniTask<T> task;
+            object current = null;
+            ExceptionDispatchInfo exception;
+
+            public ToCoroutineEnumerator(UniTask<T> task, Action<T> resultHandler, Action<Exception> exceptionHandler)
+            {
+                completed = false;
+                this.task = task;
+                this.resultHandler = resultHandler;
+                this.exceptionHandler = exceptionHandler;
+            }
+
+            async UniTaskVoid RunTask(UniTask<T> task)
+            {
+                try
+                {
+                    var value = await task;
+                    current = value; // boxed if T is struct...
+                    if (resultHandler != null)
+                    {
+                        resultHandler(value);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    if (exceptionHandler != null)
+                    {
+                        exceptionHandler(ex);
+                    }
+                    else
+                    {
+                        this.exception = ExceptionDispatchInfo.Capture(ex);
+                    }
+                }
+                finally
+                {
+                    completed = true;
+                }
+            }
+
+            public object Current => current;
+
+            public bool MoveNext()
+            {
+                if (!isStarted)
+                {
+                    isStarted = true;
+                    RunTask(task).Forget();
+                }
+
+                if (exception != null)
+                {
+                    exception.Throw();
+                    return false;
+                }
+
+                return !completed;
+            }
+
+            void IEnumerator.Reset()
+            {
+            }
+        }
+
+#endif
+    }
+}
+

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/UniTaskExtensions.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/UniTaskExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 05460c617dae1e440861a7438535389f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/UniTaskObservableExtensions.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/UniTaskObservableExtensions.cs
@@ -1,0 +1,750 @@
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using Cysharp.Threading.Tasks.Internal;
+
+namespace Cysharp.Threading.Tasks
+{
+    public static class UniTaskObservableExtensions
+    {
+        public static UniTask<T> ToUniTask<T>(this IObservable<T> source, bool useFirstValue = false, CancellationToken cancellationToken = default)
+        {
+            var promise = new UniTaskCompletionSource<T>();
+            var disposable = new SingleAssignmentDisposable();
+
+            var observer = useFirstValue
+                ? (IObserver<T>)new FirstValueToUniTaskObserver<T>(promise, disposable, cancellationToken)
+                : (IObserver<T>)new ToUniTaskObserver<T>(promise, disposable, cancellationToken);
+
+            try
+            {
+                disposable.Disposable = source.Subscribe(observer);
+            }
+            catch (Exception ex)
+            {
+                promise.TrySetException(ex);
+            }
+
+            return promise.Task;
+        }
+
+        public static IObservable<T> ToObservable<T>(this UniTask<T> task)
+        {
+            if (task.Status.IsCompleted())
+            {
+                try
+                {
+                    return new ReturnObservable<T>(task.GetAwaiter().GetResult());
+                }
+                catch (Exception ex)
+                {
+                    return new ThrowObservable<T>(ex);
+                }
+            }
+
+            var subject = new AsyncSubject<T>();
+            Fire(subject, task).Forget();
+            return subject;
+        }
+
+        /// <summary>
+        /// Ideally returns IObservabl[Unit] is best but Cysharp.Threading.Tasks does not have Unit so return AsyncUnit instead.
+        /// </summary>
+        public static IObservable<AsyncUnit> ToObservable(this UniTask task)
+        {
+            if (task.Status.IsCompleted())
+            {
+                try
+                {
+                    task.GetAwaiter().GetResult();
+                    return new ReturnObservable<AsyncUnit>(AsyncUnit.Default);
+                }
+                catch (Exception ex)
+                {
+                    return new ThrowObservable<AsyncUnit>(ex);
+                }
+            }
+
+            var subject = new AsyncSubject<AsyncUnit>();
+            Fire(subject, task).Forget();
+            return subject;
+        }
+
+        static async UniTaskVoid Fire<T>(AsyncSubject<T> subject, UniTask<T> task)
+        {
+            T value;
+            try
+            {
+                value = await task;
+            }
+            catch (Exception ex)
+            {
+                subject.OnError(ex);
+                return;
+            }
+
+            subject.OnNext(value);
+            subject.OnCompleted();
+        }
+
+        static async UniTaskVoid Fire(AsyncSubject<AsyncUnit> subject, UniTask task)
+        {
+            try
+            {
+                await task;
+            }
+            catch (Exception ex)
+            {
+                subject.OnError(ex);
+                return;
+            }
+
+            subject.OnNext(AsyncUnit.Default);
+            subject.OnCompleted();
+        }
+
+        class ToUniTaskObserver<T> : IObserver<T>
+        {
+            static readonly Action<object> callback = OnCanceled;
+
+            readonly UniTaskCompletionSource<T> promise;
+            readonly SingleAssignmentDisposable disposable;
+            readonly CancellationToken cancellationToken;
+            readonly CancellationTokenRegistration registration;
+
+            bool hasValue;
+            T latestValue;
+
+            public ToUniTaskObserver(UniTaskCompletionSource<T> promise, SingleAssignmentDisposable disposable, CancellationToken cancellationToken)
+            {
+                this.promise = promise;
+                this.disposable = disposable;
+                this.cancellationToken = cancellationToken;
+
+                if (this.cancellationToken.CanBeCanceled)
+                {
+                    this.registration = this.cancellationToken.RegisterWithoutCaptureExecutionContext(callback, this);
+                }
+            }
+
+            static void OnCanceled(object state)
+            {
+                var self = (ToUniTaskObserver<T>)state;
+                self.disposable.Dispose();
+                self.promise.TrySetCanceled(self.cancellationToken);
+            }
+
+            public void OnNext(T value)
+            {
+                hasValue = true;
+                latestValue = value;
+            }
+
+            public void OnError(Exception error)
+            {
+                try
+                {
+                    promise.TrySetException(error);
+                }
+                finally
+                {
+                    registration.Dispose();
+                    disposable.Dispose();
+                }
+            }
+
+            public void OnCompleted()
+            {
+                try
+                {
+                    if (hasValue)
+                    {
+                        promise.TrySetResult(latestValue);
+                    }
+                    else
+                    {
+                        promise.TrySetException(new InvalidOperationException("Sequence has no elements"));
+                    }
+                }
+                finally
+                {
+                    registration.Dispose();
+                    disposable.Dispose();
+                }
+            }
+        }
+
+        class FirstValueToUniTaskObserver<T> : IObserver<T>
+        {
+            static readonly Action<object> callback = OnCanceled;
+
+            readonly UniTaskCompletionSource<T> promise;
+            readonly SingleAssignmentDisposable disposable;
+            readonly CancellationToken cancellationToken;
+            readonly CancellationTokenRegistration registration;
+
+            bool hasValue;
+
+            public FirstValueToUniTaskObserver(UniTaskCompletionSource<T> promise, SingleAssignmentDisposable disposable, CancellationToken cancellationToken)
+            {
+                this.promise = promise;
+                this.disposable = disposable;
+                this.cancellationToken = cancellationToken;
+
+                if (this.cancellationToken.CanBeCanceled)
+                {
+                    this.registration = this.cancellationToken.RegisterWithoutCaptureExecutionContext(callback, this);
+                }
+            }
+
+            static void OnCanceled(object state)
+            {
+                var self = (FirstValueToUniTaskObserver<T>)state;
+                self.disposable.Dispose();
+                self.promise.TrySetCanceled(self.cancellationToken);
+            }
+
+            public void OnNext(T value)
+            {
+                hasValue = true;
+                try
+                {
+                    promise.TrySetResult(value);
+                }
+                finally
+                {
+                    registration.Dispose();
+                    disposable.Dispose();
+                }
+            }
+
+            public void OnError(Exception error)
+            {
+                try
+                {
+                    promise.TrySetException(error);
+                }
+                finally
+                {
+                    registration.Dispose();
+                    disposable.Dispose();
+                }
+            }
+
+            public void OnCompleted()
+            {
+                try
+                {
+                    if (!hasValue)
+                    {
+                        promise.TrySetException(new InvalidOperationException("Sequence has no elements"));
+                    }
+                }
+                finally
+                {
+                    registration.Dispose();
+                    disposable.Dispose();
+                }
+            }
+        }
+
+        class ReturnObservable<T> : IObservable<T>
+        {
+            readonly T value;
+
+            public ReturnObservable(T value)
+            {
+                this.value = value;
+            }
+
+            public IDisposable Subscribe(IObserver<T> observer)
+            {
+                observer.OnNext(value);
+                observer.OnCompleted();
+                return EmptyDisposable.Instance;
+            }
+        }
+
+        class ThrowObservable<T> : IObservable<T>
+        {
+            readonly Exception value;
+
+            public ThrowObservable(Exception value)
+            {
+                this.value = value;
+            }
+
+            public IDisposable Subscribe(IObserver<T> observer)
+            {
+                observer.OnError(value);
+                return EmptyDisposable.Instance;
+            }
+        }
+    }
+}
+
+namespace Cysharp.Threading.Tasks.Internal
+{
+    // Bridges for Rx.
+
+    internal class EmptyDisposable : IDisposable
+    {
+        public static EmptyDisposable Instance = new EmptyDisposable();
+
+        EmptyDisposable()
+        {
+
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+
+    internal sealed class SingleAssignmentDisposable : IDisposable
+    {
+        readonly object gate = new object();
+        IDisposable current;
+        bool disposed;
+
+        public bool IsDisposed { get { lock (gate) { return disposed; } } }
+
+        public IDisposable Disposable
+        {
+            get
+            {
+                return current;
+            }
+            set
+            {
+                var old = default(IDisposable);
+                bool alreadyDisposed;
+                lock (gate)
+                {
+                    alreadyDisposed = disposed;
+                    old = current;
+                    if (!alreadyDisposed)
+                    {
+                        if (value == null) return;
+                        current = value;
+                    }
+                }
+
+                if (alreadyDisposed && value != null)
+                {
+                    value.Dispose();
+                    return;
+                }
+
+                if (old != null) throw new InvalidOperationException("Disposable is already set");
+            }
+        }
+
+
+        public void Dispose()
+        {
+            IDisposable old = null;
+
+            lock (gate)
+            {
+                if (!disposed)
+                {
+                    disposed = true;
+                    old = current;
+                    current = null;
+                }
+            }
+
+            if (old != null) old.Dispose();
+        }
+    }
+
+    internal sealed class AsyncSubject<T> : IObservable<T>, IObserver<T>
+    {
+        object observerLock = new object();
+
+        T lastValue;
+        bool hasValue;
+        bool isStopped;
+        bool isDisposed;
+        Exception lastError;
+        IObserver<T> outObserver = EmptyObserver<T>.Instance;
+
+        public T Value
+        {
+            get
+            {
+                ThrowIfDisposed();
+                if (!isStopped) throw new InvalidOperationException("AsyncSubject is not completed yet");
+                if (lastError != null) ExceptionDispatchInfo.Capture(lastError).Throw();
+                return lastValue;
+            }
+        }
+
+        public bool HasObservers
+        {
+            get
+            {
+                return !(outObserver is EmptyObserver<T>) && !isStopped && !isDisposed;
+            }
+        }
+
+        public bool IsCompleted { get { return isStopped; } }
+
+        public void OnCompleted()
+        {
+            IObserver<T> old;
+            T v;
+            bool hv;
+            lock (observerLock)
+            {
+                ThrowIfDisposed();
+                if (isStopped) return;
+
+                old = outObserver;
+                outObserver = EmptyObserver<T>.Instance;
+                isStopped = true;
+                v = lastValue;
+                hv = hasValue;
+            }
+
+            if (hv)
+            {
+                old.OnNext(v);
+                old.OnCompleted();
+            }
+            else
+            {
+                old.OnCompleted();
+            }
+        }
+
+        public void OnError(Exception error)
+        {
+            if (error == null) throw new ArgumentNullException("error");
+
+            IObserver<T> old;
+            lock (observerLock)
+            {
+                ThrowIfDisposed();
+                if (isStopped) return;
+
+                old = outObserver;
+                outObserver = EmptyObserver<T>.Instance;
+                isStopped = true;
+                lastError = error;
+            }
+
+            old.OnError(error);
+        }
+
+        public void OnNext(T value)
+        {
+            lock (observerLock)
+            {
+                ThrowIfDisposed();
+                if (isStopped) return;
+
+                this.hasValue = true;
+                this.lastValue = value;
+            }
+        }
+
+        public IDisposable Subscribe(IObserver<T> observer)
+        {
+            if (observer == null) throw new ArgumentNullException("observer");
+
+            var ex = default(Exception);
+            var v = default(T);
+            var hv = false;
+
+            lock (observerLock)
+            {
+                ThrowIfDisposed();
+                if (!isStopped)
+                {
+                    var listObserver = outObserver as ListObserver<T>;
+                    if (listObserver != null)
+                    {
+                        outObserver = listObserver.Add(observer);
+                    }
+                    else
+                    {
+                        var current = outObserver;
+                        if (current is EmptyObserver<T>)
+                        {
+                            outObserver = observer;
+                        }
+                        else
+                        {
+                            outObserver = new ListObserver<T>(new ImmutableList<IObserver<T>>(new[] { current, observer }));
+                        }
+                    }
+
+                    return new Subscription(this, observer);
+                }
+
+                ex = lastError;
+                v = lastValue;
+                hv = hasValue;
+            }
+
+            if (ex != null)
+            {
+                observer.OnError(ex);
+            }
+            else if (hv)
+            {
+                observer.OnNext(v);
+                observer.OnCompleted();
+            }
+            else
+            {
+                observer.OnCompleted();
+            }
+
+            return EmptyDisposable.Instance;
+        }
+
+        public void Dispose()
+        {
+            lock (observerLock)
+            {
+                isDisposed = true;
+                outObserver = DisposedObserver<T>.Instance;
+                lastError = null;
+                lastValue = default(T);
+            }
+        }
+
+        void ThrowIfDisposed()
+        {
+            if (isDisposed) throw new ObjectDisposedException("");
+        }
+        
+        class Subscription : IDisposable
+        {
+            readonly object gate = new object();
+            AsyncSubject<T> parent;
+            IObserver<T> unsubscribeTarget;
+
+            public Subscription(AsyncSubject<T> parent, IObserver<T> unsubscribeTarget)
+            {
+                this.parent = parent;
+                this.unsubscribeTarget = unsubscribeTarget;
+            }
+
+            public void Dispose()
+            {
+                lock (gate)
+                {
+                    if (parent != null)
+                    {
+                        lock (parent.observerLock)
+                        {
+                            var listObserver = parent.outObserver as ListObserver<T>;
+                            if (listObserver != null)
+                            {
+                                parent.outObserver = listObserver.Remove(unsubscribeTarget);
+                            }
+                            else
+                            {
+                                parent.outObserver = EmptyObserver<T>.Instance;
+                            }
+
+                            unsubscribeTarget = null;
+                            parent = null;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    internal class ListObserver<T> : IObserver<T>
+    {
+        private readonly ImmutableList<IObserver<T>> _observers;
+
+        public ListObserver(ImmutableList<IObserver<T>> observers)
+        {
+            _observers = observers;
+        }
+
+        public void OnCompleted()
+        {
+            var targetObservers = _observers.Data;
+            for (int i = 0; i < targetObservers.Length; i++)
+            {
+                targetObservers[i].OnCompleted();
+            }
+        }
+
+        public void OnError(Exception error)
+        {
+            var targetObservers = _observers.Data;
+            for (int i = 0; i < targetObservers.Length; i++)
+            {
+                targetObservers[i].OnError(error);
+            }
+        }
+
+        public void OnNext(T value)
+        {
+            var targetObservers = _observers.Data;
+            for (int i = 0; i < targetObservers.Length; i++)
+            {
+                targetObservers[i].OnNext(value);
+            }
+        }
+
+        internal IObserver<T> Add(IObserver<T> observer)
+        {
+            return new ListObserver<T>(_observers.Add(observer));
+        }
+
+        internal IObserver<T> Remove(IObserver<T> observer)
+        {
+            var i = Array.IndexOf(_observers.Data, observer);
+            if (i < 0)
+                return this;
+
+            if (_observers.Data.Length == 2)
+            {
+                return _observers.Data[1 - i];
+            }
+            else
+            {
+                return new ListObserver<T>(_observers.Remove(observer));
+            }
+        }
+    }
+
+    internal class EmptyObserver<T> : IObserver<T>
+    {
+        public static readonly EmptyObserver<T> Instance = new EmptyObserver<T>();
+
+        EmptyObserver()
+        {
+
+        }
+
+        public void OnCompleted()
+        {
+        }
+
+        public void OnError(Exception error)
+        {
+        }
+
+        public void OnNext(T value)
+        {
+        }
+    }
+
+    internal class ThrowObserver<T> : IObserver<T>
+    {
+        public static readonly ThrowObserver<T> Instance = new ThrowObserver<T>();
+
+        ThrowObserver()
+        {
+
+        }
+
+        public void OnCompleted()
+        {
+        }
+
+        public void OnError(Exception error)
+        {
+            ExceptionDispatchInfo.Capture(error).Throw();
+        }
+
+        public void OnNext(T value)
+        {
+        }
+    }
+
+    internal class DisposedObserver<T> : IObserver<T>
+    {
+        public static readonly DisposedObserver<T> Instance = new DisposedObserver<T>();
+
+        DisposedObserver()
+        {
+
+        }
+
+        public void OnCompleted()
+        {
+            throw new ObjectDisposedException("");
+        }
+
+        public void OnError(Exception error)
+        {
+            throw new ObjectDisposedException("");
+        }
+
+        public void OnNext(T value)
+        {
+            throw new ObjectDisposedException("");
+        }
+    }
+
+    internal class ImmutableList<T>
+    {
+        public static readonly ImmutableList<T> Empty = new ImmutableList<T>();
+
+        T[] data;
+
+        public T[] Data
+        {
+            get { return data; }
+        }
+
+        ImmutableList()
+        {
+            data = new T[0];
+        }
+
+        public ImmutableList(T[] data)
+        {
+            this.data = data;
+        }
+
+        public ImmutableList<T> Add(T value)
+        {
+            var newData = new T[data.Length + 1];
+            Array.Copy(data, newData, data.Length);
+            newData[data.Length] = value;
+            return new ImmutableList<T>(newData);
+        }
+
+        public ImmutableList<T> Remove(T value)
+        {
+            var i = IndexOf(value);
+            if (i < 0) return this;
+
+            var length = data.Length;
+            if (length == 1) return Empty;
+
+            var newData = new T[length - 1];
+
+            Array.Copy(data, 0, newData, 0, i);
+            Array.Copy(data, i + 1, newData, i, length - i - 1);
+
+            return new ImmutableList<T>(newData);
+        }
+
+        public int IndexOf(T value)
+        {
+            for (var i = 0; i < data.Length; ++i)
+            {
+                // ImmutableList only use for IObserver(no worry for boxed)
+                if (object.Equals(data[i], value)) return i;
+            }
+            return -1;
+        }
+    }
+}
+

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/UniTaskObservableExtensions.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/UniTaskObservableExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: eaea262a5ad393d419c15b3b2901d664
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/UniTaskScheduler.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/UniTaskScheduler.cs
@@ -1,0 +1,103 @@
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks
+{
+    // UniTask has no scheduler like TaskScheduler.
+    // Only handle unobserved exception.
+
+    public static class UniTaskScheduler
+    {
+        public static event Action<Exception> UnobservedTaskException;
+
+        /// <summary>
+        /// Propagate OperationCanceledException to UnobservedTaskException when true. Default is false.
+        /// </summary>
+        public static bool PropagateOperationCanceledException = false;
+
+#if UNITY_2018_3_OR_NEWER
+
+        /// <summary>
+        /// Write log type when catch unobserved exception and not registered UnobservedTaskException. Default is Exception.
+        /// </summary>
+        public static UnityEngine.LogType UnobservedExceptionWriteLogType = UnityEngine.LogType.Exception;
+
+        /// <summary>
+        /// Dispatch exception event to Unity MainThread. Default is true.
+        /// </summary>
+        public static bool DispatchUnityMainThread = true;
+        
+        // cache delegate.
+        static readonly SendOrPostCallback handleExceptionInvoke = InvokeUnobservedTaskException;
+
+        static void InvokeUnobservedTaskException(object state)
+        {
+            UnobservedTaskException((Exception)state);
+        }
+#endif
+
+        internal static void PublishUnobservedTaskException(Exception ex)
+        {
+            if (ex != null)
+            {
+                if (!PropagateOperationCanceledException && ex is OperationCanceledException)
+                {
+                    return;
+                }
+
+                if (UnobservedTaskException != null)
+                {
+#if UNITY_2018_3_OR_NEWER
+                    if (!DispatchUnityMainThread || Thread.CurrentThread.ManagedThreadId == PlayerLoopHelper.MainThreadId)
+                    {
+                        // allows inlining call.
+                        UnobservedTaskException.Invoke(ex);
+                    }
+                    else
+                    {
+                        // Post to MainThread.
+                        PlayerLoopHelper.UnitySynchronizationContext.Post(handleExceptionInvoke, ex);
+                    }
+#else
+                    UnobservedTaskException.Invoke(ex);
+#endif
+                }
+                else
+                {
+#if UNITY_2018_3_OR_NEWER
+                    string msg = null;
+                    if (UnobservedExceptionWriteLogType != UnityEngine.LogType.Exception)
+                    {
+                        msg = "UnobservedTaskException: " + ex.ToString();
+                    }
+                    switch (UnobservedExceptionWriteLogType)
+                    {
+                        case UnityEngine.LogType.Error:
+                            UnityEngine.Debug.LogError(msg);
+                            break;
+                        case UnityEngine.LogType.Assert:
+                            UnityEngine.Debug.LogAssertion(msg);
+                            break;
+                        case UnityEngine.LogType.Warning:
+                            UnityEngine.Debug.LogWarning(msg);
+                            break;
+                        case UnityEngine.LogType.Log:
+                            UnityEngine.Debug.Log(msg);
+                            break;
+                        case UnityEngine.LogType.Exception:
+                            UnityEngine.Debug.LogException(ex);
+                            break;
+                        default:
+                            break;
+                    }
+#else
+                    Console.WriteLine("UnobservedTaskException: " + ex.ToString());
+#endif
+                }
+            }
+        }
+    }
+}
+

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/UniTaskScheduler.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/UniTaskScheduler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d6cad69921702d5488d96b5ef30df1b0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/UniTaskSynchronizationContext.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/UniTaskSynchronizationContext.cs
@@ -1,0 +1,158 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks
+{
+    public class UniTaskSynchronizationContext : SynchronizationContext
+    {
+        const int MaxArrayLength = 0X7FEFFFFF;
+        const int InitialSize = 16;
+
+        static SpinLock gate = new SpinLock(false);
+        static bool dequing = false;
+
+        static int actionListCount = 0;
+        static Callback[] actionList = new Callback[InitialSize];
+
+        static int waitingListCount = 0;
+        static Callback[] waitingList = new Callback[InitialSize];
+
+        static int opCount;
+
+        public override void Send(SendOrPostCallback d, object state)
+        {
+            d(state);
+        }
+
+        public override void Post(SendOrPostCallback d, object state)
+        {
+            bool lockTaken = false;
+            try
+            {
+                gate.Enter(ref lockTaken);
+
+                if (dequing)
+                {
+                    // Ensure Capacity
+                    if (waitingList.Length == waitingListCount)
+                    {
+                        var newLength = waitingListCount * 2;
+                        if ((uint)newLength > MaxArrayLength) newLength = MaxArrayLength;
+
+                        var newArray = new Callback[newLength];
+                        Array.Copy(waitingList, newArray, waitingListCount);
+                        waitingList = newArray;
+                    }
+                    waitingList[waitingListCount] = new Callback(d, state);
+                    waitingListCount++;
+                }
+                else
+                {
+                    // Ensure Capacity
+                    if (actionList.Length == actionListCount)
+                    {
+                        var newLength = actionListCount * 2;
+                        if ((uint)newLength > MaxArrayLength) newLength = MaxArrayLength;
+
+                        var newArray = new Callback[newLength];
+                        Array.Copy(actionList, newArray, actionListCount);
+                        actionList = newArray;
+                    }
+                    actionList[actionListCount] = new Callback(d, state);
+                    actionListCount++;
+                }
+            }
+            finally
+            {
+                if (lockTaken) gate.Exit(false);
+            }
+        }
+
+        public override void OperationStarted()
+        {
+            Interlocked.Increment(ref opCount);
+        }
+
+        public override void OperationCompleted()
+        {
+            Interlocked.Decrement(ref opCount);
+        }
+
+        public override SynchronizationContext CreateCopy()
+        {
+            return this;
+        }
+
+        // delegate entrypoint.
+        internal static void Run()
+        {
+            {
+                bool lockTaken = false;
+                try
+                {
+                    gate.Enter(ref lockTaken);
+                    if (actionListCount == 0) return;
+                    dequing = true;
+                }
+                finally
+                {
+                    if (lockTaken) gate.Exit(false);
+                }
+            }
+
+            for (int i = 0; i < actionListCount; i++)
+            {
+                var action = actionList[i];
+                actionList[i] = default;
+                action.Invoke();
+            }
+
+            {
+                bool lockTaken = false;
+                try
+                {
+                    gate.Enter(ref lockTaken);
+                    dequing = false;
+
+                    var swapTempActionList = actionList;
+
+                    actionListCount = waitingListCount;
+                    actionList = waitingList;
+
+                    waitingListCount = 0;
+                    waitingList = swapTempActionList;
+                }
+                finally
+                {
+                    if (lockTaken) gate.Exit(false);
+                }
+            }
+        }
+
+        [StructLayout(LayoutKind.Auto)]
+        readonly struct Callback
+        {
+            readonly SendOrPostCallback callback;
+            readonly object state;
+
+            public Callback(SendOrPostCallback callback, object state)
+            {
+                this.callback = callback;
+                this.state = state;
+            }
+
+            public void Invoke()
+            {
+                try
+                {
+                    callback(state);
+                }
+                catch (Exception ex)
+                {
+                    UnityEngine.Debug.LogException(ex);
+                }
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/UniTaskSynchronizationContext.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/UniTaskSynchronizationContext.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: abf3aae9813db2849bce518f8596e920
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/UniTaskVoid.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/UniTaskVoid.cs
@@ -1,0 +1,19 @@
+﻿#pragma warning disable CS1591
+#pragma warning disable CS0436
+
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using Cysharp.Threading.Tasks.CompilerServices;
+
+namespace Cysharp.Threading.Tasks
+{
+    [AsyncMethodBuilder(typeof(AsyncUniTaskVoidMethodBuilder))]
+    public readonly struct UniTaskVoid
+    {
+        public void Forget()
+        {
+        }
+    }
+}
+

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/UniTaskVoid.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/UniTaskVoid.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e9f28cd922179634d863011548f89ae7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/UnityAsyncExtensions.AssetBundleRequestAllAssets.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/UnityAsyncExtensions.AssetBundleRequestAllAssets.cs
@@ -1,0 +1,198 @@
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+#if UNITY_2018_4 || UNITY_2019_4_OR_NEWER
+#if UNITASK_ASSETBUNDLE_SUPPORT
+
+using Cysharp.Threading.Tasks.Internal;
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using UnityEngine;
+
+namespace Cysharp.Threading.Tasks
+{
+    public static partial class UnityAsyncExtensions
+    {
+        public static AssetBundleRequestAllAssetsAwaiter AwaitForAllAssets(this AssetBundleRequest asyncOperation)
+        {
+            Error.ThrowArgumentNullException(asyncOperation, nameof(asyncOperation));
+            return new AssetBundleRequestAllAssetsAwaiter(asyncOperation);
+        }
+
+        public static UniTask<UnityEngine.Object[]> AwaitForAllAssets(this AssetBundleRequest asyncOperation, CancellationToken cancellationToken)
+        {
+            return AwaitForAllAssets(asyncOperation, null, PlayerLoopTiming.Update, cancellationToken: cancellationToken);
+        }
+
+        public static UniTask<UnityEngine.Object[]> AwaitForAllAssets(this AssetBundleRequest asyncOperation, IProgress<float> progress = null, PlayerLoopTiming timing = PlayerLoopTiming.Update, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Error.ThrowArgumentNullException(asyncOperation, nameof(asyncOperation));
+            if (cancellationToken.IsCancellationRequested) return UniTask.FromCanceled<UnityEngine.Object[]>(cancellationToken);
+            if (asyncOperation.isDone) return UniTask.FromResult(asyncOperation.allAssets);
+            return new UniTask<UnityEngine.Object[]>(AssetBundleRequestAllAssetsConfiguredSource.Create(asyncOperation, timing, progress, cancellationToken, out var token), token);
+        }
+
+        public struct AssetBundleRequestAllAssetsAwaiter : ICriticalNotifyCompletion
+        {
+            AssetBundleRequest asyncOperation;
+            Action<AsyncOperation> continuationAction;
+
+            public AssetBundleRequestAllAssetsAwaiter(AssetBundleRequest asyncOperation)
+            {
+                this.asyncOperation = asyncOperation;
+                this.continuationAction = null;
+            }
+
+            public AssetBundleRequestAllAssetsAwaiter GetAwaiter()
+            {
+                return this;
+            }
+
+            public bool IsCompleted => asyncOperation.isDone;
+
+            public UnityEngine.Object[] GetResult()
+            {
+                if (continuationAction != null)
+                {
+                    asyncOperation.completed -= continuationAction;
+                    continuationAction = null;
+                    var result = asyncOperation.allAssets;
+                    asyncOperation = null;
+                    return result;
+                }
+                else
+                {
+                    var result = asyncOperation.allAssets;
+                    asyncOperation = null;
+                    return result;
+                }
+            }
+
+            public void OnCompleted(Action continuation)
+            {
+                UnsafeOnCompleted(continuation);
+            }
+
+            public void UnsafeOnCompleted(Action continuation)
+            {
+                Error.ThrowWhenContinuationIsAlreadyRegistered(continuationAction);
+                continuationAction = PooledDelegate<AsyncOperation>.Create(continuation);
+                asyncOperation.completed += continuationAction;
+            }
+        }
+
+        sealed class AssetBundleRequestAllAssetsConfiguredSource : IUniTaskSource<UnityEngine.Object[]>, IPlayerLoopItem, ITaskPoolNode<AssetBundleRequestAllAssetsConfiguredSource>
+        {
+            static TaskPool<AssetBundleRequestAllAssetsConfiguredSource> pool;
+            AssetBundleRequestAllAssetsConfiguredSource nextNode;
+            public ref AssetBundleRequestAllAssetsConfiguredSource NextNode => ref nextNode;
+
+            static AssetBundleRequestAllAssetsConfiguredSource()
+            {
+                TaskPool.RegisterSizeGetter(typeof(AssetBundleRequestAllAssetsConfiguredSource), () => pool.Size);
+            }
+
+            AssetBundleRequest asyncOperation;
+            IProgress<float> progress;
+            CancellationToken cancellationToken;
+
+            UniTaskCompletionSourceCore<UnityEngine.Object[]> core;
+
+            AssetBundleRequestAllAssetsConfiguredSource()
+            {
+
+            }
+
+            public static IUniTaskSource<UnityEngine.Object[]> Create(AssetBundleRequest asyncOperation, PlayerLoopTiming timing, IProgress<float> progress, CancellationToken cancellationToken, out short token)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return AutoResetUniTaskCompletionSource<UnityEngine.Object[]>.CreateFromCanceled(cancellationToken, out token);
+                }
+
+                if (!pool.TryPop(out var result))
+                {
+                    result = new AssetBundleRequestAllAssetsConfiguredSource();
+                }
+
+                result.asyncOperation = asyncOperation;
+                result.progress = progress;
+                result.cancellationToken = cancellationToken;
+
+                TaskTracker.TrackActiveTask(result, 3);
+
+                PlayerLoopHelper.AddAction(timing, result);
+
+                token = result.core.Version;
+                return result;
+            }
+
+            public UnityEngine.Object[] GetResult(short token)
+            {
+                try
+                {
+                    return core.GetResult(token);
+                }
+                finally
+                {
+                    TryReturn();
+                }
+            }
+
+            void IUniTaskSource.GetResult(short token)
+            {
+                GetResult(token);
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+
+            public bool MoveNext()
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    core.TrySetCanceled(cancellationToken);
+                    return false;
+                }
+
+                if (progress != null)
+                {
+                    progress.Report(asyncOperation.progress);
+                }
+
+                if (asyncOperation.isDone)
+                {
+                    core.TrySetResult(asyncOperation.allAssets);
+                    return false;
+                }
+
+                return true;
+            }
+
+            bool TryReturn()
+            {
+                TaskTracker.RemoveTracking(this);
+                core.Reset();
+                asyncOperation = default;
+                progress = default;
+                cancellationToken = default;
+                return pool.TryPush(this);
+            }
+        }
+    }
+}
+
+#endif
+#endif

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/UnityAsyncExtensions.AssetBundleRequestAllAssets.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/UnityAsyncExtensions.AssetBundleRequestAllAssets.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e9147caba40da434da95b39709c13784
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/UnityAsyncExtensions.AsyncGPUReadback.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/UnityAsyncExtensions.AsyncGPUReadback.cs
@@ -1,0 +1,140 @@
+﻿ #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System;
+using System.Threading;
+using UnityEngine.Rendering;
+
+namespace Cysharp.Threading.Tasks
+{
+    public static partial class UnityAsyncExtensions
+    {
+        #region AsyncGPUReadbackRequest
+
+        public static UniTask<AsyncGPUReadbackRequest>.Awaiter GetAwaiter(this AsyncGPUReadbackRequest asyncOperation)
+        {
+            return ToUniTask(asyncOperation).GetAwaiter();
+        }
+
+        public static UniTask<AsyncGPUReadbackRequest> WithCancellation(this AsyncGPUReadbackRequest asyncOperation, CancellationToken cancellationToken)
+        {
+            return ToUniTask(asyncOperation, cancellationToken: cancellationToken);
+        }
+
+        public static UniTask<AsyncGPUReadbackRequest> ToUniTask(this AsyncGPUReadbackRequest asyncOperation, PlayerLoopTiming timing = PlayerLoopTiming.Update, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (asyncOperation.done) return UniTask.FromResult(asyncOperation);
+            return new UniTask<AsyncGPUReadbackRequest>(AsyncGPUReadbackRequestAwaiterConfiguredSource.Create(asyncOperation, timing, cancellationToken, out var token), token);
+        }
+
+        sealed class AsyncGPUReadbackRequestAwaiterConfiguredSource : IUniTaskSource<AsyncGPUReadbackRequest>, IPlayerLoopItem, ITaskPoolNode<AsyncGPUReadbackRequestAwaiterConfiguredSource>
+        {
+            static TaskPool<AsyncGPUReadbackRequestAwaiterConfiguredSource> pool;
+            AsyncGPUReadbackRequestAwaiterConfiguredSource nextNode;
+            public ref AsyncGPUReadbackRequestAwaiterConfiguredSource NextNode => ref nextNode;
+
+            static AsyncGPUReadbackRequestAwaiterConfiguredSource()
+            {
+                TaskPool.RegisterSizeGetter(typeof(AsyncGPUReadbackRequestAwaiterConfiguredSource), () => pool.Size);
+            }
+
+            AsyncGPUReadbackRequest asyncOperation;
+            CancellationToken cancellationToken;
+
+            UniTaskCompletionSourceCore<AsyncGPUReadbackRequest> core;
+
+            AsyncGPUReadbackRequestAwaiterConfiguredSource()
+            {
+
+            }
+
+            public static IUniTaskSource<AsyncGPUReadbackRequest> Create(AsyncGPUReadbackRequest asyncOperation, PlayerLoopTiming timing, CancellationToken cancellationToken, out short token)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return AutoResetUniTaskCompletionSource<AsyncGPUReadbackRequest>.CreateFromCanceled(cancellationToken, out token);
+                }
+
+                if (!pool.TryPop(out var result))
+                {
+                    result = new AsyncGPUReadbackRequestAwaiterConfiguredSource();
+                }
+
+                result.asyncOperation = asyncOperation;
+                result.cancellationToken = cancellationToken;
+
+                TaskTracker.TrackActiveTask(result, 3);
+
+                PlayerLoopHelper.AddAction(timing, result);
+
+                token = result.core.Version;
+                return result;
+            }
+
+            public AsyncGPUReadbackRequest GetResult(short token)
+            {
+                try
+                {
+                    return core.GetResult(token);
+                }
+                finally
+                {
+                    TryReturn();
+                }
+            }
+
+            void IUniTaskSource.GetResult(short token)
+            {
+                GetResult(token);
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+
+            public bool MoveNext()
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    core.TrySetCanceled(cancellationToken);
+                    return false;
+                }
+
+                if (asyncOperation.hasError)
+                {
+                    core.TrySetException(new Exception("AsyncGPUReadbackRequest.hasError = true"));
+                    return false;
+                }
+
+                if (asyncOperation.done)
+                {
+                    core.TrySetResult(asyncOperation);
+                    return false;
+                }
+
+                return true;
+            }
+
+            bool TryReturn()
+            {
+                TaskTracker.RemoveTracking(this);
+                core.Reset();
+                asyncOperation = default;
+                cancellationToken = default;
+                return pool.TryPush(this);
+            }
+        }
+
+        #endregion
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/UnityAsyncExtensions.AsyncGPUReadback.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/UnityAsyncExtensions.AsyncGPUReadback.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 98f5fedb44749ab4688674d79126b46a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/UnityAsyncExtensions.Jobs.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/UnityAsyncExtensions.Jobs.cs
@@ -1,0 +1,102 @@
+﻿#if ENABLE_MANAGED_JOBS
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System;
+using System.Threading;
+using Unity.Jobs;
+using UnityEngine;
+
+namespace Cysharp.Threading.Tasks
+{
+    public static partial class UnityAsyncExtensions
+    {
+        public static async UniTask WaitAsync(this JobHandle jobHandle, PlayerLoopTiming waitTiming, CancellationToken cancellationToken = default)
+        {
+            await UniTask.Yield(waitTiming);
+            jobHandle.Complete();
+            cancellationToken.ThrowIfCancellationRequested(); // call cancel after Complete.
+        }
+
+        public static UniTask.Awaiter GetAwaiter(this JobHandle jobHandle)
+        {
+            var handler = JobHandlePromise.Create(jobHandle, out var token);
+            {
+                PlayerLoopHelper.AddAction(PlayerLoopTiming.EarlyUpdate, handler);
+                PlayerLoopHelper.AddAction(PlayerLoopTiming.PreUpdate, handler);
+                PlayerLoopHelper.AddAction(PlayerLoopTiming.Update, handler);
+                PlayerLoopHelper.AddAction(PlayerLoopTiming.PreLateUpdate, handler);
+                PlayerLoopHelper.AddAction(PlayerLoopTiming.PostLateUpdate, handler);
+            }
+
+            return new UniTask(handler, token).GetAwaiter();
+        }
+
+        // can not pass CancellationToken because can't handle JobHandle's Complete and NativeArray.Dispose.
+
+        public static UniTask ToUniTask(this JobHandle jobHandle, PlayerLoopTiming waitTiming)
+        {
+            var handler = JobHandlePromise.Create(jobHandle, out var token);
+            {
+                PlayerLoopHelper.AddAction(waitTiming, handler);
+            }
+
+            return new UniTask(handler, token);
+        }
+
+        sealed class JobHandlePromise : IUniTaskSource, IPlayerLoopItem
+        {
+            JobHandle jobHandle;
+
+            UniTaskCompletionSourceCore<AsyncUnit> core;
+
+            // Cancellation is not supported.
+            public static JobHandlePromise Create(JobHandle jobHandle, out short token)
+            {
+                // not use pool.
+                var result = new JobHandlePromise();
+
+                result.jobHandle = jobHandle;
+
+                TaskTracker.TrackActiveTask(result, 3);
+
+                token = result.core.Version;
+                return result;
+            }
+
+            public void GetResult(short token)
+            {
+                TaskTracker.RemoveTracking(this);
+                core.GetResult(token);
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+
+            public bool MoveNext()
+            {
+                if (jobHandle.IsCompleted | PlayerLoopHelper.IsEditorApplicationQuitting)
+                {
+                    jobHandle.Complete();
+                    core.TrySetResult(AsyncUnit.Default);
+                    return false;
+                }
+
+                return true;
+            }
+        }
+    }
+}
+
+#endif

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/UnityAsyncExtensions.Jobs.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/UnityAsyncExtensions.Jobs.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 30979a768fbd4b94f8694eee8a305c99
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/UnityAsyncExtensions.MonoBehaviour.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/UnityAsyncExtensions.MonoBehaviour.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Threading;
+
+namespace Cysharp.Threading.Tasks
+{
+    public static partial class UnityAsyncExtensions
+    {
+        public static UniTask StartAsyncCoroutine(this UnityEngine.MonoBehaviour monoBehaviour, Func<CancellationToken, UniTask> asyncCoroutine)
+        {
+            var token = monoBehaviour.GetCancellationTokenOnDestroy();
+            return asyncCoroutine(token);
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/UnityAsyncExtensions.MonoBehaviour.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/UnityAsyncExtensions.MonoBehaviour.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2edd588bb09eb0a4695d039d6a1f02b2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/UnityAsyncExtensions.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/UnityAsyncExtensions.cs
@@ -1,0 +1,932 @@
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using UnityEngine;
+using Cysharp.Threading.Tasks.Internal;
+#if ENABLE_UNITYWEBREQUEST && (!UNITY_2019_1_OR_NEWER || UNITASK_WEBREQUEST_SUPPORT)
+using UnityEngine.Networking;
+#endif
+
+namespace Cysharp.Threading.Tasks
+{
+    public static partial class UnityAsyncExtensions
+    {
+        #region AsyncOperation
+
+#if !UNITY_2023_1_OR_NEWER
+        // from Unity2023.1.0a15, AsyncOperationAwaitableExtensions.GetAwaiter is defined in UnityEngine.
+
+        public static AsyncOperationAwaiter GetAwaiter(this AsyncOperation asyncOperation)
+        {
+            Error.ThrowArgumentNullException(asyncOperation, nameof(asyncOperation));
+            return new AsyncOperationAwaiter(asyncOperation);
+        }
+#endif
+
+        public static UniTask WithCancellation(this AsyncOperation asyncOperation, CancellationToken cancellationToken)
+        {
+            return ToUniTask(asyncOperation, cancellationToken: cancellationToken);
+        }
+
+        public static UniTask ToUniTask(this AsyncOperation asyncOperation, IProgress<float> progress = null, PlayerLoopTiming timing = PlayerLoopTiming.Update, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Error.ThrowArgumentNullException(asyncOperation, nameof(asyncOperation));
+            if (cancellationToken.IsCancellationRequested) return UniTask.FromCanceled(cancellationToken);
+            if (asyncOperation.isDone) return UniTask.CompletedTask;
+            return new UniTask(AsyncOperationConfiguredSource.Create(asyncOperation, timing, progress, cancellationToken, out var token), token);
+        }
+
+        public struct AsyncOperationAwaiter : ICriticalNotifyCompletion
+        {
+            AsyncOperation asyncOperation;
+            Action<AsyncOperation> continuationAction;
+
+            public AsyncOperationAwaiter(AsyncOperation asyncOperation)
+            {
+                this.asyncOperation = asyncOperation;
+                this.continuationAction = null;
+            }
+
+            public bool IsCompleted => asyncOperation.isDone;
+
+            public void GetResult()
+            {
+                if (continuationAction != null)
+                {
+                    asyncOperation.completed -= continuationAction;
+                    continuationAction = null;
+                    asyncOperation = null;
+                }
+                else
+                {
+                    asyncOperation = null;
+                }
+            }
+
+            public void OnCompleted(Action continuation)
+            {
+                UnsafeOnCompleted(continuation);
+            }
+
+            public void UnsafeOnCompleted(Action continuation)
+            {
+                Error.ThrowWhenContinuationIsAlreadyRegistered(continuationAction);
+                continuationAction = PooledDelegate<AsyncOperation>.Create(continuation);
+                asyncOperation.completed += continuationAction;
+            }
+        }
+
+        sealed class AsyncOperationConfiguredSource : IUniTaskSource, IPlayerLoopItem, ITaskPoolNode<AsyncOperationConfiguredSource>
+        {
+            static TaskPool<AsyncOperationConfiguredSource> pool;
+            AsyncOperationConfiguredSource nextNode;
+            public ref AsyncOperationConfiguredSource NextNode => ref nextNode;
+
+            static AsyncOperationConfiguredSource()
+            {
+                TaskPool.RegisterSizeGetter(typeof(AsyncOperationConfiguredSource), () => pool.Size);
+            }
+
+            AsyncOperation asyncOperation;
+            IProgress<float> progress;
+            CancellationToken cancellationToken;
+
+            UniTaskCompletionSourceCore<AsyncUnit> core;
+
+            AsyncOperationConfiguredSource()
+            {
+
+            }
+
+            public static IUniTaskSource Create(AsyncOperation asyncOperation, PlayerLoopTiming timing, IProgress<float> progress, CancellationToken cancellationToken, out short token)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return AutoResetUniTaskCompletionSource.CreateFromCanceled(cancellationToken, out token);
+                }
+
+                if (!pool.TryPop(out var result))
+                {
+                    result = new AsyncOperationConfiguredSource();
+                }
+
+                result.asyncOperation = asyncOperation;
+                result.progress = progress;
+                result.cancellationToken = cancellationToken;
+
+                TaskTracker.TrackActiveTask(result, 3);
+
+                PlayerLoopHelper.AddAction(timing, result);
+
+                token = result.core.Version;
+                return result;
+            }
+
+            public void GetResult(short token)
+            {
+                try
+                {
+                    core.GetResult(token);
+                }
+                finally
+                {
+                    TryReturn();
+                }
+            }
+
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+
+            public bool MoveNext()
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    core.TrySetCanceled(cancellationToken);
+                    return false;
+                }
+
+                if (progress != null)
+                {
+                    progress.Report(asyncOperation.progress);
+                }
+
+                if (asyncOperation.isDone)
+                {
+                    core.TrySetResult(AsyncUnit.Default);
+                    return false;
+                }
+
+                return true;
+            }
+
+            bool TryReturn()
+            {
+                TaskTracker.RemoveTracking(this);
+                core.Reset();
+                asyncOperation = default;
+                progress = default;
+                cancellationToken = default;
+                return pool.TryPush(this);
+            }
+        }
+
+        #endregion
+
+        #region ResourceRequest
+
+        public static ResourceRequestAwaiter GetAwaiter(this ResourceRequest asyncOperation)
+        {
+            Error.ThrowArgumentNullException(asyncOperation, nameof(asyncOperation));
+            return new ResourceRequestAwaiter(asyncOperation);
+        }
+
+        public static UniTask<UnityEngine.Object> WithCancellation(this ResourceRequest asyncOperation, CancellationToken cancellationToken)
+        {
+            return ToUniTask(asyncOperation, cancellationToken: cancellationToken);
+        }
+
+        public static UniTask<UnityEngine.Object> ToUniTask(this ResourceRequest asyncOperation, IProgress<float> progress = null, PlayerLoopTiming timing = PlayerLoopTiming.Update, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Error.ThrowArgumentNullException(asyncOperation, nameof(asyncOperation));
+            if (cancellationToken.IsCancellationRequested) return UniTask.FromCanceled<UnityEngine.Object>(cancellationToken);
+            if (asyncOperation.isDone) return UniTask.FromResult(asyncOperation.asset);
+            return new UniTask<UnityEngine.Object>(ResourceRequestConfiguredSource.Create(asyncOperation, timing, progress, cancellationToken, out var token), token);
+        }
+
+        public struct ResourceRequestAwaiter : ICriticalNotifyCompletion
+        {
+            ResourceRequest asyncOperation;
+            Action<AsyncOperation> continuationAction;
+
+            public ResourceRequestAwaiter(ResourceRequest asyncOperation)
+            {
+                this.asyncOperation = asyncOperation;
+                this.continuationAction = null;
+            }
+
+            public bool IsCompleted => asyncOperation.isDone;
+
+            public UnityEngine.Object GetResult()
+            {
+                if (continuationAction != null)
+                {
+                    asyncOperation.completed -= continuationAction;
+                    continuationAction = null;
+                    var result = asyncOperation.asset;
+                    asyncOperation = null;
+                    return result;
+                }
+                else
+                {
+                    var result = asyncOperation.asset;
+                    asyncOperation = null;
+                    return result;
+                }
+            }
+
+            public void OnCompleted(Action continuation)
+            {
+                UnsafeOnCompleted(continuation);
+            }
+
+            public void UnsafeOnCompleted(Action continuation)
+            {
+                Error.ThrowWhenContinuationIsAlreadyRegistered(continuationAction);
+                continuationAction = PooledDelegate<AsyncOperation>.Create(continuation);
+                asyncOperation.completed += continuationAction;
+            }
+        }
+
+        sealed class ResourceRequestConfiguredSource : IUniTaskSource<UnityEngine.Object>, IPlayerLoopItem, ITaskPoolNode<ResourceRequestConfiguredSource>
+        {
+            static TaskPool<ResourceRequestConfiguredSource> pool;
+            ResourceRequestConfiguredSource nextNode;
+            public ref ResourceRequestConfiguredSource NextNode => ref nextNode;
+
+            static ResourceRequestConfiguredSource()
+            {
+                TaskPool.RegisterSizeGetter(typeof(ResourceRequestConfiguredSource), () => pool.Size);
+            }
+
+            ResourceRequest asyncOperation;
+            IProgress<float> progress;
+            CancellationToken cancellationToken;
+
+            UniTaskCompletionSourceCore<UnityEngine.Object> core;
+
+            ResourceRequestConfiguredSource()
+            {
+
+            }
+
+            public static IUniTaskSource<UnityEngine.Object> Create(ResourceRequest asyncOperation, PlayerLoopTiming timing, IProgress<float> progress, CancellationToken cancellationToken, out short token)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return AutoResetUniTaskCompletionSource<UnityEngine.Object>.CreateFromCanceled(cancellationToken, out token);
+                }
+
+                if (!pool.TryPop(out var result))
+                {
+                    result = new ResourceRequestConfiguredSource();
+                }
+
+                result.asyncOperation = asyncOperation;
+                result.progress = progress;
+                result.cancellationToken = cancellationToken;
+
+                TaskTracker.TrackActiveTask(result, 3);
+
+                PlayerLoopHelper.AddAction(timing, result);
+
+                token = result.core.Version;
+                return result;
+            }
+
+            public UnityEngine.Object GetResult(short token)
+            {
+                try
+                {
+                    return core.GetResult(token);
+                }
+                finally
+                {
+                    TryReturn();
+                }
+            }
+
+            void IUniTaskSource.GetResult(short token)
+            {
+                GetResult(token);
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+
+            public bool MoveNext()
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    core.TrySetCanceled(cancellationToken);
+                    return false;
+                }
+
+                if (progress != null)
+                {
+                    progress.Report(asyncOperation.progress);
+                }
+
+                if (asyncOperation.isDone)
+                {
+                    core.TrySetResult(asyncOperation.asset);
+                    return false;
+                }
+
+                return true;
+            }
+
+            bool TryReturn()
+            {
+                TaskTracker.RemoveTracking(this);
+                core.Reset();
+                asyncOperation = default;
+                progress = default;
+                cancellationToken = default;
+                return pool.TryPush(this);
+            }
+        }
+
+        #endregion
+
+#if UNITASK_ASSETBUNDLE_SUPPORT
+        #region AssetBundleRequest
+
+        public static AssetBundleRequestAwaiter GetAwaiter(this AssetBundleRequest asyncOperation)
+        {
+            Error.ThrowArgumentNullException(asyncOperation, nameof(asyncOperation));
+            return new AssetBundleRequestAwaiter(asyncOperation);
+        }
+
+        public static UniTask<UnityEngine.Object> WithCancellation(this AssetBundleRequest asyncOperation, CancellationToken cancellationToken)
+        {
+            return ToUniTask(asyncOperation, cancellationToken: cancellationToken);
+        }
+
+        public static UniTask<UnityEngine.Object> ToUniTask(this AssetBundleRequest asyncOperation, IProgress<float> progress = null, PlayerLoopTiming timing = PlayerLoopTiming.Update, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Error.ThrowArgumentNullException(asyncOperation, nameof(asyncOperation));
+            if (cancellationToken.IsCancellationRequested) return UniTask.FromCanceled<UnityEngine.Object>(cancellationToken);
+            if (asyncOperation.isDone) return UniTask.FromResult(asyncOperation.asset);
+            return new UniTask<UnityEngine.Object>(AssetBundleRequestConfiguredSource.Create(asyncOperation, timing, progress, cancellationToken, out var token), token);
+        }
+
+        public struct AssetBundleRequestAwaiter : ICriticalNotifyCompletion
+        {
+            AssetBundleRequest asyncOperation;
+            Action<AsyncOperation> continuationAction;
+
+            public AssetBundleRequestAwaiter(AssetBundleRequest asyncOperation)
+            {
+                this.asyncOperation = asyncOperation;
+                this.continuationAction = null;
+            }
+
+            public bool IsCompleted => asyncOperation.isDone;
+
+            public UnityEngine.Object GetResult()
+            {
+                if (continuationAction != null)
+                {
+                    asyncOperation.completed -= continuationAction;
+                    continuationAction = null;
+                    var result = asyncOperation.asset;
+                    asyncOperation = null;
+                    return result;
+                }
+                else
+                {
+                    var result = asyncOperation.asset;
+                    asyncOperation = null;
+                    return result;
+                }
+            }
+
+            public void OnCompleted(Action continuation)
+            {
+                UnsafeOnCompleted(continuation);
+            }
+
+            public void UnsafeOnCompleted(Action continuation)
+            {
+                Error.ThrowWhenContinuationIsAlreadyRegistered(continuationAction);
+                continuationAction = PooledDelegate<AsyncOperation>.Create(continuation);
+                asyncOperation.completed += continuationAction;
+            }
+        }
+
+        sealed class AssetBundleRequestConfiguredSource : IUniTaskSource<UnityEngine.Object>, IPlayerLoopItem, ITaskPoolNode<AssetBundleRequestConfiguredSource>
+        {
+            static TaskPool<AssetBundleRequestConfiguredSource> pool;
+            AssetBundleRequestConfiguredSource nextNode;
+            public ref AssetBundleRequestConfiguredSource NextNode => ref nextNode;
+
+            static AssetBundleRequestConfiguredSource()
+            {
+                TaskPool.RegisterSizeGetter(typeof(AssetBundleRequestConfiguredSource), () => pool.Size);
+            }
+
+            AssetBundleRequest asyncOperation;
+            IProgress<float> progress;
+            CancellationToken cancellationToken;
+
+            UniTaskCompletionSourceCore<UnityEngine.Object> core;
+
+            AssetBundleRequestConfiguredSource()
+            {
+
+            }
+
+            public static IUniTaskSource<UnityEngine.Object> Create(AssetBundleRequest asyncOperation, PlayerLoopTiming timing, IProgress<float> progress, CancellationToken cancellationToken, out short token)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return AutoResetUniTaskCompletionSource<UnityEngine.Object>.CreateFromCanceled(cancellationToken, out token);
+                }
+
+                if (!pool.TryPop(out var result))
+                {
+                    result = new AssetBundleRequestConfiguredSource();
+                }
+
+                result.asyncOperation = asyncOperation;
+                result.progress = progress;
+                result.cancellationToken = cancellationToken;
+
+                TaskTracker.TrackActiveTask(result, 3);
+
+                PlayerLoopHelper.AddAction(timing, result);
+
+                token = result.core.Version;
+                return result;
+            }
+
+            public UnityEngine.Object GetResult(short token)
+            {
+                try
+                {
+                    return core.GetResult(token);
+                }
+                finally
+                {
+                    TryReturn();
+                }
+            }
+
+            void IUniTaskSource.GetResult(short token)
+            {
+                GetResult(token);
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+
+            public bool MoveNext()
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    core.TrySetCanceled(cancellationToken);
+                    return false;
+                }
+
+                if (progress != null)
+                {
+                    progress.Report(asyncOperation.progress);
+                }
+
+                if (asyncOperation.isDone)
+                {
+                    core.TrySetResult(asyncOperation.asset);
+                    return false;
+                }
+
+                return true;
+            }
+
+            bool TryReturn()
+            {
+                TaskTracker.RemoveTracking(this);
+                core.Reset();
+                asyncOperation = default;
+                progress = default;
+                cancellationToken = default;
+                return pool.TryPush(this);
+            }
+        }
+
+        #endregion
+#endif
+
+#if UNITASK_ASSETBUNDLE_SUPPORT
+        #region AssetBundleCreateRequest
+
+        public static AssetBundleCreateRequestAwaiter GetAwaiter(this AssetBundleCreateRequest asyncOperation)
+        {
+            Error.ThrowArgumentNullException(asyncOperation, nameof(asyncOperation));
+            return new AssetBundleCreateRequestAwaiter(asyncOperation);
+        }
+
+        public static UniTask<AssetBundle> WithCancellation(this AssetBundleCreateRequest asyncOperation, CancellationToken cancellationToken)
+        {
+            return ToUniTask(asyncOperation, cancellationToken: cancellationToken);
+        }
+
+        public static UniTask<AssetBundle> ToUniTask(this AssetBundleCreateRequest asyncOperation, IProgress<float> progress = null, PlayerLoopTiming timing = PlayerLoopTiming.Update, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Error.ThrowArgumentNullException(asyncOperation, nameof(asyncOperation));
+            if (cancellationToken.IsCancellationRequested) return UniTask.FromCanceled<AssetBundle>(cancellationToken);
+            if (asyncOperation.isDone) return UniTask.FromResult(asyncOperation.assetBundle);
+            return new UniTask<AssetBundle>(AssetBundleCreateRequestConfiguredSource.Create(asyncOperation, timing, progress, cancellationToken, out var token), token);
+        }
+
+        public struct AssetBundleCreateRequestAwaiter : ICriticalNotifyCompletion
+        {
+            AssetBundleCreateRequest asyncOperation;
+            Action<AsyncOperation> continuationAction;
+
+            public AssetBundleCreateRequestAwaiter(AssetBundleCreateRequest asyncOperation)
+            {
+                this.asyncOperation = asyncOperation;
+                this.continuationAction = null;
+            }
+
+            public bool IsCompleted => asyncOperation.isDone;
+
+            public AssetBundle GetResult()
+            {
+                if (continuationAction != null)
+                {
+                    asyncOperation.completed -= continuationAction;
+                    continuationAction = null;
+                    var result = asyncOperation.assetBundle;
+                    asyncOperation = null;
+                    return result;
+                }
+                else
+                {
+                    var result = asyncOperation.assetBundle;
+                    asyncOperation = null;
+                    return result;
+                }
+            }
+
+            public void OnCompleted(Action continuation)
+            {
+                UnsafeOnCompleted(continuation);
+            }
+
+            public void UnsafeOnCompleted(Action continuation)
+            {
+                Error.ThrowWhenContinuationIsAlreadyRegistered(continuationAction);
+                continuationAction = PooledDelegate<AsyncOperation>.Create(continuation);
+                asyncOperation.completed += continuationAction;
+            }
+        }
+
+        sealed class AssetBundleCreateRequestConfiguredSource : IUniTaskSource<AssetBundle>, IPlayerLoopItem, ITaskPoolNode<AssetBundleCreateRequestConfiguredSource>
+        {
+            static TaskPool<AssetBundleCreateRequestConfiguredSource> pool;
+            AssetBundleCreateRequestConfiguredSource nextNode;
+            public ref AssetBundleCreateRequestConfiguredSource NextNode => ref nextNode;
+
+            static AssetBundleCreateRequestConfiguredSource()
+            {
+                TaskPool.RegisterSizeGetter(typeof(AssetBundleCreateRequestConfiguredSource), () => pool.Size);
+            }
+
+            AssetBundleCreateRequest asyncOperation;
+            IProgress<float> progress;
+            CancellationToken cancellationToken;
+
+            UniTaskCompletionSourceCore<AssetBundle> core;
+
+            AssetBundleCreateRequestConfiguredSource()
+            {
+
+            }
+
+            public static IUniTaskSource<AssetBundle> Create(AssetBundleCreateRequest asyncOperation, PlayerLoopTiming timing, IProgress<float> progress, CancellationToken cancellationToken, out short token)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return AutoResetUniTaskCompletionSource<AssetBundle>.CreateFromCanceled(cancellationToken, out token);
+                }
+
+                if (!pool.TryPop(out var result))
+                {
+                    result = new AssetBundleCreateRequestConfiguredSource();
+                }
+
+                result.asyncOperation = asyncOperation;
+                result.progress = progress;
+                result.cancellationToken = cancellationToken;
+
+                TaskTracker.TrackActiveTask(result, 3);
+
+                PlayerLoopHelper.AddAction(timing, result);
+
+                token = result.core.Version;
+                return result;
+            }
+
+            public AssetBundle GetResult(short token)
+            {
+                try
+                {
+                    return core.GetResult(token);
+                }
+                finally
+                {
+                    TryReturn();
+                }
+            }
+
+            void IUniTaskSource.GetResult(short token)
+            {
+                GetResult(token);
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+
+            public bool MoveNext()
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    core.TrySetCanceled(cancellationToken);
+                    return false;
+                }
+
+                if (progress != null)
+                {
+                    progress.Report(asyncOperation.progress);
+                }
+
+                if (asyncOperation.isDone)
+                {
+                    core.TrySetResult(asyncOperation.assetBundle);
+                    return false;
+                }
+
+                return true;
+            }
+
+            bool TryReturn()
+            {
+                TaskTracker.RemoveTracking(this);
+                core.Reset();
+                asyncOperation = default;
+                progress = default;
+                cancellationToken = default;
+                return pool.TryPush(this);
+            }
+        }
+
+        #endregion
+#endif
+
+#if ENABLE_UNITYWEBREQUEST && (!UNITY_2019_1_OR_NEWER || UNITASK_WEBREQUEST_SUPPORT)
+        #region UnityWebRequestAsyncOperation
+
+        public static UnityWebRequestAsyncOperationAwaiter GetAwaiter(this UnityWebRequestAsyncOperation asyncOperation)
+        {
+            Error.ThrowArgumentNullException(asyncOperation, nameof(asyncOperation));
+            return new UnityWebRequestAsyncOperationAwaiter(asyncOperation);
+        }
+
+        public static UniTask<UnityWebRequest> WithCancellation(this UnityWebRequestAsyncOperation asyncOperation, CancellationToken cancellationToken)
+        {
+            return ToUniTask(asyncOperation, cancellationToken: cancellationToken);
+        }
+
+        public static UniTask<UnityWebRequest> ToUniTask(this UnityWebRequestAsyncOperation asyncOperation, IProgress<float> progress = null, PlayerLoopTiming timing = PlayerLoopTiming.Update, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Error.ThrowArgumentNullException(asyncOperation, nameof(asyncOperation));
+            if (cancellationToken.IsCancellationRequested) return UniTask.FromCanceled<UnityWebRequest>(cancellationToken);
+            if (asyncOperation.isDone)
+            {
+                if (asyncOperation.webRequest.IsError())
+                {
+                    return UniTask.FromException<UnityWebRequest>(new UnityWebRequestException(asyncOperation.webRequest));
+                }
+                return UniTask.FromResult(asyncOperation.webRequest);
+            }
+            return new UniTask<UnityWebRequest>(UnityWebRequestAsyncOperationConfiguredSource.Create(asyncOperation, timing, progress, cancellationToken, out var token), token);
+        }
+
+        public struct UnityWebRequestAsyncOperationAwaiter : ICriticalNotifyCompletion
+        {
+            UnityWebRequestAsyncOperation asyncOperation;
+            Action<AsyncOperation> continuationAction;
+
+            public UnityWebRequestAsyncOperationAwaiter(UnityWebRequestAsyncOperation asyncOperation)
+            {
+                this.asyncOperation = asyncOperation;
+                this.continuationAction = null;
+            }
+
+            public bool IsCompleted => asyncOperation.isDone;
+
+            public UnityWebRequest GetResult()
+            {
+                if (continuationAction != null)
+                {
+                    asyncOperation.completed -= continuationAction;
+                    continuationAction = null;
+                    var result = asyncOperation.webRequest;
+                    asyncOperation = null;
+                    if (result.IsError())
+                    {
+                        throw new UnityWebRequestException(result);
+                    }
+                    return result;
+                }
+                else
+                {
+                    var result = asyncOperation.webRequest;
+                    asyncOperation = null;
+                    if (result.IsError())
+                    {
+                        throw new UnityWebRequestException(result);
+                    }
+                    return result;
+                }
+            }
+
+            public void OnCompleted(Action continuation)
+            {
+                UnsafeOnCompleted(continuation);
+            }
+
+            public void UnsafeOnCompleted(Action continuation)
+            {
+                Error.ThrowWhenContinuationIsAlreadyRegistered(continuationAction);
+                continuationAction = PooledDelegate<AsyncOperation>.Create(continuation);
+                asyncOperation.completed += continuationAction;
+            }
+        }
+
+        sealed class UnityWebRequestAsyncOperationConfiguredSource : IUniTaskSource<UnityWebRequest>, IPlayerLoopItem, ITaskPoolNode<UnityWebRequestAsyncOperationConfiguredSource>
+        {
+            static TaskPool<UnityWebRequestAsyncOperationConfiguredSource> pool;
+            UnityWebRequestAsyncOperationConfiguredSource nextNode;
+            public ref UnityWebRequestAsyncOperationConfiguredSource NextNode => ref nextNode;
+
+            static UnityWebRequestAsyncOperationConfiguredSource()
+            {
+                TaskPool.RegisterSizeGetter(typeof(UnityWebRequestAsyncOperationConfiguredSource), () => pool.Size);
+            }
+
+            UnityWebRequestAsyncOperation asyncOperation;
+            IProgress<float> progress;
+            CancellationToken cancellationToken;
+
+            UniTaskCompletionSourceCore<UnityWebRequest> core;
+
+            UnityWebRequestAsyncOperationConfiguredSource()
+            {
+
+            }
+
+            public static IUniTaskSource<UnityWebRequest> Create(UnityWebRequestAsyncOperation asyncOperation, PlayerLoopTiming timing, IProgress<float> progress, CancellationToken cancellationToken, out short token)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return AutoResetUniTaskCompletionSource<UnityWebRequest>.CreateFromCanceled(cancellationToken, out token);
+                }
+
+                if (!pool.TryPop(out var result))
+                {
+                    result = new UnityWebRequestAsyncOperationConfiguredSource();
+                }
+
+                result.asyncOperation = asyncOperation;
+                result.progress = progress;
+                result.cancellationToken = cancellationToken;
+
+                TaskTracker.TrackActiveTask(result, 3);
+
+                PlayerLoopHelper.AddAction(timing, result);
+
+                token = result.core.Version;
+                return result;
+            }
+
+            public UnityWebRequest GetResult(short token)
+            {
+                try
+                {
+                    return core.GetResult(token);
+                }
+                finally
+                {
+                    TryReturn();
+                }
+            }
+
+            void IUniTaskSource.GetResult(short token)
+            {
+                GetResult(token);
+            }
+
+            public UniTaskStatus GetStatus(short token)
+            {
+                return core.GetStatus(token);
+            }
+
+            public UniTaskStatus UnsafeGetStatus()
+            {
+                return core.UnsafeGetStatus();
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token)
+            {
+                core.OnCompleted(continuation, state, token);
+            }
+
+            public bool MoveNext()
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    asyncOperation.webRequest.Abort();
+                    core.TrySetCanceled(cancellationToken);
+                    return false;
+                }
+
+                if (progress != null)
+                {
+                    progress.Report(asyncOperation.progress);
+                }
+
+                if (asyncOperation.isDone)
+                {
+                    if (asyncOperation.webRequest.IsError())
+                    {
+                        core.TrySetException(new UnityWebRequestException(asyncOperation.webRequest));
+                    }
+                    else
+                    {
+                        core.TrySetResult(asyncOperation.webRequest);
+                    }
+                    return false;
+                }
+
+                return true;
+            }
+
+            bool TryReturn()
+            {
+                TaskTracker.RemoveTracking(this);
+                core.Reset();
+                asyncOperation = default;
+                progress = default;
+                cancellationToken = default;
+                return pool.TryPush(this);
+            }
+        }
+
+        #endregion
+#endif
+
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/UnityAsyncExtensions.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/UnityAsyncExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8cc7fd65dd1433e419be4764aeb51391
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/UnityAsyncExtensions.uGUI.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/UnityAsyncExtensions.uGUI.cs
@@ -1,0 +1,858 @@
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+#if !UNITY_2019_1_OR_NEWER || UNITASK_UGUI_SUPPORT
+using System;
+using System.Threading;
+using UnityEngine;
+using UnityEngine.Events;
+using UnityEngine.UI;
+
+namespace Cysharp.Threading.Tasks
+{
+    public static partial class UnityAsyncExtensions
+    {
+        public static AsyncUnityEventHandler GetAsyncEventHandler(this UnityEvent unityEvent, CancellationToken cancellationToken)
+        {
+            return new AsyncUnityEventHandler(unityEvent, cancellationToken, false);
+        }
+
+        public static UniTask OnInvokeAsync(this UnityEvent unityEvent, CancellationToken cancellationToken)
+        {
+            return new AsyncUnityEventHandler(unityEvent, cancellationToken, true).OnInvokeAsync();
+        }
+
+        public static IUniTaskAsyncEnumerable<AsyncUnit> OnInvokeAsAsyncEnumerable(this UnityEvent unityEvent, CancellationToken cancellationToken)
+        {
+            return new UnityEventHandlerAsyncEnumerable(unityEvent, cancellationToken);
+        }
+
+        public static AsyncUnityEventHandler<T> GetAsyncEventHandler<T>(this UnityEvent<T> unityEvent, CancellationToken cancellationToken)
+        {
+            return new AsyncUnityEventHandler<T>(unityEvent, cancellationToken, false);
+        }
+
+        public static UniTask<T> OnInvokeAsync<T>(this UnityEvent<T> unityEvent, CancellationToken cancellationToken)
+        {
+            return new AsyncUnityEventHandler<T>(unityEvent, cancellationToken, true).OnInvokeAsync();
+        }
+
+        public static IUniTaskAsyncEnumerable<T> OnInvokeAsAsyncEnumerable<T>(this UnityEvent<T> unityEvent, CancellationToken cancellationToken)
+        {
+            return new UnityEventHandlerAsyncEnumerable<T>(unityEvent, cancellationToken);
+        }
+
+        public static IAsyncClickEventHandler GetAsyncClickEventHandler(this Button button)
+        {
+            return new AsyncUnityEventHandler(button.onClick, button.GetCancellationTokenOnDestroy(), false);
+        }
+
+        public static IAsyncClickEventHandler GetAsyncClickEventHandler(this Button button, CancellationToken cancellationToken)
+        {
+            return new AsyncUnityEventHandler(button.onClick, cancellationToken, false);
+        }
+
+        public static UniTask OnClickAsync(this Button button)
+        {
+            return new AsyncUnityEventHandler(button.onClick, button.GetCancellationTokenOnDestroy(), true).OnInvokeAsync();
+        }
+
+        public static UniTask OnClickAsync(this Button button, CancellationToken cancellationToken)
+        {
+            return new AsyncUnityEventHandler(button.onClick, cancellationToken, true).OnInvokeAsync();
+        }
+
+        public static IUniTaskAsyncEnumerable<AsyncUnit> OnClickAsAsyncEnumerable(this Button button)
+        {
+            return new UnityEventHandlerAsyncEnumerable(button.onClick, button.GetCancellationTokenOnDestroy());
+        }
+
+        public static IUniTaskAsyncEnumerable<AsyncUnit> OnClickAsAsyncEnumerable(this Button button, CancellationToken cancellationToken)
+        {
+            return new UnityEventHandlerAsyncEnumerable(button.onClick, cancellationToken);
+        }
+
+        public static IAsyncValueChangedEventHandler<bool> GetAsyncValueChangedEventHandler(this Toggle toggle)
+        {
+            return new AsyncUnityEventHandler<bool>(toggle.onValueChanged, toggle.GetCancellationTokenOnDestroy(), false);
+        }
+
+        public static IAsyncValueChangedEventHandler<bool> GetAsyncValueChangedEventHandler(this Toggle toggle, CancellationToken cancellationToken)
+        {
+            return new AsyncUnityEventHandler<bool>(toggle.onValueChanged, cancellationToken, false);
+        }
+
+        public static UniTask<bool> OnValueChangedAsync(this Toggle toggle)
+        {
+            return new AsyncUnityEventHandler<bool>(toggle.onValueChanged, toggle.GetCancellationTokenOnDestroy(), true).OnInvokeAsync();
+        }
+
+        public static UniTask<bool> OnValueChangedAsync(this Toggle toggle, CancellationToken cancellationToken)
+        {
+            return new AsyncUnityEventHandler<bool>(toggle.onValueChanged, cancellationToken, true).OnInvokeAsync();
+        }
+
+        public static IUniTaskAsyncEnumerable<bool> OnValueChangedAsAsyncEnumerable(this Toggle toggle)
+        {
+            return new UnityEventHandlerAsyncEnumerable<bool>(toggle.onValueChanged, toggle.GetCancellationTokenOnDestroy());
+        }
+
+        public static IUniTaskAsyncEnumerable<bool> OnValueChangedAsAsyncEnumerable(this Toggle toggle, CancellationToken cancellationToken)
+        {
+            return new UnityEventHandlerAsyncEnumerable<bool>(toggle.onValueChanged, cancellationToken);
+        }
+
+        public static IAsyncValueChangedEventHandler<float> GetAsyncValueChangedEventHandler(this Scrollbar scrollbar)
+        {
+            return new AsyncUnityEventHandler<float>(scrollbar.onValueChanged, scrollbar.GetCancellationTokenOnDestroy(), false);
+        }
+
+        public static IAsyncValueChangedEventHandler<float> GetAsyncValueChangedEventHandler(this Scrollbar scrollbar, CancellationToken cancellationToken)
+        {
+            return new AsyncUnityEventHandler<float>(scrollbar.onValueChanged, cancellationToken, false);
+        }
+
+        public static UniTask<float> OnValueChangedAsync(this Scrollbar scrollbar)
+        {
+            return new AsyncUnityEventHandler<float>(scrollbar.onValueChanged, scrollbar.GetCancellationTokenOnDestroy(), true).OnInvokeAsync();
+        }
+
+        public static UniTask<float> OnValueChangedAsync(this Scrollbar scrollbar, CancellationToken cancellationToken)
+        {
+            return new AsyncUnityEventHandler<float>(scrollbar.onValueChanged, cancellationToken, true).OnInvokeAsync();
+        }
+
+        public static IUniTaskAsyncEnumerable<float> OnValueChangedAsAsyncEnumerable(this Scrollbar scrollbar)
+        {
+            return new UnityEventHandlerAsyncEnumerable<float>(scrollbar.onValueChanged, scrollbar.GetCancellationTokenOnDestroy());
+        }
+
+        public static IUniTaskAsyncEnumerable<float> OnValueChangedAsAsyncEnumerable(this Scrollbar scrollbar, CancellationToken cancellationToken)
+        {
+            return new UnityEventHandlerAsyncEnumerable<float>(scrollbar.onValueChanged, cancellationToken);
+        }
+
+        public static IAsyncValueChangedEventHandler<Vector2> GetAsyncValueChangedEventHandler(this ScrollRect scrollRect)
+        {
+            return new AsyncUnityEventHandler<Vector2>(scrollRect.onValueChanged, scrollRect.GetCancellationTokenOnDestroy(), false);
+        }
+
+        public static IAsyncValueChangedEventHandler<Vector2> GetAsyncValueChangedEventHandler(this ScrollRect scrollRect, CancellationToken cancellationToken)
+        {
+            return new AsyncUnityEventHandler<Vector2>(scrollRect.onValueChanged, cancellationToken, false);
+        }
+
+        public static UniTask<Vector2> OnValueChangedAsync(this ScrollRect scrollRect)
+        {
+            return new AsyncUnityEventHandler<Vector2>(scrollRect.onValueChanged, scrollRect.GetCancellationTokenOnDestroy(), true).OnInvokeAsync();
+        }
+
+        public static UniTask<Vector2> OnValueChangedAsync(this ScrollRect scrollRect, CancellationToken cancellationToken)
+        {
+            return new AsyncUnityEventHandler<Vector2>(scrollRect.onValueChanged, cancellationToken, true).OnInvokeAsync();
+        }
+
+        public static IUniTaskAsyncEnumerable<Vector2> OnValueChangedAsAsyncEnumerable(this ScrollRect scrollRect)
+        {
+            return new UnityEventHandlerAsyncEnumerable<Vector2>(scrollRect.onValueChanged, scrollRect.GetCancellationTokenOnDestroy());
+        }
+
+        public static IUniTaskAsyncEnumerable<Vector2> OnValueChangedAsAsyncEnumerable(this ScrollRect scrollRect, CancellationToken cancellationToken)
+        {
+            return new UnityEventHandlerAsyncEnumerable<Vector2>(scrollRect.onValueChanged, cancellationToken);
+        }
+
+        public static IAsyncValueChangedEventHandler<float> GetAsyncValueChangedEventHandler(this Slider slider)
+        {
+            return new AsyncUnityEventHandler<float>(slider.onValueChanged, slider.GetCancellationTokenOnDestroy(), false);
+        }
+
+        public static IAsyncValueChangedEventHandler<float> GetAsyncValueChangedEventHandler(this Slider slider, CancellationToken cancellationToken)
+        {
+            return new AsyncUnityEventHandler<float>(slider.onValueChanged, cancellationToken, false);
+        }
+
+        public static UniTask<float> OnValueChangedAsync(this Slider slider)
+        {
+            return new AsyncUnityEventHandler<float>(slider.onValueChanged, slider.GetCancellationTokenOnDestroy(), true).OnInvokeAsync();
+        }
+
+        public static UniTask<float> OnValueChangedAsync(this Slider slider, CancellationToken cancellationToken)
+        {
+            return new AsyncUnityEventHandler<float>(slider.onValueChanged, cancellationToken, true).OnInvokeAsync();
+        }
+
+        public static IUniTaskAsyncEnumerable<float> OnValueChangedAsAsyncEnumerable(this Slider slider)
+        {
+            return new UnityEventHandlerAsyncEnumerable<float>(slider.onValueChanged, slider.GetCancellationTokenOnDestroy());
+        }
+
+        public static IUniTaskAsyncEnumerable<float> OnValueChangedAsAsyncEnumerable(this Slider slider, CancellationToken cancellationToken)
+        {
+            return new UnityEventHandlerAsyncEnumerable<float>(slider.onValueChanged, cancellationToken);
+        }
+
+        public static IAsyncEndEditEventHandler<string> GetAsyncEndEditEventHandler(this InputField inputField)
+        {
+            return new AsyncUnityEventHandler<string>(inputField.onEndEdit, inputField.GetCancellationTokenOnDestroy(), false);
+        }
+
+        public static IAsyncEndEditEventHandler<string> GetAsyncEndEditEventHandler(this InputField inputField, CancellationToken cancellationToken)
+        {
+            return new AsyncUnityEventHandler<string>(inputField.onEndEdit, cancellationToken, false);
+        }
+
+        public static UniTask<string> OnEndEditAsync(this InputField inputField)
+        {
+            return new AsyncUnityEventHandler<string>(inputField.onEndEdit, inputField.GetCancellationTokenOnDestroy(), true).OnInvokeAsync();
+        }
+
+        public static UniTask<string> OnEndEditAsync(this InputField inputField, CancellationToken cancellationToken)
+        {
+            return new AsyncUnityEventHandler<string>(inputField.onEndEdit, cancellationToken, true).OnInvokeAsync();
+        }
+
+        public static IUniTaskAsyncEnumerable<string> OnEndEditAsAsyncEnumerable(this InputField inputField)
+        {
+            return new UnityEventHandlerAsyncEnumerable<string>(inputField.onEndEdit, inputField.GetCancellationTokenOnDestroy());
+        }
+
+        public static IUniTaskAsyncEnumerable<string> OnEndEditAsAsyncEnumerable(this InputField inputField, CancellationToken cancellationToken)
+        {
+            return new UnityEventHandlerAsyncEnumerable<string>(inputField.onEndEdit, cancellationToken);
+        }
+
+        public static IAsyncValueChangedEventHandler<string> GetAsyncValueChangedEventHandler(this InputField inputField)
+        {
+            return new AsyncUnityEventHandler<string>(inputField.onValueChanged, inputField.GetCancellationTokenOnDestroy(), false);
+        }
+
+        public static IAsyncValueChangedEventHandler<string> GetAsyncValueChangedEventHandler(this InputField inputField, CancellationToken cancellationToken)
+        {
+            return new AsyncUnityEventHandler<string>(inputField.onValueChanged, cancellationToken, false);
+        }
+
+        public static UniTask<string> OnValueChangedAsync(this InputField inputField)
+        {
+            return new AsyncUnityEventHandler<string>(inputField.onValueChanged, inputField.GetCancellationTokenOnDestroy(), true).OnInvokeAsync();
+        }
+
+        public static UniTask<string> OnValueChangedAsync(this InputField inputField, CancellationToken cancellationToken)
+        {
+            return new AsyncUnityEventHandler<string>(inputField.onValueChanged, cancellationToken, true).OnInvokeAsync();
+        }
+
+        public static IUniTaskAsyncEnumerable<string> OnValueChangedAsAsyncEnumerable(this InputField inputField)
+        {
+            return new UnityEventHandlerAsyncEnumerable<string>(inputField.onValueChanged, inputField.GetCancellationTokenOnDestroy());
+        }
+
+        public static IUniTaskAsyncEnumerable<string> OnValueChangedAsAsyncEnumerable(this InputField inputField, CancellationToken cancellationToken)
+        {
+            return new UnityEventHandlerAsyncEnumerable<string>(inputField.onValueChanged, cancellationToken);
+        }
+
+        public static IAsyncValueChangedEventHandler<int> GetAsyncValueChangedEventHandler(this Dropdown dropdown)
+        {
+            return new AsyncUnityEventHandler<int>(dropdown.onValueChanged, dropdown.GetCancellationTokenOnDestroy(), false);
+        }
+
+        public static IAsyncValueChangedEventHandler<int> GetAsyncValueChangedEventHandler(this Dropdown dropdown, CancellationToken cancellationToken)
+        {
+            return new AsyncUnityEventHandler<int>(dropdown.onValueChanged, cancellationToken, false);
+        }
+
+        public static UniTask<int> OnValueChangedAsync(this Dropdown dropdown)
+        {
+            return new AsyncUnityEventHandler<int>(dropdown.onValueChanged, dropdown.GetCancellationTokenOnDestroy(), true).OnInvokeAsync();
+        }
+
+        public static UniTask<int> OnValueChangedAsync(this Dropdown dropdown, CancellationToken cancellationToken)
+        {
+            return new AsyncUnityEventHandler<int>(dropdown.onValueChanged, cancellationToken, true).OnInvokeAsync();
+        }
+
+        public static IUniTaskAsyncEnumerable<int> OnValueChangedAsAsyncEnumerable(this Dropdown dropdown)
+        {
+            return new UnityEventHandlerAsyncEnumerable<int>(dropdown.onValueChanged, dropdown.GetCancellationTokenOnDestroy());
+        }
+
+        public static IUniTaskAsyncEnumerable<int> OnValueChangedAsAsyncEnumerable(this Dropdown dropdown, CancellationToken cancellationToken)
+        {
+            return new UnityEventHandlerAsyncEnumerable<int>(dropdown.onValueChanged, cancellationToken);
+        }
+    }
+
+    public interface IAsyncClickEventHandler : IDisposable
+    {
+        UniTask OnClickAsync();
+    }
+
+    public interface IAsyncValueChangedEventHandler<T> : IDisposable
+    {
+        UniTask<T> OnValueChangedAsync();
+    }
+
+    public interface IAsyncEndEditEventHandler<T> : IDisposable
+    {
+        UniTask<T> OnEndEditAsync();
+    }
+
+    // for TMP_PRO
+
+    public interface IAsyncEndTextSelectionEventHandler<T> : IDisposable
+    {
+        UniTask<T> OnEndTextSelectionAsync();
+    }
+
+    public interface IAsyncTextSelectionEventHandler<T> : IDisposable
+    {
+        UniTask<T> OnTextSelectionAsync();
+    }
+
+    public interface IAsyncDeselectEventHandler<T> : IDisposable
+    {
+        UniTask<T> OnDeselectAsync();
+    }
+
+    public interface IAsyncSelectEventHandler<T> : IDisposable
+    {
+        UniTask<T> OnSelectAsync();
+    }
+
+    public interface IAsyncSubmitEventHandler<T> : IDisposable
+    {
+        UniTask<T> OnSubmitAsync();
+    }
+
+    internal class TextSelectionEventConverter : UnityEvent<(string, int, int)>, IDisposable
+    {
+        readonly UnityEvent<string, int, int> innerEvent;
+        readonly UnityAction<string, int, int> invokeDelegate;
+
+
+        public TextSelectionEventConverter(UnityEvent<string, int, int> unityEvent)
+        {
+            this.innerEvent = unityEvent;
+            this.invokeDelegate = InvokeCore;
+
+            innerEvent.AddListener(invokeDelegate);
+        }
+
+        void InvokeCore(string item1, int item2, int item3)
+        {
+            innerEvent.Invoke(item1, item2, item3);
+        }
+
+        public void Dispose()
+        {
+            innerEvent.RemoveListener(invokeDelegate);
+        }
+    }
+
+    public class AsyncUnityEventHandler : IUniTaskSource, IDisposable, IAsyncClickEventHandler
+    {
+        static Action<object> cancellationCallback = CancellationCallback;
+
+        readonly UnityAction action;
+        readonly UnityEvent unityEvent;
+
+        CancellationToken cancellationToken;
+        CancellationTokenRegistration registration;
+        bool isDisposed;
+        bool callOnce;
+
+        UniTaskCompletionSourceCore<AsyncUnit> core;
+
+        public AsyncUnityEventHandler(UnityEvent unityEvent, CancellationToken cancellationToken, bool callOnce)
+        {
+            this.cancellationToken = cancellationToken;
+            if (cancellationToken.IsCancellationRequested)
+            {
+                isDisposed = true;
+                return;
+            }
+
+            this.action = Invoke;
+            this.unityEvent = unityEvent;
+            this.callOnce = callOnce;
+
+            unityEvent.AddListener(action);
+
+            if (cancellationToken.CanBeCanceled)
+            {
+                registration = cancellationToken.RegisterWithoutCaptureExecutionContext(cancellationCallback, this);
+            }
+
+            TaskTracker.TrackActiveTask(this, 3);
+        }
+
+        public UniTask OnInvokeAsync()
+        {
+            core.Reset();
+            if (isDisposed)
+            {
+                core.TrySetCanceled(this.cancellationToken);
+            }
+            return new UniTask(this, core.Version);
+        }
+
+        void Invoke()
+        {
+            core.TrySetResult(AsyncUnit.Default);
+        }
+
+        static void CancellationCallback(object state)
+        {
+            var self = (AsyncUnityEventHandler)state;
+            self.Dispose();
+        }
+
+        public void Dispose()
+        {
+            if (!isDisposed)
+            {
+                isDisposed = true;
+                TaskTracker.RemoveTracking(this);
+                registration.Dispose();
+                if (unityEvent != null)
+                {
+                    unityEvent.RemoveListener(action);
+                }
+                core.TrySetCanceled(cancellationToken);
+            }
+        }
+
+        UniTask IAsyncClickEventHandler.OnClickAsync()
+        {
+            return OnInvokeAsync();
+        }
+
+        void IUniTaskSource.GetResult(short token)
+        {
+            try
+            {
+                core.GetResult(token);
+            }
+            finally
+            {
+                if (callOnce)
+                {
+                    Dispose();
+                }
+            }
+        }
+
+        UniTaskStatus IUniTaskSource.GetStatus(short token)
+        {
+            return core.GetStatus(token);
+        }
+
+        UniTaskStatus IUniTaskSource.UnsafeGetStatus()
+        {
+            return core.UnsafeGetStatus();
+        }
+
+        void IUniTaskSource.OnCompleted(Action<object> continuation, object state, short token)
+        {
+            core.OnCompleted(continuation, state, token);
+        }
+    }
+
+    public class AsyncUnityEventHandler<T> : IUniTaskSource<T>, IDisposable, IAsyncValueChangedEventHandler<T>, IAsyncEndEditEventHandler<T>
+        , IAsyncEndTextSelectionEventHandler<T>, IAsyncTextSelectionEventHandler<T>, IAsyncDeselectEventHandler<T>, IAsyncSelectEventHandler<T>, IAsyncSubmitEventHandler<T>
+    {
+        static Action<object> cancellationCallback = CancellationCallback;
+
+        readonly UnityAction<T> action;
+        readonly UnityEvent<T> unityEvent;
+
+        CancellationToken cancellationToken;
+        CancellationTokenRegistration registration;
+        bool isDisposed;
+        bool callOnce;
+
+        UniTaskCompletionSourceCore<T> core;
+
+        public AsyncUnityEventHandler(UnityEvent<T> unityEvent, CancellationToken cancellationToken, bool callOnce)
+        {
+            this.cancellationToken = cancellationToken;
+            if (cancellationToken.IsCancellationRequested)
+            {
+                isDisposed = true;
+                return;
+            }
+
+            this.action = Invoke;
+            this.unityEvent = unityEvent;
+            this.callOnce = callOnce;
+
+            unityEvent.AddListener(action);
+
+            if (cancellationToken.CanBeCanceled)
+            {
+                registration = cancellationToken.RegisterWithoutCaptureExecutionContext(cancellationCallback, this);
+            }
+
+            TaskTracker.TrackActiveTask(this, 3);
+        }
+
+        public UniTask<T> OnInvokeAsync()
+        {
+            core.Reset();
+            if (isDisposed)
+            {
+                core.TrySetCanceled(this.cancellationToken);
+            }
+            return new UniTask<T>(this, core.Version);
+        }
+
+        void Invoke(T result)
+        {
+            core.TrySetResult(result);
+        }
+
+        static void CancellationCallback(object state)
+        {
+            var self = (AsyncUnityEventHandler<T>)state;
+            self.Dispose();
+        }
+
+        public void Dispose()
+        {
+            if (!isDisposed)
+            {
+                isDisposed = true;
+                TaskTracker.RemoveTracking(this);
+                registration.Dispose();
+                if (unityEvent != null)
+                {
+                    // Dispose inner delegate for TextSelectionEventConverter
+                    if (unityEvent is IDisposable disp)
+                    {
+                        disp.Dispose();
+                    }
+
+                    unityEvent.RemoveListener(action);
+                }
+
+                core.TrySetCanceled();
+            }
+        }
+
+        UniTask<T> IAsyncValueChangedEventHandler<T>.OnValueChangedAsync()
+        {
+            return OnInvokeAsync();
+        }
+
+        UniTask<T> IAsyncEndEditEventHandler<T>.OnEndEditAsync()
+        {
+            return OnInvokeAsync();
+        }
+
+        UniTask<T> IAsyncEndTextSelectionEventHandler<T>.OnEndTextSelectionAsync()
+        {
+            return OnInvokeAsync();
+        }
+
+        UniTask<T> IAsyncTextSelectionEventHandler<T>.OnTextSelectionAsync()
+        {
+            return OnInvokeAsync();
+        }
+
+        UniTask<T> IAsyncDeselectEventHandler<T>.OnDeselectAsync()
+        {
+            return OnInvokeAsync();
+        }
+
+        UniTask<T> IAsyncSelectEventHandler<T>.OnSelectAsync()
+        {
+            return OnInvokeAsync();
+        }
+
+        UniTask<T> IAsyncSubmitEventHandler<T>.OnSubmitAsync()
+        {
+            return OnInvokeAsync();
+        }
+
+        T IUniTaskSource<T>.GetResult(short token)
+        {
+            try
+            {
+                return core.GetResult(token);
+            }
+            finally
+            {
+                if (callOnce)
+                {
+                    Dispose();
+                }
+            }
+        }
+
+        void IUniTaskSource.GetResult(short token)
+        {
+            ((IUniTaskSource<T>)this).GetResult(token);
+        }
+
+        UniTaskStatus IUniTaskSource.GetStatus(short token)
+        {
+            return core.GetStatus(token);
+        }
+
+        UniTaskStatus IUniTaskSource.UnsafeGetStatus()
+        {
+            return core.UnsafeGetStatus();
+        }
+
+        void IUniTaskSource.OnCompleted(Action<object> continuation, object state, short token)
+        {
+            core.OnCompleted(continuation, state, token);
+        }
+    }
+
+    public class UnityEventHandlerAsyncEnumerable : IUniTaskAsyncEnumerable<AsyncUnit>
+    {
+        readonly UnityEvent unityEvent;
+        readonly CancellationToken cancellationToken1;
+
+        public UnityEventHandlerAsyncEnumerable(UnityEvent unityEvent, CancellationToken cancellationToken)
+        {
+            this.unityEvent = unityEvent;
+            this.cancellationToken1 = cancellationToken;
+        }
+
+        public IUniTaskAsyncEnumerator<AsyncUnit> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            if (this.cancellationToken1 == cancellationToken)
+            {
+                return new UnityEventHandlerAsyncEnumerator(unityEvent, this.cancellationToken1, CancellationToken.None);
+            }
+            else
+            {
+                return new UnityEventHandlerAsyncEnumerator(unityEvent, this.cancellationToken1, cancellationToken);
+            }
+        }
+
+        class UnityEventHandlerAsyncEnumerator : MoveNextSource, IUniTaskAsyncEnumerator<AsyncUnit>
+        {
+            static readonly Action<object> cancel1 = OnCanceled1;
+            static readonly Action<object> cancel2 = OnCanceled2;
+
+            readonly UnityEvent unityEvent;
+            CancellationToken cancellationToken1;
+            CancellationToken cancellationToken2;
+
+            UnityAction unityAction;
+            CancellationTokenRegistration registration1;
+            CancellationTokenRegistration registration2;
+            bool isDisposed;
+
+            public UnityEventHandlerAsyncEnumerator(UnityEvent unityEvent, CancellationToken cancellationToken1, CancellationToken cancellationToken2)
+            {
+                this.unityEvent = unityEvent;
+                this.cancellationToken1 = cancellationToken1;
+                this.cancellationToken2 = cancellationToken2;
+            }
+
+            public AsyncUnit Current => default;
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                cancellationToken1.ThrowIfCancellationRequested();
+                cancellationToken2.ThrowIfCancellationRequested();
+                completionSource.Reset();
+
+                if (unityAction == null)
+                {
+                    unityAction = Invoke;
+
+                    TaskTracker.TrackActiveTask(this, 3);
+                    unityEvent.AddListener(unityAction);
+                    if (cancellationToken1.CanBeCanceled)
+                    {
+                        registration1 = cancellationToken1.RegisterWithoutCaptureExecutionContext(cancel1, this);
+                    }
+                    if (cancellationToken2.CanBeCanceled)
+                    {
+                        registration2 = cancellationToken2.RegisterWithoutCaptureExecutionContext(cancel2, this);
+                    }
+                }
+
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            void Invoke()
+            {
+                completionSource.TrySetResult(true);
+            }
+
+            static void OnCanceled1(object state)
+            {
+                var self = (UnityEventHandlerAsyncEnumerator)state;
+                try
+                {
+                    self.completionSource.TrySetCanceled(self.cancellationToken1);
+                }
+                finally
+                {
+                    self.DisposeAsync().Forget();
+                }
+            }
+
+            static void OnCanceled2(object state)
+            {
+                var self = (UnityEventHandlerAsyncEnumerator)state;
+                try
+                {
+                    self.completionSource.TrySetCanceled(self.cancellationToken2);
+                }
+                finally
+                {
+                    self.DisposeAsync().Forget();
+                }
+            }
+
+            public UniTask DisposeAsync()
+            {
+                if (!isDisposed)
+                {
+                    isDisposed = true;
+                    TaskTracker.RemoveTracking(this);
+                    registration1.Dispose();
+                    registration2.Dispose();
+                    unityEvent.RemoveListener(unityAction);
+
+                    completionSource.TrySetCanceled();
+                }
+
+                return default;
+            }
+        }
+    }
+
+    public class UnityEventHandlerAsyncEnumerable<T> : IUniTaskAsyncEnumerable<T>
+    {
+        readonly UnityEvent<T> unityEvent;
+        readonly CancellationToken cancellationToken1;
+
+        public UnityEventHandlerAsyncEnumerable(UnityEvent<T> unityEvent, CancellationToken cancellationToken)
+        {
+            this.unityEvent = unityEvent;
+            this.cancellationToken1 = cancellationToken;
+        }
+
+        public IUniTaskAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            if (this.cancellationToken1 == cancellationToken)
+            {
+                return new UnityEventHandlerAsyncEnumerator(unityEvent, this.cancellationToken1, CancellationToken.None);
+            }
+            else
+            {
+                return new UnityEventHandlerAsyncEnumerator(unityEvent, this.cancellationToken1, cancellationToken);
+            }
+        }
+
+        class UnityEventHandlerAsyncEnumerator : MoveNextSource, IUniTaskAsyncEnumerator<T>
+        {
+            static readonly Action<object> cancel1 = OnCanceled1;
+            static readonly Action<object> cancel2 = OnCanceled2;
+
+            readonly UnityEvent<T> unityEvent;
+            CancellationToken cancellationToken1;
+            CancellationToken cancellationToken2;
+
+            UnityAction<T> unityAction;
+            CancellationTokenRegistration registration1;
+            CancellationTokenRegistration registration2;
+            bool isDisposed;
+
+            public UnityEventHandlerAsyncEnumerator(UnityEvent<T> unityEvent, CancellationToken cancellationToken1, CancellationToken cancellationToken2)
+            {
+                this.unityEvent = unityEvent;
+                this.cancellationToken1 = cancellationToken1;
+                this.cancellationToken2 = cancellationToken2;
+            }
+
+            public T Current { get; private set; }
+
+            public UniTask<bool> MoveNextAsync()
+            {
+                cancellationToken1.ThrowIfCancellationRequested();
+                cancellationToken2.ThrowIfCancellationRequested();
+                completionSource.Reset();
+
+                if (unityAction == null)
+                {
+                    unityAction = Invoke;
+
+                    TaskTracker.TrackActiveTask(this, 3);
+                    unityEvent.AddListener(unityAction);
+                    if (cancellationToken1.CanBeCanceled)
+                    {
+                        registration1 = cancellationToken1.RegisterWithoutCaptureExecutionContext(cancel1, this);
+                    }
+                    if (cancellationToken2.CanBeCanceled)
+                    {
+                        registration2 = cancellationToken2.RegisterWithoutCaptureExecutionContext(cancel2, this);
+                    }
+                }
+
+                return new UniTask<bool>(this, completionSource.Version);
+            }
+
+            void Invoke(T value)
+            {
+                Current = value;
+                completionSource.TrySetResult(true);
+            }
+
+            static void OnCanceled1(object state)
+            {
+                var self = (UnityEventHandlerAsyncEnumerator)state;
+                try
+                {
+                    self.completionSource.TrySetCanceled(self.cancellationToken1);
+                }
+                finally
+                {
+                    self.DisposeAsync().Forget();
+                }
+            }
+
+            static void OnCanceled2(object state)
+            {
+                var self = (UnityEventHandlerAsyncEnumerator)state;
+                try
+                {
+                    self.completionSource.TrySetCanceled(self.cancellationToken2);
+                }
+                finally
+                {
+                    self.DisposeAsync().Forget();
+                }
+            }
+
+            public UniTask DisposeAsync()
+            {
+                if (!isDisposed)
+                {
+                    isDisposed = true;
+                    TaskTracker.RemoveTracking(this);
+                    registration1.Dispose();
+                    registration2.Dispose();
+                    if (unityEvent is IDisposable disp)
+                    {
+                        disp.Dispose();
+                    }
+                    unityEvent.RemoveListener(unityAction);
+
+                    completionSource.TrySetCanceled();
+                }
+
+                return default;
+            }
+        }
+    }
+}
+
+#endif

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/UnityAsyncExtensions.uGUI.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/UnityAsyncExtensions.uGUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6804799fba2376d4099561d176101aff
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/UnityBindingExtensions.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/UnityBindingExtensions.cs
@@ -1,0 +1,245 @@
+﻿using System;
+using System.Threading;
+using UnityEngine;
+#if !UNITY_2019_1_OR_NEWER || UNITASK_UGUI_SUPPORT
+using UnityEngine.UI;
+#endif
+
+namespace Cysharp.Threading.Tasks
+{
+    public static class UnityBindingExtensions
+    {
+#if !UNITY_2019_1_OR_NEWER || UNITASK_UGUI_SUPPORT
+        // <string> -> Text
+
+        public static void BindTo(this IUniTaskAsyncEnumerable<string> source, UnityEngine.UI.Text text, bool rebindOnError = true)
+        {
+            BindToCore(source, text, text.GetCancellationTokenOnDestroy(), rebindOnError).Forget();
+        }
+
+        public static void BindTo(this IUniTaskAsyncEnumerable<string> source, UnityEngine.UI.Text text, CancellationToken cancellationToken, bool rebindOnError = true)
+        {
+            BindToCore(source, text, cancellationToken, rebindOnError).Forget();
+        }
+
+        static async UniTaskVoid BindToCore(IUniTaskAsyncEnumerable<string> source, UnityEngine.UI.Text text, CancellationToken cancellationToken, bool rebindOnError)
+        {
+            var repeat = false;
+            BIND_AGAIN:
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (true)
+                {
+                    bool moveNext;
+                    try
+                    {
+                        moveNext = await e.MoveNextAsync();
+                        repeat = false;
+                    }
+                    catch (Exception ex)
+                    {
+                        if (ex is OperationCanceledException) return;
+
+                        if (rebindOnError && !repeat)
+                        {
+                            repeat = true;
+                            goto BIND_AGAIN;
+                        }
+                        else
+                        {
+                            throw;
+                        }
+                    }
+
+                    if (!moveNext) return;
+
+                    text.text = e.Current;
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+        }
+
+        // <T> -> Text
+
+        public static void BindTo<T>(this IUniTaskAsyncEnumerable<T> source, UnityEngine.UI.Text text, bool rebindOnError = true)
+        {
+            BindToCore(source, text, text.GetCancellationTokenOnDestroy(), rebindOnError).Forget();
+        }
+
+        public static void BindTo<T>(this IUniTaskAsyncEnumerable<T> source, UnityEngine.UI.Text text, CancellationToken cancellationToken, bool rebindOnError = true)
+        {
+            BindToCore(source, text, cancellationToken, rebindOnError).Forget();
+        }
+
+        public static void BindTo<T>(this AsyncReactiveProperty<T> source, UnityEngine.UI.Text text, bool rebindOnError = true)
+        {
+            BindToCore(source, text, text.GetCancellationTokenOnDestroy(), rebindOnError).Forget();
+        }
+
+        static async UniTaskVoid BindToCore<T>(IUniTaskAsyncEnumerable<T> source, UnityEngine.UI.Text text, CancellationToken cancellationToken, bool rebindOnError)
+        {
+            var repeat = false;
+            BIND_AGAIN:
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (true)
+                {
+                    bool moveNext;
+                    try
+                    {
+                        moveNext = await e.MoveNextAsync();
+                        repeat = false;
+                    }
+                    catch (Exception ex)
+                    {
+                        if (ex is OperationCanceledException) return;
+
+                        if (rebindOnError && !repeat)
+                        {
+                            repeat = true;
+                            goto BIND_AGAIN;
+                        }
+                        else
+                        {
+                            throw;
+                        }
+                    }
+
+                    if (!moveNext) return;
+
+                    text.text = e.Current.ToString();
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+        }
+
+        // <bool> -> Selectable
+
+        public static void BindTo(this IUniTaskAsyncEnumerable<bool> source, Selectable selectable, bool rebindOnError = true)
+        {
+            BindToCore(source, selectable, selectable.GetCancellationTokenOnDestroy(), rebindOnError).Forget();
+        }
+
+        public static void BindTo(this IUniTaskAsyncEnumerable<bool> source, Selectable selectable, CancellationToken cancellationToken, bool rebindOnError = true)
+        {
+            BindToCore(source, selectable, cancellationToken, rebindOnError).Forget();
+        }
+
+        static async UniTaskVoid BindToCore(IUniTaskAsyncEnumerable<bool> source, Selectable selectable, CancellationToken cancellationToken, bool rebindOnError)
+        {
+            var repeat = false;
+            BIND_AGAIN:
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (true)
+                {
+                    bool moveNext;
+                    try
+                    {
+                        moveNext = await e.MoveNextAsync();
+                        repeat = false;
+                    }
+                    catch (Exception ex)
+                    {
+                        if (ex is OperationCanceledException) return;
+
+                        if (rebindOnError && !repeat)
+                        {
+                            repeat = true;
+                            goto BIND_AGAIN;
+                        }
+                        else
+                        {
+                            throw;
+                        }
+                    }
+
+                    if (!moveNext) return;
+
+
+                    selectable.interactable = e.Current;
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+        }
+#endif
+
+        // <T> -> Action
+
+        public static void BindTo<TSource, TObject>(this IUniTaskAsyncEnumerable<TSource> source, TObject monoBehaviour, Action<TObject, TSource> bindAction, bool rebindOnError = true)
+            where TObject : MonoBehaviour
+        {
+            BindToCore(source, monoBehaviour, bindAction, monoBehaviour.GetCancellationTokenOnDestroy(), rebindOnError).Forget();
+        }
+
+        public static void BindTo<TSource, TObject>(this IUniTaskAsyncEnumerable<TSource> source, TObject bindTarget, Action<TObject, TSource> bindAction, CancellationToken cancellationToken, bool rebindOnError = true)
+        {
+            BindToCore(source, bindTarget, bindAction, cancellationToken, rebindOnError).Forget();
+        }
+
+        static async UniTaskVoid BindToCore<TSource, TObject>(IUniTaskAsyncEnumerable<TSource> source, TObject bindTarget, Action<TObject, TSource> bindAction, CancellationToken cancellationToken, bool rebindOnError)
+        {
+            var repeat = false;
+            BIND_AGAIN:
+            var e = source.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (true)
+                {
+                    bool moveNext;
+                    try
+                    {
+                        moveNext = await e.MoveNextAsync();
+                        repeat = false;
+                    }
+                    catch (Exception ex)
+                    {
+                        if (ex is OperationCanceledException) return;
+
+                        if (rebindOnError && !repeat)
+                        {
+                            repeat = true;
+                            goto BIND_AGAIN;
+                        }
+                        else
+                        {
+                            throw;
+                        }
+                    }
+
+                    if (!moveNext) return;
+
+                    bindAction(bindTarget, e.Current);
+                }
+            }
+            finally
+            {
+                if (e != null)
+                {
+                    await e.DisposeAsync();
+                }
+            }
+        }
+    }
+}

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/UnityBindingExtensions.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/UnityBindingExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 090b20e3528552b4a8d751f7df525c2b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/UnityWebRequestException.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/UnityWebRequestException.cs
@@ -1,0 +1,67 @@
+#if ENABLE_UNITYWEBREQUEST && (!UNITY_2019_1_OR_NEWER || UNITASK_WEBREQUEST_SUPPORT)
+
+using System;
+using System.Collections.Generic;
+using UnityEngine.Networking;
+
+namespace Cysharp.Threading.Tasks
+{
+    public class UnityWebRequestException : Exception
+    {
+        public UnityWebRequest UnityWebRequest { get; }
+#if UNITY_2020_2_OR_NEWER
+        public UnityWebRequest.Result Result { get; }
+#else
+        public bool IsNetworkError { get; }
+        public bool IsHttpError { get; }
+#endif
+        public string Error { get; }
+        public string Text { get; }
+        public long ResponseCode { get; }
+        public Dictionary<string, string> ResponseHeaders { get; }
+
+        string msg;
+
+        public UnityWebRequestException(UnityWebRequest unityWebRequest)
+        {
+            this.UnityWebRequest = unityWebRequest;
+#if UNITY_2020_2_OR_NEWER
+            this.Result = unityWebRequest.result;
+#else
+            this.IsNetworkError = unityWebRequest.isNetworkError;
+            this.IsHttpError = unityWebRequest.isHttpError;
+#endif
+            this.Error = unityWebRequest.error;
+            this.ResponseCode = unityWebRequest.responseCode;
+            if (UnityWebRequest.downloadHandler != null)
+            {
+                if (unityWebRequest.downloadHandler is DownloadHandlerBuffer dhb)
+                {
+                    this.Text = dhb.text;
+                }
+            }
+            this.ResponseHeaders = unityWebRequest.GetResponseHeaders();
+        }
+
+        public override string Message
+        {
+            get
+            {
+                if (msg == null)
+                {
+                    if(!string.IsNullOrWhiteSpace(Text))
+                    {
+                        msg = Error + Environment.NewLine + Text;
+                    }
+                    else
+                    {
+                        msg = Error;
+                    }
+                }
+                return msg;
+            }
+        }
+    }
+}
+
+#endif

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/UnityWebRequestException.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/UnityWebRequestException.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 013a499e522703a42962a779b4d9850c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/_InternalVisibleTo.cs
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/_InternalVisibleTo.cs
@@ -1,0 +1,6 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("UniTask.Linq")]
+[assembly: InternalsVisibleTo("UniTask.Addressables")]
+[assembly: InternalsVisibleTo("UniTask.DOTween")]
+[assembly: InternalsVisibleTo("UniTask.TextMeshPro")]

--- a/Cauldron/Assets/Plugins/UniTask/Runtime/_InternalVisibleTo.cs.meta
+++ b/Cauldron/Assets/Plugins/UniTask/Runtime/_InternalVisibleTo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8507e97eb606fad4b99c6edf92e19cb8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Plugins/UniTask/package.json
+++ b/Cauldron/Assets/Plugins/UniTask/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "com.cysharp.unitask",
+    "displayName": "UniTask",
+    "author": { "name": "Cysharp, Inc.", "url": "https://cysharp.co.jp/en/" },
+    "version": "2.3.3",
+    "unity": "2018.4",
+    "description": "Provides an efficient async/await integration to Unity.",
+    "keywords": [ "async/await", "async", "Task", "UniTask" ],
+    "license": "MIT",
+    "category": "Task",
+    "dependencies": {}
+}

--- a/Cauldron/Assets/Plugins/UniTask/package.json.meta
+++ b/Cauldron/Assets/Plugins/UniTask/package.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d1a9a71f68bb0d04db91ddaa3329abf9
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Scenes/Main_desktop.unity
+++ b/Cauldron/Assets/Scenes/Main_desktop.unity
@@ -2560,17 +2560,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f6654de298b34bfead649ffb11bb4918, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &1093776957 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6757446306212766796, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
-  m_PrefabInstance: {fileID: 6473006011012922249}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &1097069312
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2728,17 +2717,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 3042944657875605219, guid: 0d470b4f39da8c2faa26706ae24d61c4, type: 3}
   m_PrefabInstance: {fileID: 1097069312}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1103599555 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6329640101207629244, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
-  m_PrefabInstance: {fileID: 6473006011012922249}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &1153789303
 GameObject:
   m_ObjectHideFlags: 0
@@ -4460,17 +4438,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 3042944657875605219, guid: 0d470b4f39da8c2faa26706ae24d61c4, type: 3}
   m_PrefabInstance: {fileID: 1890490583}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1891540163 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 3804933415849432442, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
-  m_PrefabInstance: {fileID: 6473006011012922249}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &1913952887
 GameObject:
   m_ObjectHideFlags: 0
@@ -44139,82 +44106,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 2027161261}
     m_Modifications:
-    - target: {fileID: 89690296189175350, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
-      propertyPath: image
-      value: 
-      objectReference: {fileID: 1093776957}
-    - target: {fileID: 89690296189175350, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
-      propertyPath: panel
-      value: 
-      objectReference: {fileID: 2079205777}
-    - target: {fileID: 89690296189175350, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
-      propertyPath: locked
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 89690296189175350, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
-      propertyPath: number
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 89690296189175350, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
-      propertyPath: current
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 89690296189175350, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
-      propertyPath: unlocked
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 89690296189175350, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
-      propertyPath: lockedHighlighted
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 373057622696401439, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
-      propertyPath: panel
-      value: 
-      objectReference: {fileID: 2079205777}
-    - target: {fileID: 373057622696401439, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
-      propertyPath: locked
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 373057622696401439, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
-      propertyPath: current
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 373057622696401439, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
-      propertyPath: unlocked
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 373057622696401439, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
-      propertyPath: lockedHighlighted
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 805730261244182470, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
-      propertyPath: image
-      value: 
-      objectReference: {fileID: 1103599555}
-    - target: {fileID: 805730261244182470, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
-      propertyPath: panel
-      value: 
-      objectReference: {fileID: 2079205777}
-    - target: {fileID: 805730261244182470, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
-      propertyPath: locked
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 805730261244182470, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
-      propertyPath: number
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 805730261244182470, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
-      propertyPath: current
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 805730261244182470, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
-      propertyPath: unlocked
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 805730261244182470, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
-      propertyPath: lockedHighlighted
-      value: 
-      objectReference: {fileID: 0}
     - target: {fileID: 983583039303105097, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -44230,26 +44121,6 @@ PrefabInstance:
     - target: {fileID: 983583039303105097, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1471259376261031269, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
-      propertyPath: panel
-      value: 
-      objectReference: {fileID: 2079205777}
-    - target: {fileID: 1471259376261031269, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
-      propertyPath: locked
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 1471259376261031269, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
-      propertyPath: current
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 1471259376261031269, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
-      propertyPath: unlocked
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 1471259376261031269, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
-      propertyPath: lockedHighlighted
-      value: 
       objectReference: {fileID: 0}
     - target: {fileID: 3759971623509295245, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
       propertyPath: m_AnchorMax.y
@@ -44398,34 +44269,6 @@ PrefabInstance:
     - target: {fileID: 6757446306212766794, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7508687560936896256, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
-      propertyPath: image
-      value: 
-      objectReference: {fileID: 1891540163}
-    - target: {fileID: 7508687560936896256, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
-      propertyPath: panel
-      value: 
-      objectReference: {fileID: 2079205777}
-    - target: {fileID: 7508687560936896256, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
-      propertyPath: locked
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 7508687560936896256, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
-      propertyPath: number
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7508687560936896256, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
-      propertyPath: current
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 7508687560936896256, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
-      propertyPath: unlocked
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 7508687560936896256, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
-      propertyPath: lockedHighlighted
-      value: 
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
@@ -44633,11 +44476,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8623712691376270924, guid: 91a3c0984198dad4ab7b7e9c485ea986, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8623712691376270924, guid: 91a3c0984198dad4ab7b7e9c485ea986, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8623712691376270924, guid: 91a3c0984198dad4ab7b7e9c485ea986, type: 3}
       propertyPath: m_SizeDelta.x
@@ -44653,15 +44496,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8623712691376270924, guid: 91a3c0984198dad4ab7b7e9c485ea986, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -85.2282
       objectReference: {fileID: 0}
     - target: {fileID: 8623712691454781668, guid: 91a3c0984198dad4ab7b7e9c485ea986, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8623712691454781668, guid: 91a3c0984198dad4ab7b7e9c485ea986, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8623712691454781668, guid: 91a3c0984198dad4ab7b7e9c485ea986, type: 3}
       propertyPath: m_SizeDelta.x
@@ -44677,15 +44520,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8623712691454781668, guid: 91a3c0984198dad4ab7b7e9c485ea986, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -1130.903
       objectReference: {fileID: 0}
     - target: {fileID: 8623712691945399254, guid: 91a3c0984198dad4ab7b7e9c485ea986, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8623712691945399254, guid: 91a3c0984198dad4ab7b7e9c485ea986, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8623712691945399254, guid: 91a3c0984198dad4ab7b7e9c485ea986, type: 3}
       propertyPath: m_SizeDelta.x
@@ -44701,15 +44544,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8623712691945399254, guid: 91a3c0984198dad4ab7b7e9c485ea986, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -365.29202
       objectReference: {fileID: 0}
     - target: {fileID: 8623712691978736945, guid: 91a3c0984198dad4ab7b7e9c485ea986, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8623712691978736945, guid: 91a3c0984198dad4ab7b7e9c485ea986, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8623712691978736945, guid: 91a3c0984198dad4ab7b7e9c485ea986, type: 3}
       propertyPath: m_SizeDelta.x
@@ -44725,15 +44568,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8623712691978736945, guid: 91a3c0984198dad4ab7b7e9c485ea986, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -1786.6111
       objectReference: {fileID: 0}
     - target: {fileID: 8623712692416809425, guid: 91a3c0984198dad4ab7b7e9c485ea986, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8623712692416809425, guid: 91a3c0984198dad4ab7b7e9c485ea986, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8623712692416809425, guid: 91a3c0984198dad4ab7b7e9c485ea986, type: 3}
       propertyPath: m_SizeDelta.x
@@ -44749,15 +44592,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8623712692416809425, guid: 91a3c0984198dad4ab7b7e9c485ea986, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -1624.7771
       objectReference: {fileID: 0}
     - target: {fileID: 8623712692756528935, guid: 91a3c0984198dad4ab7b7e9c485ea986, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8623712692756528935, guid: 91a3c0984198dad4ab7b7e9c485ea986, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8623712692756528935, guid: 91a3c0984198dad4ab7b7e9c485ea986, type: 3}
       propertyPath: m_SizeDelta.x
@@ -44773,7 +44616,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8623712692756528935, guid: 91a3c0984198dad4ab7b7e9c485ea986, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -689.00525
       objectReference: {fileID: 0}
     - target: {fileID: 8623712692758641660, guid: 91a3c0984198dad4ab7b7e9c485ea986, type: 3}
       propertyPath: tutorialScript

--- a/Cauldron/Assets/Scenes/Main_desktop.unity
+++ b/Cauldron/Assets/Scenes/Main_desktop.unity
@@ -2560,6 +2560,17 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f6654de298b34bfead649ffb11bb4918, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &1093776957 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6757446306212766796, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
+  m_PrefabInstance: {fileID: 6473006011012922249}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1097069312
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2717,6 +2728,17 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 3042944657875605219, guid: 0d470b4f39da8c2faa26706ae24d61c4, type: 3}
   m_PrefabInstance: {fileID: 1097069312}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1103599555 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6329640101207629244, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
+  m_PrefabInstance: {fileID: 6473006011012922249}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1153789303
 GameObject:
   m_ObjectHideFlags: 0
@@ -4438,6 +4460,17 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 3042944657875605219, guid: 0d470b4f39da8c2faa26706ae24d61c4, type: 3}
   m_PrefabInstance: {fileID: 1890490583}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1891540163 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3804933415849432442, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
+  m_PrefabInstance: {fileID: 6473006011012922249}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1913952887
 GameObject:
   m_ObjectHideFlags: 0
@@ -44106,6 +44139,82 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 2027161261}
     m_Modifications:
+    - target: {fileID: 89690296189175350, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
+      propertyPath: image
+      value: 
+      objectReference: {fileID: 1093776957}
+    - target: {fileID: 89690296189175350, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
+      propertyPath: panel
+      value: 
+      objectReference: {fileID: 2079205777}
+    - target: {fileID: 89690296189175350, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
+      propertyPath: locked
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 89690296189175350, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
+      propertyPath: number
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 89690296189175350, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
+      propertyPath: current
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 89690296189175350, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
+      propertyPath: unlocked
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 89690296189175350, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
+      propertyPath: lockedHighlighted
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 373057622696401439, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
+      propertyPath: panel
+      value: 
+      objectReference: {fileID: 2079205777}
+    - target: {fileID: 373057622696401439, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
+      propertyPath: locked
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 373057622696401439, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
+      propertyPath: current
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 373057622696401439, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
+      propertyPath: unlocked
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 373057622696401439, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
+      propertyPath: lockedHighlighted
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 805730261244182470, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
+      propertyPath: image
+      value: 
+      objectReference: {fileID: 1103599555}
+    - target: {fileID: 805730261244182470, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
+      propertyPath: panel
+      value: 
+      objectReference: {fileID: 2079205777}
+    - target: {fileID: 805730261244182470, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
+      propertyPath: locked
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 805730261244182470, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
+      propertyPath: number
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 805730261244182470, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
+      propertyPath: current
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 805730261244182470, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
+      propertyPath: unlocked
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 805730261244182470, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
+      propertyPath: lockedHighlighted
+      value: 
+      objectReference: {fileID: 0}
     - target: {fileID: 983583039303105097, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -44121,6 +44230,26 @@ PrefabInstance:
     - target: {fileID: 983583039303105097, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1471259376261031269, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
+      propertyPath: panel
+      value: 
+      objectReference: {fileID: 2079205777}
+    - target: {fileID: 1471259376261031269, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
+      propertyPath: locked
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1471259376261031269, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
+      propertyPath: current
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1471259376261031269, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
+      propertyPath: unlocked
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1471259376261031269, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
+      propertyPath: lockedHighlighted
+      value: 
       objectReference: {fileID: 0}
     - target: {fileID: 3759971623509295245, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
       propertyPath: m_AnchorMax.y
@@ -44269,6 +44398,34 @@ PrefabInstance:
     - target: {fileID: 6757446306212766794, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7508687560936896256, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
+      propertyPath: image
+      value: 
+      objectReference: {fileID: 1891540163}
+    - target: {fileID: 7508687560936896256, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
+      propertyPath: panel
+      value: 
+      objectReference: {fileID: 2079205777}
+    - target: {fileID: 7508687560936896256, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
+      propertyPath: locked
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 7508687560936896256, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
+      propertyPath: number
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7508687560936896256, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
+      propertyPath: current
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 7508687560936896256, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
+      propertyPath: unlocked
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 7508687560936896256, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
+      propertyPath: lockedHighlighted
+      value: 
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a30141408f1dfd7499b59c07ab3daa6b, type: 3}
@@ -44476,11 +44633,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8623712691376270924, guid: 91a3c0984198dad4ab7b7e9c485ea986, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8623712691376270924, guid: 91a3c0984198dad4ab7b7e9c485ea986, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8623712691376270924, guid: 91a3c0984198dad4ab7b7e9c485ea986, type: 3}
       propertyPath: m_SizeDelta.x
@@ -44496,15 +44653,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8623712691376270924, guid: 91a3c0984198dad4ab7b7e9c485ea986, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -85.2282
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8623712691454781668, guid: 91a3c0984198dad4ab7b7e9c485ea986, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8623712691454781668, guid: 91a3c0984198dad4ab7b7e9c485ea986, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8623712691454781668, guid: 91a3c0984198dad4ab7b7e9c485ea986, type: 3}
       propertyPath: m_SizeDelta.x
@@ -44520,15 +44677,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8623712691454781668, guid: 91a3c0984198dad4ab7b7e9c485ea986, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -1130.903
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8623712691945399254, guid: 91a3c0984198dad4ab7b7e9c485ea986, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8623712691945399254, guid: 91a3c0984198dad4ab7b7e9c485ea986, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8623712691945399254, guid: 91a3c0984198dad4ab7b7e9c485ea986, type: 3}
       propertyPath: m_SizeDelta.x
@@ -44544,15 +44701,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8623712691945399254, guid: 91a3c0984198dad4ab7b7e9c485ea986, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -365.29202
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8623712691978736945, guid: 91a3c0984198dad4ab7b7e9c485ea986, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8623712691978736945, guid: 91a3c0984198dad4ab7b7e9c485ea986, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8623712691978736945, guid: 91a3c0984198dad4ab7b7e9c485ea986, type: 3}
       propertyPath: m_SizeDelta.x
@@ -44568,15 +44725,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8623712691978736945, guid: 91a3c0984198dad4ab7b7e9c485ea986, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -1786.6111
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8623712692416809425, guid: 91a3c0984198dad4ab7b7e9c485ea986, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8623712692416809425, guid: 91a3c0984198dad4ab7b7e9c485ea986, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8623712692416809425, guid: 91a3c0984198dad4ab7b7e9c485ea986, type: 3}
       propertyPath: m_SizeDelta.x
@@ -44592,15 +44749,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8623712692416809425, guid: 91a3c0984198dad4ab7b7e9c485ea986, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -1624.7771
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8623712692756528935, guid: 91a3c0984198dad4ab7b7e9c485ea986, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8623712692756528935, guid: 91a3c0984198dad4ab7b7e9c485ea986, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8623712692756528935, guid: 91a3c0984198dad4ab7b7e9c485ea986, type: 3}
       propertyPath: m_SizeDelta.x
@@ -44616,7 +44773,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8623712692756528935, guid: 91a3c0984198dad4ab7b7e9c485ea986, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -689.00525
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8623712692758641660, guid: 91a3c0984198dad4ab7b7e9c485ea986, type: 3}
       propertyPath: tutorialScript

--- a/Cauldron/Assets/Scripts/EncounterListWrapper.cs
+++ b/Cauldron/Assets/Scripts/EncounterListWrapper.cs
@@ -1,0 +1,9 @@
+﻿using System;
+using System.Collections.Generic;
+using CauldronCodebase;
+
+[Serializable]
+public class EncounterListWrapper
+{
+    public List<Encounter> encounters;
+}

--- a/Cauldron/Assets/Scripts/EncounterListWrapper.cs.meta
+++ b/Cauldron/Assets/Scripts/EncounterListWrapper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 45363ac7ef1daed449cdb7036034cf7d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cauldron/Assets/Scripts/GameDataHandler.cs
+++ b/Cauldron/Assets/Scripts/GameDataHandler.cs
@@ -29,10 +29,20 @@ namespace CauldronCodebase
             set => Set(Statustype.Money, value);
         }
 
+        public int daysToRememberCards
+        {
+            get => gameplaySettings.daysToSaveCard;
+        }
+        public int roundsToRememberCards
+        {
+            get => gameplaySettings.roundsToSaveCards;
+        }
+
         private Status status;
         
         public int currentDay = 0;
         public int cardsDrawnToday;
+        public int currentRound;
         public GameStateMachine.GamePhase gamePhase;
         public Encounter currentCard;
         public Villager currentVillager;
@@ -45,6 +55,7 @@ namespace CauldronCodebase
         public NightEventProvider currentEvents;
 
         private MainSettings.StatusBars statusSettings;
+        private MainSettings.Gameplay gameplaySettings;
 
         private DataPersistenceManager dataPersistenceManager;
         public event Action StatusChanged;
@@ -67,9 +78,9 @@ namespace CauldronCodebase
             dataManager.AddToDataPersistenceObjList(this);
 
             statusSettings = settings.statusBars;
-
+            gameplaySettings = settings.gameplay;
             currentDeck = deck;
-            currentDeck.Init(this, dataPersistenceManager, dictionary);
+            currentDeck.Init(this, dataPersistenceManager, dictionary, settings);
             currentEvents = events;
             currentEvents.Init(dataPersistenceManager, dictionary);
         }
@@ -209,6 +220,12 @@ namespace CauldronCodebase
                 potionsBrewedInADays.RemoveAt(0);
             }
         }
+
+        public void RememberRound()
+        {
+            currentRound += 1;
+            PlayerPrefs.SetInt("CurrentRound", currentRound);
+        }
         
         public void CalculatePotionsOnLastDays()
         {
@@ -234,7 +251,6 @@ namespace CauldronCodebase
             {
                 int highThreshold = (int)((100f - statusSettings.InitialThreshold) / 100 * statusSettings.Total);
                 int lowThreshold = (int)(statusSettings.InitialThreshold / 100 * statusSettings.Total);
-
                 status.FameThresholdHigh = highThreshold;
                 status.FearThresholdHigh = highThreshold;
                 status.FameThresholdLow = lowThreshold;

--- a/Cauldron/Assets/Scripts/GameDataHandler.cs
+++ b/Cauldron/Assets/Scripts/GameDataHandler.cs
@@ -29,20 +29,10 @@ namespace CauldronCodebase
             set => Set(Statustype.Money, value);
         }
 
-        public int daysToRememberCards
-        {
-            get => gameplaySettings.daysToSaveCard;
-        }
-        public int roundsToRememberCards
-        {
-            get => gameplaySettings.roundsToSaveCards;
-        }
-
         private Status status;
         
         public int currentDay = 0;
         public int cardsDrawnToday;
-        public int currentRound;
         public GameStateMachine.GamePhase gamePhase;
         public Encounter currentCard;
         public Villager currentVillager;
@@ -55,7 +45,6 @@ namespace CauldronCodebase
         public NightEventProvider currentEvents;
 
         private MainSettings.StatusBars statusSettings;
-        private MainSettings.Gameplay gameplaySettings;
 
         private DataPersistenceManager dataPersistenceManager;
         public event Action StatusChanged;
@@ -78,9 +67,9 @@ namespace CauldronCodebase
             dataManager.AddToDataPersistenceObjList(this);
 
             statusSettings = settings.statusBars;
-            gameplaySettings = settings.gameplay;
+
             currentDeck = deck;
-            currentDeck.Init(this, dataPersistenceManager, dictionary, settings);
+            currentDeck.Init(this, dataPersistenceManager, dictionary);
             currentEvents = events;
             currentEvents.Init(dataPersistenceManager, dictionary);
         }
@@ -220,12 +209,6 @@ namespace CauldronCodebase
                 potionsBrewedInADays.RemoveAt(0);
             }
         }
-
-        public void RememberRound()
-        {
-            currentRound += 1;
-            PlayerPrefs.SetInt("CurrentRound", currentRound);
-        }
         
         public void CalculatePotionsOnLastDays()
         {
@@ -251,6 +234,7 @@ namespace CauldronCodebase
             {
                 int highThreshold = (int)((100f - statusSettings.InitialThreshold) / 100 * statusSettings.Total);
                 int lowThreshold = (int)(statusSettings.InitialThreshold / 100 * statusSettings.Total);
+
                 status.FameThresholdHigh = highThreshold;
                 status.FearThresholdHigh = highThreshold;
                 status.FameThresholdLow = lowThreshold;

--- a/Cauldron/Assets/Scripts/GameStates/GameStateMachine.cs
+++ b/Cauldron/Assets/Scripts/GameStates/GameStateMachine.cs
@@ -50,7 +50,17 @@ namespace CauldronCodebase.GameStates
         {
             dataPersistenceManager.LoadDataPersistenceObj();
             currentGameState = gameStates[gameData.gamePhase];
-            PlayerPrefs.SetInt("FirstTime", 1);
+            
+            if (!PlayerPrefs.HasKey("CurrentRound"))
+            {
+                PlayerPrefs.SetInt("CurrentRound", 0);
+                gameData.currentDeck.ForgetCards();
+            }
+            else
+            {
+                gameData.currentRound = PlayerPrefs.GetInt("CurrentRound");
+            }
+            
             currentGameState.Enter();
         }
  

--- a/Cauldron/Assets/Scripts/GameStates/GameStateMachine.cs
+++ b/Cauldron/Assets/Scripts/GameStates/GameStateMachine.cs
@@ -50,17 +50,7 @@ namespace CauldronCodebase.GameStates
         {
             dataPersistenceManager.LoadDataPersistenceObj();
             currentGameState = gameStates[gameData.gamePhase];
-            
-            if (!PlayerPrefs.HasKey("CurrentRound"))
-            {
-                PlayerPrefs.SetInt("CurrentRound", 0);
-                gameData.currentDeck.ForgetCards();
-            }
-            else
-            {
-                gameData.currentRound = PlayerPrefs.GetInt("CurrentRound");
-            }
-            
+            PlayerPrefs.SetInt("FirstTime", 1);
             currentGameState.Enter();
         }
  

--- a/Cauldron/Assets/Scripts/GameStates/NightState.cs
+++ b/Cauldron/Assets/Scripts/GameStates/NightState.cs
@@ -67,7 +67,6 @@ namespace CauldronCodebase.GameStates
             {
                 stateMachine.currentEnding = check;
                 stateMachine.SwitchState(GameStateMachine.GamePhase.EndGame);
-                gameDataHandler.RememberRound();
                 return true;
             }
 

--- a/Cauldron/Assets/Scripts/GameStates/NightState.cs
+++ b/Cauldron/Assets/Scripts/GameStates/NightState.cs
@@ -67,6 +67,7 @@ namespace CauldronCodebase.GameStates
             {
                 stateMachine.currentEnding = check;
                 stateMachine.SwitchState(GameStateMachine.GamePhase.EndGame);
+                gameDataHandler.RememberRound();
                 return true;
             }
 

--- a/Cauldron/Assets/Scripts/GameStates/VisitorState.cs
+++ b/Cauldron/Assets/Scripts/GameStates/VisitorState.cs
@@ -1,6 +1,5 @@
 ﻿using Save;
 using System.Linq;
-using UnityEngine;
 
 namespace CauldronCodebase.GameStates
 {
@@ -47,7 +46,6 @@ namespace CauldronCodebase.GameStates
             {
                 stateMachine.currentEnding = EndingsProvider.Unlocks.HighMoney;
                 stateMachine.SwitchState(GameStateMachine.GamePhase.EndGame);
-                gameDataHandler.RememberRound();
                 return;
             }
                      

--- a/Cauldron/Assets/Scripts/GameStates/VisitorState.cs
+++ b/Cauldron/Assets/Scripts/GameStates/VisitorState.cs
@@ -1,5 +1,6 @@
 ﻿using Save;
 using System.Linq;
+using UnityEngine;
 
 namespace CauldronCodebase.GameStates
 {
@@ -46,6 +47,7 @@ namespace CauldronCodebase.GameStates
             {
                 stateMachine.currentEnding = EndingsProvider.Unlocks.HighMoney;
                 stateMachine.SwitchState(GameStateMachine.GamePhase.EndGame);
+                gameDataHandler.RememberRound();
                 return;
             }
                      

--- a/Cauldron/Assets/Scripts/SO/EncounterDeckBase.cs
+++ b/Cauldron/Assets/Scripts/SO/EncounterDeckBase.cs
@@ -8,14 +8,20 @@ namespace CauldronCodebase
     //This class is only to display interface in Unity inspector
     [Serializable]
     public abstract class EncounterDeckBase : ScriptableObject, IEncounterDeck, IDataPersistence
-    { 
-        public abstract void Init(GameDataHandler game, DataPersistenceManager dataPersistenceManager, SODictionary dictionary);
+    {
+        private IEncounterDeck encounterDeckImplementation;
+
+        public abstract void Init(GameDataHandler game, DataPersistenceManager dataPersistenceManager,
+            SODictionary dictionary, MainSettings mainSettings);
 
         public abstract void NewDayPool(int day);
 
         public abstract void DealCards(int num);
 
         public abstract void AddStoryCards();
+
+        public abstract void ForgetCards();
+
 
         public abstract void AddCardToPool(Encounter card);
 
@@ -25,6 +31,5 @@ namespace CauldronCodebase
 
         public abstract void LoadData(GameData data, bool newGame);
         public abstract void SaveData(ref GameData data);
-
     }
 }

--- a/Cauldron/Assets/Scripts/SO/EncounterDeckBase.cs
+++ b/Cauldron/Assets/Scripts/SO/EncounterDeckBase.cs
@@ -8,20 +8,14 @@ namespace CauldronCodebase
     //This class is only to display interface in Unity inspector
     [Serializable]
     public abstract class EncounterDeckBase : ScriptableObject, IEncounterDeck, IDataPersistence
-    {
-        private IEncounterDeck encounterDeckImplementation;
-
-        public abstract void Init(GameDataHandler game, DataPersistenceManager dataPersistenceManager,
-            SODictionary dictionary, MainSettings mainSettings);
+    { 
+        public abstract void Init(GameDataHandler game, DataPersistenceManager dataPersistenceManager, SODictionary dictionary);
 
         public abstract void NewDayPool(int day);
 
         public abstract void DealCards(int num);
 
         public abstract void AddStoryCards();
-
-        public abstract void ForgetCards();
-
 
         public abstract void AddCardToPool(Encounter card);
 
@@ -31,5 +25,6 @@ namespace CauldronCodebase
 
         public abstract void LoadData(GameData data, bool newGame);
         public abstract void SaveData(ref GameData data);
+
     }
 }

--- a/Cauldron/Assets/Scripts/SO/IEncounterDeck.cs
+++ b/Cauldron/Assets/Scripts/SO/IEncounterDeck.cs
@@ -4,7 +4,7 @@ namespace CauldronCodebase
 {
     public interface IEncounterDeck
     {
-        void Init(GameDataHandler game, DataPersistenceManager dataPersistenceManager, SODictionary dictionary);
+        void Init(GameDataHandler game, DataPersistenceManager dataPersistenceManager, SODictionary dictionary, MainSettings mainSettings);
         void NewDayPool(int day);
 
         /// <summary>

--- a/Cauldron/Assets/Scripts/SO/IEncounterDeck.cs
+++ b/Cauldron/Assets/Scripts/SO/IEncounterDeck.cs
@@ -4,7 +4,7 @@ namespace CauldronCodebase
 {
     public interface IEncounterDeck
     {
-        void Init(GameDataHandler game, DataPersistenceManager dataPersistenceManager, SODictionary dictionary, MainSettings mainSettings);
+        void Init(GameDataHandler game, DataPersistenceManager dataPersistenceManager, SODictionary dictionary);
         void NewDayPool(int day);
 
         /// <summary>

--- a/Cauldron/Assets/Scripts/SO/MainSettings.cs
+++ b/Cauldron/Assets/Scripts/SO/MainSettings.cs
@@ -18,6 +18,8 @@ namespace CauldronCodebase
              public int cardsPerDay = 3;
              public int cardsDealtAtNight = 3;
              public float villagerDelay = 2f;
+             public int roundsToSaveCards = 2; //Первые N-1 кругов необходимо сохранять все карты
+             public int daysToSaveCard = 3; // выпавшие в первые три X дня игры
         }
 
         [Serializable]

--- a/Cauldron/Assets/Scripts/SO/MainSettings.cs
+++ b/Cauldron/Assets/Scripts/SO/MainSettings.cs
@@ -18,8 +18,6 @@ namespace CauldronCodebase
              public int cardsPerDay = 3;
              public int cardsDealtAtNight = 3;
              public float villagerDelay = 2f;
-             public int roundsToSaveCards = 2; //Первые N-1 кругов необходимо сохранять все карты
-             public int daysToSaveCard = 3; // выпавшие в первые три X дня игры
         }
 
         [Serializable]


### PR DESCRIPTION
Проблема: игрок видит много повторяющихся карт (под картой имею в виду запрос посетителя) в начале каждого круга игры.
Решение:
Первые N-1 кругов (на данный момент N=2) необходимо сохранять все карты, выпавшие в первые три (X=3) дня игры, а на последующих кругах вплоть до N-го по счету в начале игры убирать эти карты из колоды. На N+1 круге и далее начальную колоду не меняем. 
Сохраняем в один ключ PlayerPrefs (строка через JsonSerializer). X и N вынести в настройки (MainSettings).
Здесь еще нужно будет сохранять номер круга (сейчас есть ключ префсов для первого круга, "FirstTime" - он работает как bool - надо заменить его на номер круга).

Надо дополнительно потестить.